### PR TITLE
Initialize project structure and agent rules

### DIFF
--- a/.context/decisions/0000-template.md
+++ b/.context/decisions/0000-template.md
@@ -1,0 +1,26 @@
+# ADR NNNN: Short decision title
+
+**Status:** proposed | accepted | superseded by ADR-NNNN
+**Date:** YYYY-MM-DD
+**Owner:** <name>
+
+## Context
+
+What is the situation that forces a decision? Two to four sentences. Include the constraints that matter (technical, legal, scheduling, organizational).
+
+## Decision
+
+The decision in one or two sentences. Active voice.
+
+## Consequences
+
+What becomes easier, what becomes harder, what new obligations are created. Be honest about the downsides.
+
+## Alternatives considered
+
+- **Alternative A:** what it was, why it lost.
+- **Alternative B:** what it was, why it lost.
+
+## Receipts
+
+Links, prior art, or commit references that informed the decision.

--- a/.context/decisions/README.md
+++ b/.context/decisions/README.md
@@ -1,0 +1,27 @@
+# Architecture Decision Records
+
+Architecture Decision Records (ADRs) capture significant decisions that shape the project: choice of stack, structural patterns, trade-offs accepted, alternatives rejected. Tuck them all in here so they are easy to find later.
+
+## Convention
+
+- One file per decision: `NNNN-short-kebab-title.md`, zero-padded to four digits.
+- `0000-template.md` is the template; copy it to start a new ADR. Do not edit `0000-template.md` itself.
+- Number sequentially. The next ADR after `0007-...` is `0008-...`.
+- Status flows `proposed` -> `accepted` -> (later) `superseded by ADR-NNNN`. Never delete an ADR; supersede it.
+- Keep each ADR short. If it grows past two screens, you are probably writing a design doc, not a decision.
+
+## When to write an ADR
+
+Write one when a decision:
+- Will be hard or expensive to reverse.
+- Cuts off other reasonable paths a future contributor might wonder about.
+- Has been argued about more than once.
+- Embeds a constraint (legal, performance, schedule) that is not obvious from the code.
+
+Do not write one for routine choices that are obvious from reading the code.
+
+## Index
+
+Add new entries here as you create ADRs:
+
+- ADR 0000 - template (do not edit)

--- a/.context/ideas.md
+++ b/.context/ideas.md
@@ -1,0 +1,43 @@
+# pyAMICA Design Ideas
+
+High-level PyTorch design decisions and library options for the AMICA port.
+
+## Vision
+Build a GPU-accelerated AMICA (CUDA / Apple MPS / CPU) that matches the Fortran reference, using
+PyTorch autograd instead of hand-coded derivatives, and leaning on battle-tested libraries for
+standard components (Newton, mixture models, natural gradient) so effort concentrates on
+AMICA-specific logic.
+
+## Architecture
+- **`nn.Module` framework:** parameters (A, c, alpha, mu, beta, rho) as `nn.Parameter`; free
+  serialization and optimizer compatibility.
+- **Log-space throughout:** stable `logsumexp` for mixtures; epsilon on denominators.
+- **Pluggable optimizers:** natural gradient for warm-up, Newton for final convergence.
+- **Configurable device placement:** auto-select MPS/CUDA/CPU.
+- **Hybrid EM-gradient (candidate):** EM for mixture weights (stable), gradients for mixing matrices.
+
+## Library options considered
+- **Newton:** `pytorch-minimize` (rfeinman) - exact Hessian + Newton-CG, GPU. Built-in
+  `torch.optim.LBFGS` as fallback; `hjmshi/PyTorch-LBFGS` for mini-batch/line-search stability.
+- **Mixture models:** `gmm-torch` (ldeecke) - GPU, sklearn-like; `GMMPytorch` (kylesayrs) -
+  gradient-based with singularity mitigation.
+- **Natural gradient / Fisher:** `NNGeometry` (tfjgeorge) - KFAC/EKFAC/diagonal Fisher, GPU;
+  `gpytorch.optim.NGD`.
+  (These are optional; see the commented entries in `../requirements-torch.txt`.)
+
+## Advantages of the PyTorch port
+- GPU/MPS acceleration; autograd removes manual gradient code.
+- Built-in stability tools (clipping, mixed precision, stable log-sum-exp).
+- Faster iteration and easier extension than the Fortran/NumPy paths.
+
+## Key risks -> mitigations
+- **Memory:** gradient checkpointing, batch/block processing, low-rank Fisher.
+- **Numerical stability:** log-probabilities, gradient clipping, epsilon denominators, bounded values.
+- **Matching Fortran exactly:** identical initialization, log all intermediates for comparison,
+  replicate Fortran's specific numerical tricks, validate against the binary.
+
+## Open questions
+1. Why `do_approx_sphere=.true.` in Fortran while Python uses exact sphering?
+2. Relationship between `sbeta` and `beta`.
+3. Exact mixture-model update in Fortran.
+4. What is `baralpha` and why 3D?

--- a/.context/plan.md
+++ b/.context/plan.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 **Goal:** Python (PyTorch) implementation of AMICA that reproduces the Fortran binary's results within tolerance.
-**Stack:** Python 3.10+, PyTorch (MPS/CUDA/CPU), NumPy/SciPy, Fortran reference.
+**Stack:** Python 3.12+, PyTorch (MPS/CUDA/CPU), NumPy/SciPy, Fortran reference.
 **Definition of done:** Component correlation >0.95 with Fortran, LL within ~1% of Fortran, no NaN/Inf, runtime within ~2-3x of Fortran.
 
 ## Development Tasks
@@ -14,17 +14,17 @@
 - [ ] Add numerical-stability bounds from Fortran (`mincond=1e-15`, `minlog=-1500`, `maxdble=1e32`, `mineig=1e-15`)
 - [ ] Add NaN/Inf checks and epsilon to all divisions (notably `dmu / dalpha`)
 - [ ] Ensure identical initialization vs Fortran (seed, sphering/whitening, starting mixing matrix)
-- [ ] Raise component correlation with Fortran from ~0.7-0.9 to >0.95
+- [ ] Raise component correlation with Fortran (~0.46-0.9, run-dependent) to >0.95
 
 ### Priority 2: Missing core features
-- [ ] Outlier rejection (`do_reject` / `reject_data`)
-- [ ] Complete Newton optimization (`baralpha`, full Hessian, convergence checks)
-- [~] Adaptive PDF selection (`do_choose_pdfs`) - partially implemented
+- [ ] Port outlier rejection (`do_reject` / `reject_data`) to the torch backend (exists in legacy NumPy `pyAMICA.py`)
+- [ ] Wire up / stabilize Newton for the torch backend (`baralpha`, full Hessian, convergence checks; exists in legacy NumPy)
+- [~] Adaptive PDF selection (`do_choose_pdfs`) - in `amica_torch_v2.py`, not yet wired into the default `AMICA` interface
 - [ ] Multi-model AMICA - framework exists, needs testing
 - [ ] Component sharing
 
 ### Priority 3: Testing & validation
-- [ ] Real-data test suite exercising the PyTorch backend end-to-end (see linked issue; currently unverified and expected to fail)
+- [ ] Real-data test suite exercising the PyTorch backend end-to-end (issue #7; currently unverified and expected to fail)
 - [ ] Integration tests comparing against Fortran outputs (`tests/torch_tests/`)
 - [ ] Numerical-stability regression tests
 - [ ] Edge cases (single channel, single sample)

--- a/.context/plan.md
+++ b/.context/plan.md
@@ -1,0 +1,46 @@
+# pyAMICA Development Plan
+
+## Project Overview
+**Goal:** Python (PyTorch) implementation of AMICA that reproduces the Fortran binary's results within tolerance.
+**Stack:** Python 3.10+, PyTorch (MPS/CUDA/CPU), NumPy/SciPy, Fortran reference.
+**Definition of done:** Component correlation >0.95 with Fortran, LL within ~1% of Fortran, no NaN/Inf, runtime within ~2-3x of Fortran.
+
+## Development Tasks
+<!-- Status markers: [ ] pending, [~] in progress, [x] complete -->
+
+### Priority 1: Parity blockers
+- [~] Fix likelihood sign/scaling vs Fortran (~13x factor; GG normalization corrected, needs revalidation)
+- [~] Stabilize Newton optimization (NaN at Newton-start iter; clipping + Fortran-matched ramp added, needs revalidation)
+- [ ] Add numerical-stability bounds from Fortran (`mincond=1e-15`, `minlog=-1500`, `maxdble=1e32`, `mineig=1e-15`)
+- [ ] Add NaN/Inf checks and epsilon to all divisions (notably `dmu / dalpha`)
+- [ ] Ensure identical initialization vs Fortran (seed, sphering/whitening, starting mixing matrix)
+- [ ] Raise component correlation with Fortran from ~0.7-0.9 to >0.95
+
+### Priority 2: Missing core features
+- [ ] Outlier rejection (`do_reject` / `reject_data`)
+- [ ] Complete Newton optimization (`baralpha`, full Hessian, convergence checks)
+- [~] Adaptive PDF selection (`do_choose_pdfs`) - partially implemented
+- [ ] Multi-model AMICA - framework exists, needs testing
+- [ ] Component sharing
+
+### Priority 3: Testing & validation
+- [ ] Real-data test suite exercising the PyTorch backend end-to-end (see linked issue; currently unverified and expected to fail)
+- [ ] Integration tests comparing against Fortran outputs (`tests/torch_tests/`)
+- [ ] Numerical-stability regression tests
+- [ ] Edge cases (single channel, single sample)
+
+### Infrastructure / migration
+- [ ] Migrate environment from conda `torch-312` to UV; declare the PyTorch stack in `pyproject.toml`
+- [ ] Set up CI (see `.rules/ci_cd.md`)
+- [ ] Fix legacy test function signatures (`load_data_file` extra parameter)
+
+## Success Criteria
+- [ ] Component correlation > 0.95 with Fortran
+- [ ] LL convergence within 1% of Fortran
+- [ ] No NaN/Inf during optimization
+- [ ] Runtime within 2-3x of Fortran
+- [ ] Real (non-mock) test suite green
+
+## Notes
+- Correctness is defined by parity with the Fortran binary, not by convergence alone.
+- Detailed feature status: `../FEATURE_PARITY.md`; migration timeline: `../MIGRATION_PLAN.md`.

--- a/.context/research.md
+++ b/.context/research.md
@@ -14,25 +14,27 @@ Fortran-vs-Python parity analysis. Fortran reference: `amica17.f90` (~3900 lines
 | alpha, mu, sbeta, rho | `self.alpha`, `self.mu`, `self.beta`, `self.rho` | done |
 | comp_list, LL, nd | `self.comp_list`, `self.ll`, `self.nd` | done |
 | lambda, kappa, sigma2 (Newton) | `compute_newton_direction()` | partial |
-| baralpha (Newton) | not found | missing |
+| baralpha (Newton) | `self.baralpha` in legacy `pyAMICA.py` | done in NumPy; missing in torch backend |
 
 ## Core Subroutines (Fortran -> Python)
 | Fortran | Python | Status |
 |---|---|---|
 | get_data | `load_data_file()`, `preprocess_data()` | done |
-| get_updates_and_likelihood | `_compute_updates()` | partial |
-| accum_updates_and_likelihood | merged into `_compute_updates()` | merged |
+| get_updates_and_likelihood | `_get_updates_and_likelihood()` | partial |
+| accum_updates_and_likelihood | merged into `_get_updates_and_likelihood()` | merged |
 | update_params | `_update_parameters()` | done |
 | get_unmixing_matrices | `get_unmixing_matrices()` | done |
 | identify_shared_comps | `identify_shared_components()` | done |
-| reject_data | not found | missing |
+| reject_data | `_reject_outliers()` in legacy `pyAMICA.py` | done in NumPy; missing in torch backend |
 | determine_block_size | `determine_block_size()` | done |
 | write_output / write_history | `save_results()` | done / partial |
 
-## Missing / incomplete features
-1. Outlier rejection (`do_reject`, `reject_data`).
-2. Adaptive PDF selection (`do_choose_pdfs`) - partial.
-3. Full Newton (`baralpha`, complete Hessian).
+## Missing / incomplete in the PyTorch backend
+The legacy NumPy `pyAMICA.py` implements outlier rejection, `baralpha`, and Newton; the PyTorch
+backend (the parity-focused path) does not yet. Items below refer to the torch backend.
+1. Outlier rejection (`do_reject`, `reject_data`) - present in NumPy, absent in torch.
+2. Adaptive PDF selection (`do_choose_pdfs`) - partial, in `amica_torch_v2.py`, not wired into the default interface.
+3. Full Newton (`baralpha`, complete Hessian) - present in NumPy; torch Newton (`amica_torch_v2.py`) is unstable and not wired into the default interface.
 4. Parallel processing (Fortran uses OpenMP).
 5. Numerical-stability safeguards (eigenvalue/condition bounds, overflow/underflow protection).
 
@@ -64,8 +66,9 @@ Fixes applied: Fortran-matched ramp, off-by-one iteration-counter fix, gradient 
 the enhanced model may still produce positive LL; both need revalidation after the latest fixes.
 
 ### Observed LL scale (per sample)
-Fortran -3.41, PyTorch basic -44.56, PyTorch enhanced (post-fix) -114.58 — roughly a 13x factor
-vs Fortran, suggesting a normalization/computation difference still to resolve.
+Fortran -3.41, PyTorch basic -44.56 (~13x vs Fortran), PyTorch enhanced post-fix -114.58 (~34x).
+The "~13x" figure quoted elsewhere refers to the basic backend; the enhanced model diverges further.
+A normalization/computation difference remains to resolve.
 
 ### Component correlation
 Mean ~0.46 (best 0.68, worst 0.24) in the analyzed run; target >0.95. Likely causes: initialization

--- a/.context/research.md
+++ b/.context/research.md
@@ -1,0 +1,78 @@
+# pyAMICA Research & Parity Analysis
+
+Fortran-vs-Python parity analysis. Fortran reference: `amica17.f90` (~3900 lines),
+`amica17_header.f90` (declarations), `funmod2.f90` (function modules).
+
+## Core Data Structures (Fortran -> Python)
+| Fortran | Python | Status |
+|---|---|---|
+| A (mixing) | `self.A` | done |
+| W (unmixing) | `self.W` | done |
+| c (bias), mean | `self.c`, `self.mean` | done |
+| sphere (S) | `self.sphere` | done |
+| gm (model weights) | `self.gm` | done |
+| alpha, mu, sbeta, rho | `self.alpha`, `self.mu`, `self.beta`, `self.rho` | done |
+| comp_list, LL, nd | `self.comp_list`, `self.ll`, `self.nd` | done |
+| lambda, kappa, sigma2 (Newton) | `compute_newton_direction()` | partial |
+| baralpha (Newton) | not found | missing |
+
+## Core Subroutines (Fortran -> Python)
+| Fortran | Python | Status |
+|---|---|---|
+| get_data | `load_data_file()`, `preprocess_data()` | done |
+| get_updates_and_likelihood | `_compute_updates()` | partial |
+| accum_updates_and_likelihood | merged into `_compute_updates()` | merged |
+| update_params | `_update_parameters()` | done |
+| get_unmixing_matrices | `get_unmixing_matrices()` | done |
+| identify_shared_comps | `identify_shared_components()` | done |
+| reject_data | not found | missing |
+| determine_block_size | `determine_block_size()` | done |
+| write_output / write_history | `save_results()` | done / partial |
+
+## Missing / incomplete features
+1. Outlier rejection (`do_reject`, `reject_data`).
+2. Adaptive PDF selection (`do_choose_pdfs`) - partial.
+3. Full Newton (`baralpha`, complete Hessian).
+4. Parallel processing (Fortran uses OpenMP).
+5. Numerical-stability safeguards (eigenvalue/condition bounds, overflow/underflow protection).
+
+## Critical divergence causes
+1. **Likelihood scaling/sign.** Fortran LL ~ -3.44/sample; early Python LL was positive and large.
+   Enhanced PyTorch produced positive LLs (mathematically impossible).
+2. **Numerical stability.** Python hits NaN during optimization; Fortran uses bounds
+   `mincond=1e-15`, `minlog=-1500`, `maxdble=1e32`, `mineig=1e-15`.
+3. **Update equations.** Possible gradient/accumulation differences; mixture-component handling.
+4. **Data format.** Fortran column-major vs Python row-major (handled, watch edge cases).
+5. **Precision.** Fortran double throughout; Python mixes float32/float64.
+
+## 2025-08-20 deep analysis
+### Log-likelihood normalization fix
+Generalized Gaussian PDF: `p(x; rho, beta) = (rho / (2*beta*Gamma(1/rho))) * exp(-(|x/beta|)^rho)`,
+so `log p = log(rho) - log(2) - log(beta) - log(Gamma(1/rho)) - (|x/beta|)^rho`.
+```python
+# INCORRECT (produced positive LL):
+log_norm = torch.lgamma(1.0 + 1.0/rho) + torch.log(torch.tensor(2.0))
+# CORRECT:
+log_norm = torch.log(torch.tensor(2.0)) + torch.lgamma(1.0/rho) - torch.log(rho)
+```
+Location: `pyAMICA/torch_impl/adaptive_pdf.py`.
+
+### Newton ramping
+Fortran ramps conservatively at Newton start (lrate 0.05 -> 0.10 at iter 51, doubling, capped ~0.5).
+Fixes applied: Fortran-matched ramp, off-by-one iteration-counter fix, gradient clipping
+(max_norm=5.0 when Newton active). Remaining: NaN still occurs at the Newton-start iteration and
+the enhanced model may still produce positive LL; both need revalidation after the latest fixes.
+
+### Observed LL scale (per sample)
+Fortran -3.41, PyTorch basic -44.56, PyTorch enhanced (post-fix) -114.58 — roughly a 13x factor
+vs Fortran, suggesting a normalization/computation difference still to resolve.
+
+### Component correlation
+Mean ~0.46 (best 0.68, worst 0.24) in the analyzed run; target >0.95. Likely causes: initialization
+mismatch, precision, optimization-path divergence, sphering/whitening differences.
+
+## Next steps for parity
+1. Match Fortran initialization exactly (seed, sphering, starting matrices).
+2. Step through Fortran likelihood and compare intermediate values.
+3. Add the numerical-stability bounds and epsilon guards.
+4. Complete Newton (line search for stability) and outlier rejection.

--- a/.context/scratch_history.md
+++ b/.context/scratch_history.md
@@ -1,0 +1,52 @@
+# pyAMICA Scratch History
+
+Debugging notes, failed attempts, and lessons. Prevents repeating dead ends.
+
+## Debugging notes
+
+### Likelihood divergence
+- Fortran: iter 1 LL ~ -3.51 -> converges ~ -3.44. Early Python: ~1.42e6 -> ~1.51e6.
+- Hypothesis: sign flip or missing `log()`; check `-log(p(x))` vs `log(p(x))`.
+- Enhanced model produced positive LLs -> traced to wrong GG normalization constant (see research.md).
+
+### NaN issues
+- Occurred ~iter 49-50 (Newton start). `RuntimeWarning: invalid value in divide` at
+  `dmu = updates['dmu'] / updates['dalpha']` -> `dalpha` near zero. Add epsilon to denominators.
+- Gradient norm jumped from ~70 to ~2e5 at Newton start before clipping was added.
+
+### Fortran structure references
+- `get_updates_and_likelihood` (~line 1174), `accum_updates_and_likelihood` (~line 1671),
+  `update_params` (~line 1878). Fortran separates accumulation; Python merged it.
+- PDFs live in `funmod2.f90`; Fortran uses fast approximations (fastlog/fastexp/fastpow).
+
+## Known differences to watch
+- Data layout: Fortran column-major vs Python row-major default (handled; verify edge cases).
+- PDF computed inline in Python vs separate module in Fortran.
+- Block processing simplified in Python vs Fortran's block-size optimization.
+- Fortran 1-based vs Python 0-based indexing; OpenMP -> multiprocessing/joblib; BLAS/LAPACK -> scipy.linalg.
+
+## Quick fixes to try
+- Epsilon on all divisions: `dmu / (dalpha + 1e-10)`.
+- Verify LL sign: possibly `ll = -sum(log(pdf + 1e-10))`.
+- Bound values: `clip(value, -1500, 1500)` (Fortran `minlog`).
+
+## Test data
+- Sample data: 32 channels, 30504 samples, 32-bit float. Fortran output in `amicaout/`,
+  Python in `pyresults/` (load via `loadmodout()`).
+
+## Performance
+- Fortran ~0.02s/iter; Python ~0.5s/iter (~25x slower). Matrix ops likely the bottleneck; profile.
+
+## Debugging commands
+```bash
+python -m pytest pyAMICA/tests/test_sample_data.py::test_sample_data_light -v -s
+python -m pyAMICA.amica_cli pyAMICA/sample_data/sample_params.json --verbose --outdir debug_out
+# Fortran build (if needed):
+gfortran -O3 -fopenmp amica17.f90 funmod2.f90 -o amica -llapack -lblas
+```
+
+## Lessons / check first next time
+- [ ] Positive LL almost always means a wrong PDF normalization constant.
+- [ ] NaN at a phase transition (e.g. Newton start) points at unclipped gradients or zero denominators.
+- [ ] Confirm initialization parity (seed, sphering, starting matrices) before chasing algorithmic bugs.
+- [ ] Legacy test signatures drift (`load_data_file` dropped a parameter) - update call sites.

--- a/.context/scratch_history.md
+++ b/.context/scratch_history.md
@@ -17,7 +17,7 @@ Debugging notes, failed attempts, and lessons. Prevents repeating dead ends.
 ### Fortran structure references
 - `get_updates_and_likelihood` (~line 1174), `accum_updates_and_likelihood` (~line 1671),
   `update_params` (~line 1878). Fortran separates accumulation; Python merged it.
-- PDFs live in `funmod2.f90`; Fortran uses fast approximations (fastlog/fastexp/fastpow).
+- `funmod2.f90` holds special-function helpers (gamln/psifun/etc.), not the PDFs; PDF computation is inline in `amica17.f90`. (`fastlog/fastexp/fastpow` are declared but unused stubs in `amica17_header.f90`.)
 
 ## Known differences to watch
 - Data layout: Fortran column-major vs Python row-major default (handled; verify edge cases).

--- a/.gitignore
+++ b/.gitignore
@@ -8,12 +8,10 @@ gen_api/
 # Ignore everything in the egg-info directory
 pyAMICA.egg-info/*
 
-# Ignore project documentation files (per CLAUDE.md instructions)
-CLAUDE.md
-plan.md
-research.md
-scratch_notes.md
-ideas.md
+# Generated run/validation output
 output/
 validation_output/
 enhanced_test_output/
+
+# AGENTS.md, CLAUDE.md, .rules/, and .context/ are tracked in git.
+# Working docs (plan/research/ideas/scratch) now live in .context/.

--- a/.rules/ci_cd.md
+++ b/.rules/ci_cd.md
@@ -1,0 +1,95 @@
+# CI/CD Workflow Standards
+
+## Purpose: Automated Quality Gates
+**Why CI/CD?** Catch issues before users do.
+**Think:** Every pipeline failure is a production bug prevented.
+**Goal:** Fast feedback, high confidence, zero surprises.
+
+## Essential Workflows
+
+### 1. Testing (`test.yml`)
+**Triggers:** `on: [push, pull_request]` to main branches
+**Jobs (in order):**
+- **Lint:** `ruff check` / `biome check` (fails fast)
+- **Type Check:** `ty` / `tsc --noEmit`
+- **Test:** Real tests only, matrix for versions
+- **Build:** Verify compilation if applicable
+- **Coverage:** Optional reporting to Codecov
+
+### 2. Documentation (`docs.yml`)
+**Triggers:** `on: push: branches: [main]`
+**Jobs:** Build with MkDocs -> Deploy to GitHub Pages
+
+### 3. Release (`release.yml`)
+**Triggers:** Tag creation or manual
+**Jobs:** Build -> Create release -> Publish packages
+
+## Python Example (UV)
+```yaml
+name: CI
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: astral-sh/setup-uv@v4
+    - run: uv sync --dev
+    - run: uv run ruff check .
+    - run: uv run ruff format --check .
+
+  test:
+    needs: lint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: { python-version: ['3.11', '3.12', '3.13'] }
+    steps:
+    - uses: actions/checkout@v4
+    - uses: astral-sh/setup-uv@v4
+      with: { python-version: '${{ matrix.python-version }}' }
+    - run: uv sync --dev
+    - run: uv run pytest --cov=src
+```
+
+## JavaScript/TypeScript Example (Bun)
+```yaml
+name: CI
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: oven-sh/setup-bun@v2
+    - run: bun install
+    - run: bun run biome check .
+
+  test:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: oven-sh/setup-bun@v2
+    - run: bun install
+    - run: bun test
+```
+
+## Key Practices (Think About Pipeline Flow)
+- **Pin versions:** `actions/checkout@v4` (reproducibility)
+- **Cache deps:** UV and Bun both have built-in caching; use `setup-uv` and `setup-bun` actions
+- **Fail fast:** Lint -> Type Check -> Test -> Build -> Deploy (catch cheap failures first)
+- **Matrix testing:** Test all supported versions
+- **Secrets:** Never commit credentials; use GitHub Secrets
+- **Conditional:** Deploy only from protected branches
+
+## Pipeline Philosophy
+**Fast feedback:** Developers should know in <5 min
+**Clear failures:** Error messages should guide fixes
+**No surprises:** If it passes CI, it works in production
+
+**Ask yourself:**
+- Will this catch real issues?
+- Is the feedback loop fast enough?
+- Are we testing what actually matters?

--- a/.rules/ci_cd.md
+++ b/.rules/ci_cd.md
@@ -43,7 +43,7 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     strategy:
-      matrix: { python-version: ['3.11', '3.12', '3.13'] }
+      matrix: { python-version: ['3.12', '3.13'] }
     steps:
     - uses: actions/checkout@v4
     - uses: astral-sh/setup-uv@v4

--- a/.rules/code_review.md
+++ b/.rules/code_review.md
@@ -1,0 +1,57 @@
+# Code Review Standards
+
+## PR Review Toolkit
+When the `pr-review-toolkit` plugin is available, use it after creating PRs to catch issues before merge.
+
+### Available Agents
+- `code-reviewer` - Review for style, best practices, project guidelines
+- `silent-failure-hunter` - Find inadequate error handling, silent failures
+- `code-simplifier` - Simplify code while preserving functionality
+- `comment-analyzer` - Check comment accuracy and maintainability
+- `pr-test-analyzer` - Review test coverage quality
+- `type-design-analyzer` - Analyze type design and invariants
+
+### Workflow
+**No technical debt carried forward.** Address all findings, not just critical ones.
+1. Create PR with `gh pr create`
+2. Run code review agents on the changes (all agents in parallel)
+3. Address ALL findings: critical, important, suggestions, and nice-to-haves
+4. Only skip genuine false positives or intentionally different design choices
+5. Document skipped findings with clear reasoning (false positive / intended behavior)
+
+## Manual Code Review Checklist
+
+### Before Committing
+- [ ] Code compiles/runs without warnings
+- [ ] Tests pass (real tests, no mocks)
+- [ ] No debug code left (print statements, TODO hacks)
+- [ ] No sensitive data in code or logs
+
+### Logic & Safety
+- [ ] Error cases handled with specific exceptions
+- [ ] No silent failures (empty catch blocks, bare except)
+- [ ] Resource cleanup (files, connections, context managers)
+- [ ] Input validation at system boundaries
+
+### Code Quality
+- [ ] Functions do one thing
+- [ ] Clear naming (no abbreviations)
+- [ ] No magic numbers (use constants)
+- [ ] No premature abstraction (three uses before extracting)
+
+### Never Do This
+- [ ] No `except Exception: pass` or empty catch blocks
+- [ ] No `# type: ignore` without explanation
+- [ ] No commented-out code (delete it; git has history)
+- [ ] No `TODO` without a linked issue
+- [ ] No backward-compatibility shims; replace, don't deprecate
+
+## Review Comments
+When leaving review comments:
+- Be specific about the issue
+- Suggest a fix when possible
+- Distinguish blocking vs. non-blocking issues
+- Reference documentation or examples
+
+---
+*No technical debt carried forward. Review early, review often.*

--- a/.rules/documentation.md
+++ b/.rules/documentation.md
@@ -1,0 +1,101 @@
+# Documentation Standards (MkDocs)
+
+## Core Philosophy: Write for Your Future Self
+**Good docs** answer questions before they're asked.
+**Think:** What would confuse me in 6 months?
+**Goal:** New developers productive in <1 hour.
+
+## Setup
+```bash
+# Python projects (UV)
+uv add --dev mkdocs mkdocs-material "mkdocstrings[python]"
+
+# JS/TS projects
+bun add -D typedoc
+```
+
+## Minimal mkdocs.yml
+```yaml
+site_name: {{PROJECT_NAME}}
+site_url: https://example.com
+repo_url: https://github.com/user/repo
+
+theme:
+  name: material
+  features: [navigation.tabs, search.suggest]
+
+nav:
+  - Home: index.md
+  - API: api/
+  - Guides: guides/
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            show_root_heading: yes
+            members_order: source
+
+markdown_extensions:
+  - pymdownx.highlight
+  - pymdownx.superfences
+  - admonition
+  - toc
+```
+
+## Structure
+```
+docs/
+  index.md           # Home page
+  guides/
+    getting_started.md
+    advanced.md
+  api/               # Auto-generated from docstrings
+    module_a.md      # Contains ::: my_project.module_a
+```
+
+## API Documentation
+```markdown
+# Module A
+::: my_project.module_a
+    handler: python
+    options:
+      show_source: no
+```
+
+## Commands
+```bash
+# Python (MkDocs)
+uv run mkdocs serve    # Live preview at localhost:8000
+uv run mkdocs build    # Generate site/
+uv run mkdocs gh-deploy # Deploy to GitHub Pages
+
+# JS/TS (TypeDoc)
+bun run typedoc
+```
+
+## Writing Tips (Think Like a Teacher)
+- **Start with why:** Context before details
+- **Show, don't tell:** Examples > explanations
+- **Use admonitions:** `!!! warning "Common mistake"`
+- **Code blocks:** Include full context, not fragments
+- **Progressive disclosure:** Simple first, then advanced
+
+**Ask yourself:**
+- Would a new developer understand this?
+- Did I explain the "why" not just the "how"?
+- Are there examples for each concept?
+
+## CI/CD Integration
+See `ci_cd.md` for auto-deployment workflow
+
+## Documentation Mindset
+**You're not just documenting** - you're teaching.
+**Every README** should get someone running in minutes.
+**Every guide** should prevent a support question.
+**Think:** "What would I want to know?"
+
+---
+*Great docs make great developers. Write with empathy.*

--- a/.rules/documentation.md
+++ b/.rules/documentation.md
@@ -16,7 +16,7 @@ bun add -D typedoc
 
 ## Minimal mkdocs.yml
 ```yaml
-site_name: {{PROJECT_NAME}}
+site_name: pyAMICA
 site_url: https://example.com
 repo_url: https://github.com/user/repo
 

--- a/.rules/git.md
+++ b/.rules/git.md
@@ -1,0 +1,74 @@
+# Git & Version Control Standards
+
+## Commit Messages
+- **Format:** `<type>: <description>`
+- **Length:** <50 characters
+- **No emojis** in commits or PR titles
+- **No AI attribution** (no "Co-Authored-By: Claude" or similar)
+- **Types:**
+  - `feat:` New feature
+  - `fix:` Bug fix
+  - `docs:` Documentation only
+  - `refactor:` Code restructuring
+  - `test:` Adding tests (real tests only)
+  - `chore:` Maintenance tasks
+
+## Branch Strategy
+- **Feature branches:** `feature/issue-N-short-description`
+- **Bugfix branches:** `fix/issue-N-description`
+- **Use `gh issue develop`** to create branches from issues
+- **No spaces** in branch names, use hyphens
+- **Delete after merge**
+
+## Commit Practice
+- **Atomic commits** - One logical change per commit
+- **Test before commit** - Ensure code works
+- **No broken commits** - Each commit should work independently
+
+## Pull Request Process
+1. Create issue first (for significant changes)
+2. Use `gh issue develop` to create branch
+3. Make atomic commits
+4. Push branch
+5. Create PR with `gh pr create`:
+   - Clear title (<70 chars, no emojis)
+   - Description with "Fixes #123"
+   - Test results summary
+6. Run `/review-pr` and address ALL findings
+7. Squash merge to keep history clean
+
+## Merge Strategy
+- **Squash merge** for feature branches (clean history)
+- **Rebase** to update feature branches from base (`git rebase origin/main`)
+- **Never force-push** to shared branches (main, develop)
+- **Delete branch** after merge
+
+## Git Commands
+```bash
+# Start feature from issue
+gh issue develop 123
+
+# Atomic commits
+git add -p  # Stage selectively
+git commit -m "feat: add user authentication"
+
+# Update branch
+git fetch origin
+git rebase origin/main
+
+# Push and create PR
+git push -u origin feature/issue-123-auth
+gh pr create
+```
+
+## .gitignore Essentials
+```
+__pycache__/     # Python
+node_modules/    # JavaScript
+.env             # Secrets
+*.log            # Logs
+.venv/           # Virtual environments
+```
+
+---
+*Atomic commits, clear messages, clean history. No emojis, no AI attribution.*

--- a/.rules/git.md
+++ b/.rules/git.md
@@ -35,10 +35,10 @@
    - Description with "Fixes #123"
    - Test results summary
 6. Run `/review-pr` and address ALL findings
-7. Squash merge to keep history clean
+7. Merge with a regular merge commit to preserve history (squash only for epic sub-phase PRs)
 
 ## Merge Strategy
-- **Squash merge** for feature branches (clean history)
+- **Regular merge commits** by default to preserve history; squash only when explicitly requested (e.g. epic sub-phase PRs)
 - **Rebase** to update feature branches from base (`git rebase origin/main`)
 - **Never force-push** to shared branches (main, develop)
 - **Delete branch** after merge

--- a/.rules/python.md
+++ b/.rules/python.md
@@ -1,0 +1,101 @@
+# Python Development Standards
+
+## Version & Environment
+- **Python 3.11+** minimum (use latest stable)
+- **Package Manager:** UV only (not pip, conda, or virtualenv)
+- **Virtual Environment:** Managed by UV (`uv venv`, `uv sync`)
+- **Project Config:** `pyproject.toml` (no requirements.txt)
+
+## Quick Reference
+```bash
+# Create project
+uv init my-project && cd my-project
+
+# Add dependencies
+uv add requests pandas
+
+# Add dev dependencies
+uv add --dev pytest ruff
+
+# Run commands in venv
+uv run pytest
+uv run python main.py
+
+# Sync environment
+uv sync
+```
+
+## Code Style
+- **Formatter:** `ruff format` (Black-compatible)
+- **Linter:** `ruff check --fix --unsafe-fixes`
+- **Type Checker:** `ty` (not mypy)
+- **Line Length:** 88 characters (Black standard)
+- **Imports:** Sorted by ruff (isort-compatible)
+
+## Type Hints
+- **Required for:** All public functions and methods
+- **Example:**
+```python
+def process_data(items: list[dict[str, Any]]) -> pd.DataFrame:
+    """Process raw data into DataFrame."""
+    ...
+```
+
+## Project Structure
+```
+project/
+├── src/project/       # Source code
+│   ├── __init__.py
+│   └── module.py
+├── tests/            # Real tests only
+├── pyproject.toml    # Project config (UV + ruff + ty)
+└── .gitignore
+```
+
+## Pre-commit Hook
+```bash
+#!/bin/bash
+# .git/hooks/pre-commit
+files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.py$')
+if [ -n "$files" ]; then
+    uv run ruff check --fix --unsafe-fixes $files
+    uv run ruff format $files
+    git add $files
+fi
+```
+
+## Common Patterns
+- **Context Managers:** For resource management
+- **Dataclasses:** For data structures
+- **Pathlib:** For file operations (not os.path)
+- **F-strings:** For string formatting
+
+## Error Handling
+```python
+# Be specific with exceptions
+try:
+    result = risky_operation()
+except SpecificError as e:
+    logger.error(f"Operation failed: {e}")
+    raise  # Re-raise or handle appropriately
+
+# Never do this:
+# except Exception:
+#     pass  # Silent failure
+```
+
+## Never Do This
+- Never use `pip install` directly; use `uv add` or `uv pip install`
+- Never use `conda`, `virtualenv`, or `venv`; UV handles environments
+- Never use `mypy`; use `ty` for type checking
+- Never use bare `except:` or `except Exception: pass`
+- Never use `os.path`; use `pathlib.Path`
+- Never commit `.env` files or hardcoded secrets
+
+## Documentation
+- **Docstrings:** Google or NumPy style
+- **Module docs:** At file top
+- **Type hints:** Self-documenting code
+
+---
+*UV for everything. Ruff for style. Ty for types. Real tests only.*

--- a/.rules/python.md
+++ b/.rules/python.md
@@ -1,7 +1,7 @@
 # Python Development Standards
 
 ## Version & Environment
-- **Python 3.11+** minimum (use latest stable)
+- **Python 3.12+** minimum (use latest stable)
 - **Package Manager:** UV only (not pip, conda, or virtualenv)
 - **Virtual Environment:** Managed by UV (`uv venv`, `uv sync`)
 - **Project Config:** `pyproject.toml` (no requirements.txt)

--- a/.rules/self_improve.md
+++ b/.rules/self_improve.md
@@ -1,0 +1,85 @@
+# Continuous Rule Improvement
+
+## Philosophy: Rules Grow from Understanding
+**Think deeply:** Why did this pattern emerge? What problem does it solve?
+**Learn actively:** Every project teaches something - capture it.
+**Evolve thoughtfully:** Rules should guide, not constrain creativity.
+
+## Improvement Triggers
+- Pattern used 3+ times → Create rule
+- Common failures in .context/scratch_history.md → Add prevention rule
+- Successful .context/research.md solutions → Standardize
+- Mature .context/ideas.md concepts → Formalize
+- Repeated PR feedback → Document standard
+
+## Analysis Sources
+1. **.context/scratch_history.md:** Mine for anti-patterns
+2. **.context/research.md:** Extract proven solutions  
+3. **.context/ideas.md:** Promote design principles
+4. **.context/plan.md:** Identify workflow patterns
+5. **Code reviews:** Track common feedback
+
+## Rule Updates
+
+### Add Rules When:
+- New pattern appears 3+ times
+- Common bug could be prevented
+- Better approach discovered
+- Security/performance pattern emerges
+
+### Modify Rules When:
+- Better examples found in codebase
+- Edge cases discovered
+- Implementation changed
+- Related rules updated
+
+### Remove Rules When:
+- Tech stack changed
+- Pattern deprecated
+- No longer applicable
+
+## Quality Checks
+- **Actionable:** Clear what to do
+- **Specific:** No ambiguity
+- **Examples:** From actual code
+- **Cross-referenced:** Link related rules
+
+## Learning-Driven Creation
+**Extract wisdom, not just fixes:**
+```python
+# From .context/scratch_history.md failure:
+# "Database connections leaked after 24hrs"
+# THINK: Why? Resource management issue.
+# LESSON: Explicit cleanup isn't reliable.
+# → Rule: Always use context managers
+
+with get_db() as db:  # Guaranteed cleanup
+    process(db)
+# Not: db = get_db(); process(db); db.close()  # Risky
+```
+
+**Ask yourself:**
+- What's the root cause?
+- Will this prevent future issues?
+- Is this a symptom of a bigger pattern?
+
+## Thoughtful Maintenance Process
+1. **Weekly:** Review .context/scratch_history.md - What patterns emerged?
+2. **After features:** Mine .context/research.md - What worked well?
+3. **Post-refactor:** Update rules - What changed fundamentally?
+4. **Quarterly:** Audit all - Are rules still serving us?
+
+**Critical questions:**
+- Are developers following these rules naturally?
+- Do rules prevent issues or create friction?
+- What would a new team member need to know?
+
+## The Bigger Picture
+**Rules aren't just constraints** - they're collective wisdom.
+**Good rules:** Enable creativity within proven patterns.
+**Bad rules:** Create busywork without clear value.
+
+**Remember:** You're codifying experience for future developers (including future you).
+
+---
+*Rules evolve from understanding. Think deeply, document failures, standardize successes thoughtfully.*

--- a/.rules/serena_mcp.md
+++ b/.rules/serena_mcp.md
@@ -1,0 +1,49 @@
+# Serena MCP for Code Intelligence
+
+## When Available
+Use Serena MCP tools for efficient code exploration and editing when the MCP server is configured.
+
+## Core Tools
+
+### Exploration (Read-Only)
+- `get_symbols_overview` - Get file structure before reading entire files
+- `find_symbol` - Search for classes, methods, functions by name
+- `find_referencing_symbols` - Find all usages of a symbol
+- `search_for_pattern` - Flexible regex search across codebase
+- `list_dir` - List directory contents
+- `find_file` - Find files by name pattern
+
+### Editing (Symbolic)
+- `replace_symbol_body` - Replace entire method/function body
+- `insert_after_symbol` - Add code after a symbol
+- `insert_before_symbol` - Add code before a symbol
+- `rename_symbol` - Rename a symbol across the codebase
+
+## Best Practices
+
+### Prefer Symbolic Tools Over Full File Reads
+```
+# Good: Get overview first, then read specific symbols
+get_symbols_overview(file) -> find_symbol(name, include_body=True)
+
+# Avoid: Reading entire large files when you only need one function
+```
+
+### Incremental Exploration
+1. Start with `get_symbols_overview` to understand file structure
+2. Use `find_symbol` with `depth=1` to see method signatures
+3. Only read bodies (`include_body=True`) when needed
+4. Use `find_referencing_symbols` to understand usage patterns
+
+### Efficient Editing
+- Use `replace_symbol_body` for modifying entire functions
+- Use `insert_after_symbol` for adding new methods to a class
+- Prefer symbolic editing over line-based edits for complex changes
+
+## Memory Integration
+- Use `write_memory` to persist findings across sessions
+- Use `read_memory` to recall previous context
+- Name memories descriptively for easy retrieval
+
+---
+*Token-efficient code exploration and precise symbolic editing.*

--- a/.rules/testing.md
+++ b/.rules/testing.md
@@ -1,0 +1,90 @@
+# Testing Standards - NO MOCKS Policy
+
+## Core Philosophy: Test Reality, Not Fiction
+**Why NO MOCKS?** Mocks test your assumptions, not your code.  
+**Real bugs** hide in integration points, not unit logic.  
+**Better approach:** No test is better than a false-confidence mock test.
+
+## [STRICT] NO MOCKS, NO FAKE DATA
+Never use mocks, stubs, or fake datasets. If real testing isn't possible, don't write tests.
+- **No mock objects** - Use real implementations
+- **No mock datasets** - Use actual sample data
+- **No stub services** - Connect to real test instances
+- **Alternative:** Ask user for sample data or test environment setup
+
+## When to Write Tests
+- **DO:** Test with real data and actual dependencies
+- **DO:** Use test databases with real schemas
+- **DO:** Test against actual file systems
+- **DON'T:** Write tests if only mocks would work
+- **DON'T:** Create artificial test scenarios
+
+## Test Structure
+```
+tests/
+  conftest.py          # Real test fixtures
+  sample_data/         # Actual data samples (user-provided)
+    valid/
+    invalid/
+  integration/         # Tests with real dependencies
+    test_database.py   # Real DB connection
+    test_api.py        # Real API calls
+```
+
+## Frameworks (Language-Specific)
+- **Python:** `pytest` with real fixtures
+- **JavaScript:** `vitest` or `jest` (no mocking libs)
+- **Database:** Use test DB with real migrations
+- **APIs:** Test against staging/local instances
+
+## Writing Real Tests
+```python
+# GOOD: Tests actual behavior
+def test_user_creation(real_db):
+    """Tests that users are actually persisted."""
+    user = User.create(email="test@example.com")
+    # This catches: ORM issues, DB constraints, connection problems
+    assert real_db.query(User).filter_by(email="test@example.com").first()
+
+# BAD: Tests nothing meaningful
+# def test_user_creation(mock_db):  # NO!
+#     mock_db.return_value = User()  # Tests that Python works?
+```
+
+**Ask:** What am I actually testing? Would this catch real bugs?
+
+## Test Data Management
+- **Sample data:** Request from user or use production samples
+- **Test databases:** Use Docker containers or test instances
+- **File fixtures:** Use actual files, not generated ones
+- **API testing:** Point to real test endpoints
+
+## CI Integration
+- Run tests with real test environment
+- Skip tests if environment unavailable
+- Document required test infrastructure
+- See `ci_cd.md` for pipeline setup
+
+## When Real Testing Seems Impossible
+**Think creatively before giving up:**
+- Can you use Docker for a test database?
+- Can you record real API responses for replay?
+- Can you get anonymized production data samples?
+- Can you create a minimal test environment?
+
+**If truly impossible:**
+1. Document needs in `test_requirements.md`
+2. Explain to user what's needed and why
+3. Ask for:
+   - Sample datasets from production
+   - Test environment access
+   - Sandbox API credentials
+4. **Be honest:** "Without real test data, I cannot verify this works"
+
+## The Testing Mindset
+- **You're not checking boxes** - you're building confidence
+- **Every test should** catch at least one real bug category
+- **Think:** "Will this test save someone from a 3am wake-up call?"
+
+---
+*NO MOCKS. Real tests build real confidence. When in doubt, ask for real data.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,110 @@
+# pyAMICA Instructions
+
+## Project Context
+**Purpose:** Python implementation of AMICA (Adaptive Mixture Independent Component Analysis) that reproduces the results of the reference Fortran binary. Targets EEG/EMG source separation with GPU/MPS/CPU support.
+**Tech Stack:** Python 3.10+, PyTorch (primary backend, MPS/CUDA/CPU), NumPy/SciPy (legacy backend), matplotlib. Reference implementation is Fortran (`amica17.f90`, `funmod2.f90`).
+**Architecture:** Two coexisting backends. The PyTorch backend (`pyAMICA/torch_impl/`) is the default and is exposed through a scikit-learn-style `AMICA` interface; the legacy NumPy implementation is retained as `AMICA_NumPy`. Correctness is defined by parity with the Fortran binary, validated by `validate_implementations.py`.
+
+## Architecture Map
+```
+pyAMICA/
+├── amica.py                 # Main scikit-learn-style AMICA interface (PyTorch-backed)
+├── __init__.py              # Exposes AMICA (PyTorch) and AMICA_NumPy (legacy)
+├── torch_impl/              # PyTorch backend (default)
+│   ├── amica_torch.py       #   Core AMICA module
+│   ├── amica_torch_v2.py    #   Enhanced model (Newton + adaptive PDF + multi-model)
+│   ├── adaptive_pdf.py      #   Adaptive PDF selection (Laplace/Student-t/GG)
+│   ├── newton_optimizer.py  #   Newton optimization with Fortran-style ramping
+│   ├── mixture_models.py    #   Mixture-of-densities components
+│   ├── optimizers.py        #   Natural-gradient / optimizer utilities
+│   ├── fortran_output.py    #   Fortran-style debug/log output
+│   └── utils.py             #   Preprocessing (sphering, PCA), device selection
+├── pyAMICA.py, amica_*.py   # Legacy NumPy implementation + CLI/data/viz/pdf/newton
+├── amica17.f90, funmod2.f90 # Fortran reference source (read-only, for parity)
+├── sample_data/             # Sample EEG data + Fortran binary (amica15mac)
+└── tests/                   # Tests, incl. tests/torch_tests/ (vs-Fortran parity)
+
+validate_implementations.py  # Runs both backends, Hungarian component matching, reports
+```
+
+## Environment Setup
+Canonical environment is **UV** (per global standards). Migration from the legacy conda env
+(`torch-312`) to a UV-managed environment is tracked in `.context/plan.md` and not yet complete;
+until it lands, `requirements-torch.txt` documents the PyTorch dependency set.
+```bash
+uv sync                          # Install dependencies (once pyproject declares the torch stack)
+uv run pytest                    # Run tests
+uv run ruff check --fix . && uv run ruff format .
+```
+MPS note: run with `PYTORCH_ENABLE_MPS_FALLBACK=1` for ops MPS does not yet support.
+
+## Key Files
+- **Main interface:** `pyAMICA/amica.py`
+- **Default backend:** `pyAMICA/torch_impl/amica_torch.py` (and `amica_torch_v2.py` for the enhanced model)
+- **Validation harness:** `validate_implementations.py`
+- **Fortran reference binary:** `pyAMICA/sample_data/amica15mac`
+- **Sample data:** `pyAMICA/sample_data/`
+
+## Current Status
+- PyTorch backend with GPU/MPS/CPU support and basic AMICA converges.
+- Validation harness runs both backends and matches components via the Hungarian algorithm.
+- Newton optimization, adaptive PDF selection, and multi-model support are partially implemented.
+- See `FEATURE_PARITY.md`, `MIGRATION_PLAN.md`, and `PROGRESS_SUMMARY.md` for detailed roadmaps.
+
+## Known Issues (parity blockers)
+1. Component correlation with Fortran ~0.7-0.9 (target: >0.95).
+2. Log-likelihood scaling differs from Fortran (~13x factor); enhanced model has produced
+   positive LLs (addressed by the GG normalization fix, needs revalidation).
+3. Newton method unstable, NaN at the Newton-start iteration (gradient clipping + Fortran-matched
+   ramp added, needs revalidation).
+4. Missing adaptive/outlier-rejection features reduce separation quality.
+
+## Development Workflow
+1. **Check context:** `.context/plan.md` for current tasks and priorities.
+2. **Understand deeply:** `.context/ideas.md` (design), `.context/research.md` (Fortran-vs-Python parity).
+3. **Branch:** `gh issue develop <issue-number>` (create an issue first, except minor fixes).
+4. **Code:** Follow patterns in `.rules/`.
+5. **Test:** Real data only (sample EEG + Fortran binary); see `.rules/testing.md`.
+6. **Document failures:** Log dead ends in `.context/scratch_history.md`.
+7. **Commit:** Atomic, <50 chars, no emojis, no AI attribution.
+8. **PR + review:** Run `/review-pr` and address all findings (`.rules/code_review.md`).
+
+## [CRITICAL] Core Principles
+- **NO MOCKS:** Validate against real sample data and the Fortran binary, never fabricated data. Details: `.rules/testing.md`.
+- **No technical debt carried forward:** Address ALL PR review findings; replace, don't deprecate. Details: `.rules/code_review.md`.
+- **Numerical parity is the spec:** Correctness means matching Fortran output within tolerance, not merely "converging".
+
+## [NEVER DO THIS]
+- Never use mocks, stubs, or fake/synthetic data as the basis for correctness tests.
+- Never use `pip`, `conda`, or `virtualenv`; use UV for Python.
+- Never commit secrets, `.env` files, or credentials.
+- Never leave empty catch blocks or silent failures (this codebase already has NaN-suppression risks).
+- Never add backward-compatibility shims; replace directly.
+- Never add a TODO without a linked issue.
+- Never use emojis in commits, PRs, or code.
+
+## [REFERENCE] Rules Directory
+- `.rules/testing.md` - NO MOCK policy, coverage
+- `.rules/python.md` - UV, ruff, ty
+- `.rules/git.md` - Commit/branch conventions
+- `.rules/code_review.md` - PR review toolkit and checklist
+- `.rules/ci_cd.md` - GitHub Actions setup
+- `.rules/documentation.md` - Docs conventions
+- `.rules/self_improve.md` - Learning/pattern extraction
+- `.rules/serena_mcp.md` - Serena MCP code intelligence (when available)
+
+## Context Files
+- `.context/plan.md` - Current tasks, phases, priorities
+- `.context/research.md` - Fortran-vs-Python parity analysis (data structures, subroutines, divergence causes)
+- `.context/ideas.md` - PyTorch design decisions and library options
+- `.context/scratch_history.md` - Debugging notes, failed attempts, lessons
+- `.context/decisions/` - Architecture Decision Records (copy `0000-template.md` to start one)
+
+## Project Docs (top-level)
+- `FEATURE_PARITY.md` - Feature comparison and implementation roadmap
+- `MIGRATION_PLAN.md` - NumPy to PyTorch migration timeline
+- `PROGRESS_SUMMARY.md` - Achievements and validation metrics snapshot
+- `README.md` - Overview and quick start
+
+---
+Remember: parity with the Fortran reference is the definition of done. Check `.rules/` for detailed guidance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,8 @@
 
 ## Project Context
 **Purpose:** Python implementation of AMICA (Adaptive Mixture Independent Component Analysis) that reproduces the results of the reference Fortran binary. Targets EEG/EMG source separation with GPU/MPS/CPU support.
-**Tech Stack:** Python 3.10+, PyTorch (primary backend, MPS/CUDA/CPU), NumPy/SciPy (legacy backend), matplotlib. Reference implementation is Fortran (`amica17.f90`, `funmod2.f90`).
-**Architecture:** Two coexisting backends. The PyTorch backend (`pyAMICA/torch_impl/`) is the default and is exposed through a scikit-learn-style `AMICA` interface; the legacy NumPy implementation is retained as `AMICA_NumPy`. Correctness is defined by parity with the Fortran binary, validated by `validate_implementations.py`.
+**Tech Stack:** Python 3.12+, PyTorch (primary backend, MPS/CUDA/CPU), NumPy/SciPy (legacy backend), matplotlib. Reference implementation is Fortran (`amica17.f90`, `funmod2.f90`).
+**Architecture:** Two coexisting backends. The default scikit-learn-style `AMICA` interface wraps the basic `AMICATorch` (`torch_impl/amica_torch.py`), which currently has Newton disabled and no adaptive PDF. An enhanced `AMICATorchV2` (`torch_impl/amica_torch_v2.py`) adds Newton, adaptive PDF, and multi-model support but is experimental and NOT yet wired into the public interface. The legacy NumPy implementation (`pyAMICA.py`, retained as `AMICA_NumPy`) has the fuller feature set (Newton, baralpha, outlier rejection). Correctness is defined by parity with the Fortran binary, validated by `validate_implementations.py`.
 
 ## Architecture Map
 ```
@@ -11,8 +11,8 @@ pyAMICA/
 ├── amica.py                 # Main scikit-learn-style AMICA interface (PyTorch-backed)
 ├── __init__.py              # Exposes AMICA (PyTorch) and AMICA_NumPy (legacy)
 ├── torch_impl/              # PyTorch backend (default)
-│   ├── amica_torch.py       #   Core AMICA module
-│   ├── amica_torch_v2.py    #   Enhanced model (Newton + adaptive PDF + multi-model)
+│   ├── amica_torch.py       #   Core AMICA module (basic; Newton disabled) - backs the default AMICA
+│   ├── amica_torch_v2.py    #   Enhanced model (Newton + adaptive PDF + multi-model); experimental, NOT wired into default AMICA
 │   ├── adaptive_pdf.py      #   Adaptive PDF selection (Laplace/Student-t/GG)
 │   ├── newton_optimizer.py  #   Newton optimization with Fortran-style ramping
 │   ├── mixture_models.py    #   Mixture-of-densities components
@@ -40,7 +40,7 @@ MPS note: run with `PYTORCH_ENABLE_MPS_FALLBACK=1` for ops MPS does not yet supp
 
 ## Key Files
 - **Main interface:** `pyAMICA/amica.py`
-- **Default backend:** `pyAMICA/torch_impl/amica_torch.py` (and `amica_torch_v2.py` for the enhanced model)
+- **Default backend:** `pyAMICA/torch_impl/amica_torch.py` (`AMICATorch`, Newton disabled). Enhanced but not-yet-wired: `amica_torch_v2.py` (`AMICATorchV2`)
 - **Validation harness:** `validate_implementations.py`
 - **Fortran reference binary:** `pyAMICA/sample_data/amica15mac`
 - **Sample data:** `pyAMICA/sample_data/`
@@ -48,16 +48,17 @@ MPS note: run with `PYTORCH_ENABLE_MPS_FALLBACK=1` for ops MPS does not yet supp
 ## Current Status
 - PyTorch backend with GPU/MPS/CPU support and basic AMICA converges.
 - Validation harness runs both backends and matches components via the Hungarian algorithm.
-- Newton optimization, adaptive PDF selection, and multi-model support are partially implemented.
+- Newton, adaptive PDF, and multi-model exist only in the experimental `AMICATorchV2` (not wired into the default `AMICA`); the legacy NumPy `pyAMICA.py` implements Newton, baralpha, and outlier rejection.
 - See `FEATURE_PARITY.md`, `MIGRATION_PLAN.md`, and `PROGRESS_SUMMARY.md` for detailed roadmaps.
 
 ## Known Issues (parity blockers)
-1. Component correlation with Fortran ~0.7-0.9 (target: >0.95).
-2. Log-likelihood scaling differs from Fortran (~13x factor); enhanced model has produced
-   positive LLs (addressed by the GG normalization fix, needs revalidation).
-3. Newton method unstable, NaN at the Newton-start iteration (gradient clipping + Fortran-matched
-   ramp added, needs revalidation).
-4. Missing adaptive/outlier-rejection features reduce separation quality.
+1. Component correlation with Fortran ~0.46-0.9 (run-dependent; target: >0.95).
+2. Log-likelihood scaling differs from Fortran (~13x for the basic backend, more for enhanced);
+   the enhanced model produced positive LLs (addressed by the GG normalization fix, needs revalidation).
+3. Newton (in `AMICATorchV2`) is unstable, NaN at the Newton-start iteration (gradient clipping +
+   Fortran-matched ramp added in commit 2ccbae6, needs revalidation).
+4. The default torch backend lacks adaptive-PDF and outlier rejection (present in legacy NumPy),
+   reducing separation quality.
 
 ## Development Workflow
 1. **Check context:** `.context/plan.md` for current tasks and priorities.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+@AGENTS.md
+
+# Claude Code Notes
+
+The project's instructions, architecture, environment, and conventions live in `AGENTS.md`
+(imported above). Only Claude Code-specific guidance belongs here.
+
+## Environment reminder
+Canonical env is UV (see AGENTS.md). The legacy conda env still exists as `torch-312`; migration
+to UV is tracked in `.context/plan.md`. Prefer `PYTORCH_ENABLE_MPS_FALLBACK=1` when running on MPS.
+
+## Skills & commands
+- `/review-pr` (pr-review-toolkit) before finalizing any PR; run reviewers with the model set to Sonnet.
+- `/plan` for detailed implementation planning on non-trivial features.
+- ADRs live in `.context/decisions/`; copy `0000-template.md` to start a new one.
+
+## Validation
+Correctness = parity with the Fortran binary. Use `validate_implementations.py` (real sample data,
+never synthetic) as the source of truth when comparing backends.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python",
     "Topic :: Scientific/Engineering"
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
     "numpy",
     "scipy",


### PR DESCRIPTION
## Summary

Initializes the cross-agent project structure via the vibe-rules templates. No source code changes; this is documentation, rules, and context scaffolding only.

## Changes

- **`AGENTS.md`** — project facts customized for pyAMICA: architecture map (PyTorch default backend + legacy NumPy), key files, current status, known parity blockers, workflow, and rule/context references. UV documented as the canonical environment.
- **`CLAUDE.md`** — reduced to a thin `@AGENTS.md` adapter plus Claude Code-specific notes (skills, ADRs, validation). Previously held project content that now lives in `AGENTS.md`.
- **`.rules/`** — python, testing, git, code_review, ci_cd, documentation, self_improve, serena_mcp.
- **`.context/`** — plan, research, ideas, scratch_history, and `decisions/` (ADRs). The former gitignored root working docs (`plan.md`, `research.md`, `ideas.md`, `scratch_notes.md`) were consolidated into `.context/` and the root copies removed.
- **`.gitignore`** — dropped the ignore entries for `CLAUDE.md` and the consolidated root docs (now tracked); kept generated-output ignores.
- Pre-commit hook (ruff via UV) installed locally.

Top-level `FEATURE_PARITY.md`, `MIGRATION_PLAN.md`, and `PROGRESS_SUMMARY.md` are intentionally kept as polished docs.

## Notes

- Follow-up: environment migration from conda `torch-312` to UV is tracked in `.context/plan.md` (the pre-commit hook and AGENTS.md assume `uv run`).
- Related: #7 (run the real-data PyTorch test suite).

## Testing

No code changed. Verified the scaffolding exists (`AGENTS.md`, `CLAUDE.md`, `.rules/`, `.context/`, `.context/decisions/`) and that no `{{PLACEHOLDER}}` tokens remain in the customized files.
