### PR TITLE
Phase 3: Natural-gradient EM backend (opt-in)

### DIFF
--- a/pyAMICA/amica.py
+++ b/pyAMICA/amica.py
@@ -6,12 +6,11 @@ implementation for GPU-accelerated ICA with adaptive mixtures.
 """
 
 import numpy as np
-from pathlib import Path
-from typing import Optional, Dict, Union
+from typing import Optional, Union
 import json
 import logging
 
-from .torch_impl import AMICATorch, setup_device
+from .torch_impl import AMICATorch, AMICATorchNG, setup_device
 
 logger = logging.getLogger(__name__)
 
@@ -19,10 +18,10 @@ logger = logging.getLogger(__name__)
 class AMICA:
     """
     Adaptive Mixture ICA using PyTorch backend.
-    
+
     This is the main interface for pyAMICA, providing a scikit-learn style
     API while using the GPU-accelerated PyTorch implementation underneath.
-    
+
     Parameters
     ----------
     n_models : int, default=1
@@ -33,7 +32,16 @@ class AMICA:
         Device to use ('cuda', 'mps', 'cpu', or None for auto)
     verbose : bool, default=True
         Whether to show progress during fitting
-    
+    backend : {"torch", "ng"}, default="torch"
+        Which underlying implementation to use. ``"torch"`` (the default)
+        is ``AMICATorch``, the existing Adam/autograd-driven backend.
+        ``"ng"`` is ``AMICATorchNG`` (ADR 0001), a natural-gradient EM port
+        that matches the Fortran/NumPy fixed-point update rule; it is
+        opt-in and experimental (see ``.context/decisions/0001-torch-backend-natural-gradient-em.md``).
+        Because the two backends have different constructor/fit shapes,
+        ``**kwargs`` passed to :meth:`fit` are routed differently depending
+        on ``backend`` -- see :meth:`fit`.
+
     Attributes
     ----------
     model_ : AMICATorch
@@ -42,42 +50,47 @@ class AMICA:
         Whether the model has been fitted
     ll_history_ : list
         Log-likelihood history during training
-    
+
     Examples
     --------
     >>> from pyAMICA import AMICA
     >>> import numpy as np
-    >>> 
+    >>>
     >>> # Generate sample data
     >>> X = np.random.randn(32, 10000)  # 32 channels, 10000 samples
-    >>> 
+    >>>
     >>> # Fit AMICA model
     >>> amica = AMICA(n_models=1, n_mix=3)
     >>> amica.fit(X, max_iter=100)
-    >>> 
+    >>>
     >>> # Transform data to sources
     >>> S = amica.transform(X)
-    >>> 
+    >>>
     >>> # Get mixing matrix
     >>> A = amica.get_mixing_matrix()
     """
-    
+
     def __init__(
         self,
         n_models: int = 1,
         n_mix: int = 3,
         device: Optional[Union[str, object]] = None,
-        verbose: bool = True
+        verbose: bool = True,
+        backend: str = "torch",
     ):
+        if backend not in ("torch", "ng"):
+            raise ValueError(f"backend must be 'torch' or 'ng', got {backend!r}")
+
         self.n_models = n_models
         self.n_mix = n_mix
         self.device = device
         self.verbose = verbose
-        
+        self.backend = backend
+
         self.model_ = None
         self.is_fitted_ = False
         self.ll_history_ = []
-        
+
     def fit(
         self,
         X: np.ndarray,
@@ -88,11 +101,11 @@ class AMICA:
         do_newton: bool = False,
         output_dir: Optional[str] = None,
         debug: bool = False,
-        **kwargs
-    ) -> 'AMICA':
+        **kwargs,
+    ) -> "AMICA":
         """
         Fit AMICA model to data.
-        
+
         Parameters
         ----------
         X : np.ndarray
@@ -106,14 +119,23 @@ class AMICA:
         do_sphere : bool, default=True
             Whether to sphere (whiten) the data
         do_newton : bool, default=False
-            Whether to use Newton optimization (experimental)
+            Whether to use Newton optimization (experimental). Only supported
+            by ``backend="torch"``; passing ``do_newton=True`` with
+            ``backend="ng"`` raises, since Newton is not yet ported to the
+            natural-gradient backend (Phase 4).
         output_dir : str, optional
-            Directory for debug output (only used if debug=True)
+            Directory for debug output (only used if debug=True). Only
+            supported by ``backend="torch"``.
         debug : bool, default=False
-            If True, use Fortran-style output; if False, use tqdm progress bar
+            If True, use Fortran-style output; if False, use tqdm progress
+            bar. Only supported by ``backend="torch"``.
         **kwargs
-            Additional parameters passed to AMICATorch.fit()
-            
+            For ``backend="torch"``, additional parameters passed to
+            ``AMICATorch.fit()``. For ``backend="ng"``, additional
+            parameters passed to the ``AMICATorchNG`` constructor instead
+            (e.g. ``block_size``, ``rho0``, ``seed``, ``dtype``) -- the NG
+            backend's tunables are constructor arguments, not fit() kwargs.
+
         Returns
         -------
         self : AMICA
@@ -122,28 +144,62 @@ class AMICA:
         # Validate input
         if X.ndim != 2:
             raise ValueError(f"X must be 2D array, got shape {X.shape}")
-        
+
         n_channels, n_samples = X.shape
-        
+
         if self.verbose:
             print(f"Fitting AMICA with {n_channels} channels, {n_samples} samples")
             print(f"Models: {self.n_models}, Mixture components: {self.n_mix}")
-        
+
         # Setup device
         if self.device is None:
             device = setup_device()
         else:
             device = self.device
-            
+
+        if self.backend == "ng":
+            if do_newton:
+                raise ValueError(
+                    "do_newton=True is not supported by backend='ng' yet "
+                    "(Newton is Phase 4, not ported to AMICATorchNG)."
+                )
+            if debug:
+                raise ValueError(
+                    "debug=True (Fortran-style output) is not supported by "
+                    "backend='ng'."
+                )
+            if output_dir is not None:
+                raise ValueError(
+                    "output_dir is not supported by backend='ng' (no debug "
+                    "output path)."
+                )
+
+            self.model_ = AMICATorchNG(
+                n_channels=n_channels,
+                n_models=self.n_models,
+                n_mix=self.n_mix,
+                lrate=lrate,
+                do_mean=do_mean,
+                do_sphere=do_sphere,
+                device=device,
+                **kwargs,
+            )
+            self.model_.fit(X, max_iter=max_iter, verbose=self.verbose)
+
+            self.ll_history_ = self.model_.ll_history
+            self.is_fitted_ = True
+
+            return self
+
         # Create PyTorch model
         self.model_ = AMICATorch(
             n_channels=n_channels,
             n_sources=n_channels,  # Default to square mixing
             n_models=self.n_models,
             n_mix=self.n_mix,
-            device=device
+            device=device,
         )
-        
+
         # Fit model
         self.model_.fit(
             X,
@@ -154,26 +210,26 @@ class AMICA:
             do_newton=do_newton,
             debug=debug or not self.verbose,
             output_dir=output_dir,
-            **kwargs
+            **kwargs,
         )
-        
+
         # Store history
         self.ll_history_ = self.model_.ll_history
         self.is_fitted_ = True
-        
+
         return self
-    
+
     def transform(self, X: np.ndarray, model_idx: int = 0) -> np.ndarray:
         """
         Transform data to source space.
-        
+
         Parameters
         ----------
         X : np.ndarray
             Input data of shape (n_channels, n_samples)
         model_idx : int, default=0
             Which model to use for transformation
-            
+
         Returns
         -------
         S : np.ndarray
@@ -181,20 +237,20 @@ class AMICA:
         """
         if not self.is_fitted_:
             raise ValueError("Model must be fitted before transform")
-            
+
         return self.model_.transform(X, model_idx=model_idx)
-    
+
     def fit_transform(self, X: np.ndarray, **fit_params) -> np.ndarray:
         """
         Fit model and transform data.
-        
+
         Parameters
         ----------
         X : np.ndarray
             Input data of shape (n_channels, n_samples)
         **fit_params
             Parameters passed to fit()
-            
+
         Returns
         -------
         S : np.ndarray
@@ -202,16 +258,16 @@ class AMICA:
         """
         self.fit(X, **fit_params)
         return self.transform(X)
-    
+
     def get_mixing_matrix(self, model_idx: int = 0) -> np.ndarray:
         """
         Get the mixing matrix A.
-        
+
         Parameters
         ----------
         model_idx : int, default=0
             Which model's mixing matrix to return
-            
+
         Returns
         -------
         A : np.ndarray
@@ -219,18 +275,18 @@ class AMICA:
         """
         if not self.is_fitted_:
             raise ValueError("Model must be fitted before getting mixing matrix")
-            
+
         return self.model_.get_mixing_matrix(model_idx=model_idx)
-    
+
     def get_unmixing_matrix(self, model_idx: int = 0) -> np.ndarray:
         """
         Get the unmixing matrix W.
-        
+
         Parameters
         ----------
         model_idx : int, default=0
             Which model's unmixing matrix to return
-            
+
         Returns
         -------
         W : np.ndarray
@@ -238,13 +294,13 @@ class AMICA:
         """
         if not self.is_fitted_:
             raise ValueError("Model must be fitted before getting unmixing matrix")
-            
+
         return self.model_.get_unmixing_matrix(model_idx=model_idx)
-    
+
     def save(self, filepath: str):
         """
         Save model to file.
-        
+
         Parameters
         ----------
         filepath : str
@@ -252,87 +308,102 @@ class AMICA:
         """
         if not self.is_fitted_:
             raise ValueError("Cannot save unfitted model")
-            
+        if self.backend == "ng":
+            raise NotImplementedError(
+                "save() is not implemented for backend='ng': AMICATorchNG "
+                "is not an nn.Module and has no state_dict()."
+            )
+
         import torch
-        torch.save({
-            'model_state': self.model_.state_dict(),
-            'n_models': self.n_models,
-            'n_mix': self.n_mix,
-            'n_channels': self.model_.n_channels,
-            'n_sources': self.model_.n_sources,
-            'll_history': self.ll_history_
-        }, filepath)
-        
+
+        torch.save(
+            {
+                "model_state": self.model_.state_dict(),
+                "n_models": self.n_models,
+                "n_mix": self.n_mix,
+                "n_channels": self.model_.n_channels,
+                "n_sources": self.model_.n_sources,
+                "ll_history": self.ll_history_,
+            },
+            filepath,
+        )
+
         if self.verbose:
             print(f"Model saved to {filepath}")
-    
+
     def load(self, filepath: str):
         """
         Load model from file.
-        
+
         Parameters
         ----------
         filepath : str
             Path to load the model from
         """
+        if self.backend == "ng":
+            raise NotImplementedError(
+                "load() is not implemented for backend='ng': AMICATorchNG "
+                "has no save()/state_dict() counterpart."
+            )
+
         import torch
-        
-        checkpoint = torch.load(filepath, map_location='cpu')
-        
+
+        checkpoint = torch.load(filepath, map_location="cpu")
+
         # Setup device
         if self.device is None:
             device = setup_device()
         else:
             device = self.device
-        
+
         # Create model with saved dimensions
         self.model_ = AMICATorch(
-            n_channels=checkpoint['n_channels'],
-            n_sources=checkpoint['n_sources'],
-            n_models=checkpoint['n_models'],
-            n_mix=checkpoint['n_mix'],
-            device=device
+            n_channels=checkpoint["n_channels"],
+            n_sources=checkpoint["n_sources"],
+            n_models=checkpoint["n_models"],
+            n_mix=checkpoint["n_mix"],
+            device=device,
         )
-        
+
         # Load state
-        self.model_.load_state_dict(checkpoint['model_state'])
+        self.model_.load_state_dict(checkpoint["model_state"])
         self.model_.to(device)
-        
+
         # Update attributes
-        self.n_models = checkpoint['n_models']
-        self.n_mix = checkpoint['n_mix']
-        self.ll_history_ = checkpoint.get('ll_history', [])
+        self.n_models = checkpoint["n_models"]
+        self.n_mix = checkpoint["n_mix"]
+        self.ll_history_ = checkpoint.get("ll_history", [])
         self.is_fitted_ = True
-        
+
         if self.verbose:
             print(f"Model loaded from {filepath}")
-    
+
     @classmethod
-    def from_params_file(cls, params_file: str, **kwargs) -> 'AMICA':
+    def from_params_file(cls, params_file: str, **kwargs) -> "AMICA":
         """
         Create AMICA instance from parameter file.
-        
+
         Parameters
         ----------
         params_file : str
             Path to JSON parameter file
         **kwargs
             Additional parameters to override
-            
+
         Returns
         -------
         amica : AMICA
             Configured AMICA instance
         """
-        with open(params_file, 'r') as f:
+        with open(params_file, "r") as f:
             params = json.load(f)
-        
+
         # Extract relevant parameters
-        n_models = params.get('num_models', 1)
-        n_mix = params.get('num_mix', 3)
-        
+        n_models = params.get("num_models", 1)
+        n_mix = params.get("num_mix", 3)
+
         # Override with kwargs
-        n_models = kwargs.pop('n_models', n_models)
-        n_mix = kwargs.pop('n_mix', n_mix)
-        
+        n_models = kwargs.pop("n_models", n_models)
+        n_mix = kwargs.pop("n_mix", n_mix)
+
         return cls(n_models=n_models, n_mix=n_mix, **kwargs)

--- a/pyAMICA/tests/torch_tests/test_ng_backend.py
+++ b/pyAMICA/tests/torch_tests/test_ng_backend.py
@@ -1,0 +1,174 @@
+"""Tests for the natural-gradient EM backend (AMICATorchNG).
+
+Real sample EEG data only (no synthetic/mock). The decisive correctness
+check is that the vectorized per-block sufficient statistics match the
+validated NumPy reference (``AMICA_NumPy._get_block_updates``) to float64
+precision on an identical block with identical parameters.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from pyAMICA.torch_impl import AMICATorchNG
+from pyAMICA.pyAMICA import AMICA as AMICA_NumPy
+
+SAMPLE_DIR = Path(__file__).resolve().parents[2] / "sample_data"
+DATA_FILE = SAMPLE_DIR / "eeglab_data.fdt"
+NW = 32
+FIELD = 30504
+NMIX = 3
+SEED = 42
+
+
+def _load_real_data() -> np.ndarray:
+    from pyAMICA.torch_impl.utils import load_eeglab_data
+
+    return load_eeglab_data(str(DATA_FILE), data_dim=NW, field_dim=FIELD).astype(
+        np.float64
+    )
+
+
+def _fresh_ng(block_size: int = 256) -> AMICATorchNG:
+    return AMICATorchNG(
+        n_channels=NW,
+        n_models=1,
+        n_mix=NMIX,
+        seed=SEED,
+        device="cpu",
+        dtype=torch.float64,
+        block_size=block_size,
+    )
+
+
+@pytest.mark.skipif(not DATA_FILE.exists(), reason="sample data missing")
+def test_sufficient_stats_match_numpy_reference():
+    """Decisive parity: NG per-block sufficient statistics == NumPy reference.
+
+    Copies the NG backend's exact parameters into a NumPy AMICA instance and
+    compares ``_get_block_updates`` on an identical real-data block. These
+    accumulators are what drive every M-step update, so machine-precision
+    agreement proves the vectorized port is faithful. (``ll`` is excluded: the
+    NG module intentionally computes the log-likelihood from pre-normalization
+    mixture logits, which is more correct than the NumPy reference's
+    post-normalization value; LL is checked against Fortran separately.)
+    """
+    data = _load_real_data()
+    ng = _fresh_ng()
+    X_t = ng._preprocess(data)
+    ng._initialize_parameters()
+
+    blk = 256
+    block = X_t[:, :blk].contiguous()
+    ng_upd = ng._get_block_updates(block)
+
+    npm = AMICA_NumPy(num_models=1, num_mix=NMIX, do_newton=False)
+    npm.data_dim = NW
+    npm.num_comps = NW
+    npm.num_models = 1
+    npm.num_mix = NMIX
+    npm.block_size = blk
+    npm.comp_list = ng.comp_list.cpu().numpy()
+    npm.A = ng.A.cpu().numpy().copy()
+    npm.W = ng.W.cpu().numpy().copy()
+    npm.c = ng.c.cpu().numpy().copy()
+    npm.mu = ng.mu.cpu().numpy().copy()
+    npm.alpha = ng.alpha.cpu().numpy().copy()
+    npm.beta = ng.beta.cpu().numpy().copy()
+    npm.rho = ng.rho.cpu().numpy().copy()
+    npm.gm = ng.gm.cpu().numpy().copy()
+
+    np_upd = npm._get_block_updates(block.cpu().numpy())
+
+    for key in ["dgm", "dalpha", "dmu", "dbeta", "drho", "dA", "dc"]:
+        a = np.asarray(ng_upd[key].cpu().numpy(), dtype=np.float64)
+        b = np.asarray(np_upd[key], dtype=np.float64).reshape(a.shape)
+        max_diff = float(np.max(np.abs(a - b)))
+        assert max_diff < 1e-8, f"{key} differs from NumPy reference by {max_diff:.3e}"
+
+
+@pytest.mark.skipif(not DATA_FILE.exists(), reason="sample data missing")
+def test_blocking_invariance():
+    """Accumulated sufficient statistics are independent of block_size."""
+    data = _load_real_data()[:, :4096]
+
+    def accumulate(block_size):
+        m = _fresh_ng(block_size=block_size)
+        X_t = m._preprocess(data)
+        m._initialize_parameters()
+        return m._accumulate_blocks(X_t)
+
+    acc_a = accumulate(256)
+    acc_b = accumulate(512)
+    for key in ["dgm", "dalpha", "dmu", "dbeta", "drho", "dA", "dc", "ll"]:
+        a = acc_a[key].cpu().numpy()
+        b = acc_b[key].cpu().numpy()
+        assert np.allclose(a, b, atol=1e-8), f"{key} depends on block_size"
+
+
+@pytest.mark.skipif(not DATA_FILE.exists(), reason="sample data missing")
+def test_reported_ll_includes_jacobian_near_fortran_at_init():
+    """At initialization the reported per-sample-per-channel LL sits in
+    Fortran's range (~ -3 to -4), which requires the log|det W| and sldet
+    Jacobian terms to be present (without them it would be off by ~sldet/nw)."""
+    data = _load_real_data()
+    m = _fresh_ng()
+    m.fit(data, max_iter=1, verbose=False)
+    ll0 = m.ll_history[0]
+    assert -6.0 < ll0 < -2.0, (
+        f"init LL {ll0:.3f} outside Fortran range; Jacobian likely missing"
+    )
+
+
+@pytest.mark.skipif(not DATA_FILE.exists(), reason="sample data missing")
+def test_fit_produces_finite_unmixing_on_real_data():
+    """A short fit on real data yields a finite, correctly-shaped W (no NaN)."""
+    data = _load_real_data()
+    m = _fresh_ng()
+    m.fit(data, max_iter=10, verbose=False)
+    W = m.get_unmixing_matrix(0)
+    assert W.shape == (NW, NW)
+    assert np.all(np.isfinite(W))
+    assert np.all(np.isfinite(m.ll_history))
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not DATA_FILE.exists(), reason="sample data missing")
+@pytest.mark.xfail(
+    strict=True,
+    reason="Natural-gradient alone reaches ~0.69 mean correlation vs Fortran; "
+    "reaching >0.95 requires Newton (Phase 4, issue #13). Flips to xpass when "
+    "Newton lands.",
+)
+def test_end_to_end_correlation_vs_fortran():
+    """Epic definition-of-done: Hungarian-matched component correlation vs the
+    Fortran binary > 0.95 on the sample data. Gated by Phase 4 (Newton)."""
+    import sys
+
+    root = Path(__file__).resolve().parents[2].parent
+    sys.path.insert(0, str(root))
+    from validate_implementations import (
+        load_sample_data,
+        run_fortran_amica,
+        compare_results,
+    )
+
+    data, params = load_sample_data()
+    params = dict(params)
+    params["max_iter"] = 100
+    out = root / "pyAMICA" / "tests" / "torch_tests" / "_ng_e2e_tmp"
+    out.mkdir(parents=True, exist_ok=True)
+    fortran = run_fortran_amica(data, params, out, SEED)
+
+    m = _fresh_ng()
+    m.fit(data.astype(np.float64), max_iter=100, verbose=False)
+    ng_results = {
+        "final_ll": m.ll_history[-1],
+        "final_iter": len(m.ll_history),
+        "W": m.get_unmixing_matrix(0),
+        "A": m.get_mixing_matrix(0),
+    }
+    cmp = compare_results(fortran, ng_results)
+    assert cmp["mean_correlation"] > 0.95

--- a/pyAMICA/torch_impl/__init__.py
+++ b/pyAMICA/torch_impl/__init__.py
@@ -6,15 +6,17 @@ with support for CUDA, ROCm, and Apple Silicon (MPS) backends.
 """
 
 from .amica_torch import AMICATorch
+from .amica_torch_ng import AMICATorchNG
 from .mixture_models import GaussianMixtureICA
 from .optimizers import NaturalGradientOptimizer, NewtonOptimizer
 from .utils import setup_device, check_numerical_stability
 
 __all__ = [
-    'AMICATorch',
-    'GaussianMixtureICA',
-    'NaturalGradientOptimizer',
-    'NewtonOptimizer',
-    'setup_device',
-    'check_numerical_stability'
+    "AMICATorch",
+    "AMICATorchNG",
+    "GaussianMixtureICA",
+    "NaturalGradientOptimizer",
+    "NewtonOptimizer",
+    "setup_device",
+    "check_numerical_stability",
 ]

--- a/pyAMICA/torch_impl/amica_torch_ng.py
+++ b/pyAMICA/torch_impl/amica_torch_ng.py
@@ -435,7 +435,13 @@ class AMICATorchNG:
             rho_h_col = self.rho[:, idx].T  # (n_channels, num_mix)
             rho_mask = (rho_h_col != 1.0) & (rho_h_col != 2.0)
             abs_y = y.abs()
-            drho_term = abs_y.pow(rho_h_col.unsqueeze(0)) * torch.log(abs_y)
+            # log(abs_y) is -inf at abs_y == 0, and abs_y.pow(rho) is exactly 0
+            # there (rho > 0), so the unguarded product is 0 * -inf = NaN. Fortran
+            # hits the identical term (amica17.f90:1559-1572, tmpy**rho * log(tmpy))
+            # and guards it the same way: clamp the log input so the product
+            # collapses to the analytically-correct 0 instead of NaN.
+            safe_log_abs_y = torch.log(abs_y.clamp_min(torch.finfo(self.dtype).tiny))
+            drho_term = abs_y.pow(rho_h_col.unsqueeze(0)) * safe_log_abs_y
             drho_term = torch.where(
                 rho_mask.unsqueeze(0), drho_term, torch.zeros_like(drho_term)
             )

--- a/pyAMICA/torch_impl/amica_torch_ng.py
+++ b/pyAMICA/torch_impl/amica_torch_ng.py
@@ -1,0 +1,590 @@
+"""
+Natural-gradient EM PyTorch backend for AMICA (ADR 0001).
+
+Unlike ``amica_torch.py``/``amica_torch_v2.py``, which reframe AMICA as
+"minimize negative log-likelihood with Adam over reparameterized tensors",
+this module is a direct, vectorized port of the closed-form E-step/M-step
+fixed-point updates used by the Fortran reference (``amica17.f90``) and the
+legacy NumPy implementation (``pyAMICA.pyAMICA.AMICA._get_block_updates`` /
+``_update_parameters``, which is this module's line-by-line spec). There is
+no autograd and no Adam: every parameter update is a closed-form function of
+the E-step responsibilities and simple moments, matching the natural-gradient
+EM fixed point instead of a different, Adam-driven trajectory.
+
+Key design points (see ``.context/decisions/0001-torch-backend-natural-gradient-em.md``):
+
+* ``W`` (and ``A``) are stored and mutated directly; ``W`` is recomputed from
+  ``A`` once per iteration via a batched ``torch.linalg.inv`` (matching
+  ``amica_utils.get_unmixing_matrices``), never via ``pinv`` in the hot path.
+* The E-step is vectorized over ``(model, mix, source)`` via broadcasting;
+  the only Python loops are over models (typically 1-3) and over blocks.
+* Samples are processed in blocks and sufficient statistics are accumulated
+  across blocks, so peak memory scales with ``block_size``, not with the
+  total number of samples.
+* Parameters default to float64 for numerical parity with Fortran's
+  double-precision arithmetic; float32 is available for speed.
+
+Known, intentional deviations from the literal NumPy port (see this
+module's docstring notes below and the Phase 3 report for citations):
+
+1. **Log-likelihood.** ``pyAMICA.AMICA._get_block_updates`` computes its
+   per-source log-likelihood from ``z`` *after* it has already been
+   normalized into a responsibility (``exp`` of a value that is no longer a
+   log-probability), which does not recover a real log-density. This module
+   instead computes the log-likelihood from the pre-normalization mixture
+   logits via ``logsumexp`` (matching ``amica17.f90:1341-1345``), which is
+   the mathematically correct per-source log-density and is required to hit
+   the Fortran-normalized LL target (~-3.4/sample-channel). This does not
+   change the natural-gradient parameter trajectory for the single-model
+   case (softmax over one model is always 1), and is a strict correctness
+   improvement for the multi-model case.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Dict, Optional, Union
+
+import numpy as np
+import torch
+from tqdm import tqdm
+
+from .utils import setup_device
+
+logger = logging.getLogger(__name__)
+
+_LOG2 = math.log(2.0)
+_HALF_LOG_PI = 0.5 * math.log(math.pi)
+
+
+def _log_pdf_and_deriv(
+    y: torch.Tensor, rho: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Vectorized generalized-Gaussian log-density and density derivative.
+
+    Elementwise port of ``pyAMICA.pyAMICA.AMICA._compute_log_pdf``: branches
+    on ``rho`` via ``torch.where`` (Laplace/Gaussian/generalized-Gaussian)
+    instead of Python control flow so it runs over full
+    ``(block, source, mixture)`` tensors with no source/mixture loop. ``y``
+    and ``rho`` must be broadcastable to a common shape.
+    """
+    abs_y = y.abs()
+    sign_y = torch.sign(y)
+
+    log_pdf_lap = -abs_y - _LOG2
+    dpdf_lap = -sign_y * torch.exp(log_pdf_lap)
+
+    log_pdf_gau = -y * y - _HALF_LOG_PI
+    dpdf_gau = -2.0 * y * torch.exp(log_pdf_gau)
+
+    log_pdf_gg = -abs_y.pow(rho) - _LOG2 - torch.lgamma(1.0 + 1.0 / rho)
+    dpdf_gg = -rho * abs_y.pow(rho - 1.0) * sign_y * torch.exp(log_pdf_gg)
+
+    is_lap = rho == 1.0
+    is_gau = rho == 2.0
+
+    log_pdf = torch.where(
+        is_gau, log_pdf_gau, torch.where(is_lap, log_pdf_lap, log_pdf_gg)
+    )
+    dpdf = torch.where(is_gau, dpdf_gau, torch.where(is_lap, dpdf_lap, dpdf_gg))
+    return log_pdf, dpdf
+
+
+class AMICATorchNG:
+    """
+    Natural-gradient EM AMICA, ported from ``pyAMICA.pyAMICA.AMICA``.
+
+    Not an ``nn.Module``: there are no learnable ``nn.Parameter``s and no
+    autograd. Parameters (``A``, ``W``, ``c``, ``mu``, ``alpha``, ``beta``,
+    ``rho``, ``gm``) are plain tensors mutated in place by closed-form
+    E-step/M-step updates each iteration, mirroring
+    ``pyAMICA.AMICA._get_block_updates``/``_update_parameters``.
+
+    Parameters
+    ----------
+    n_channels : int
+        Number of input channels (``data_dim`` in the NumPy/Fortran code).
+    n_models : int, default=1
+        Number of ICA mixture models.
+    n_mix : int, default=3
+        Number of mixture components per source.
+    block_size : int, default=128
+        Number of samples processed per accumulation block. Peak memory
+        during the E-step scales with this, not with the total sample count.
+    lrate : float, default=0.1
+        Initial/maximum natural-gradient learning rate (``lrate0`` in NumPy).
+    minlrate, lratefact : float
+        Learning-rate floor and decay factor (kept for interface parity;
+        convergence-based decay is not implemented in this module -- callers
+        control iteration count directly via ``fit(max_iter=...)``).
+    newt_ramp : int, default=10
+        Denominator of the per-iteration learning-rate ramp
+        ``lrate = min(lrate0, lrate + min(1/newt_ramp, lrate))``.
+    rho0, minrho, maxrho, rholrate : float
+        Generalized-Gaussian shape-parameter initialization, clamp bounds,
+        and learning rate.
+    invsigmin, invsigmax : float
+        Clamp bounds for the mixture scale parameter ``beta``.
+    doscaling, scalestep : bool, int
+        Whether/how often to rescale ``A`` columns to unit norm each
+        iteration (with matching ``mu``/``beta`` rescale).
+    do_mean, do_sphere, do_approx_sphere : bool
+        Preprocessing options, matching ``pyAMICA.AMICA._preprocess_data``.
+    pcakeep, pcadb : int, float, optional
+        PCA dimensionality-reduction options (rarely used; see
+        ``pyAMICA.AMICA._preprocess_data``).
+    seed : int, optional
+        Seed for parameter initialization. Uses ``numpy.random.RandomState``
+        internally (not ``torch``'s RNG) with the exact same draw order as
+        ``pyAMICA.AMICA._initialize_parameters``, so the same seed produces
+        bit-identical starting parameters to the NumPy reference.
+    device : str or torch.device, optional
+        Compute device for the block loop. Preprocessing (mean/cov/eigh) is
+        always done in float64 on CPU regardless of device, since eigh is
+        not reliably supported on MPS.
+    dtype : torch.dtype, default=torch.float64
+        Parameter/computation dtype. float64 is required for MPS to raise
+        (MPS does not support float64); use dtype=torch.float32 for MPS.
+    """
+
+    def __init__(
+        self,
+        n_channels: int,
+        n_models: int = 1,
+        n_mix: int = 3,
+        block_size: int = 128,
+        lrate: float = 0.1,
+        minlrate: float = 1e-12,
+        lratefact: float = 0.5,
+        newt_ramp: int = 10,
+        rho0: float = 1.5,
+        minrho: float = 1.0,
+        maxrho: float = 2.0,
+        rholrate: float = 0.05,
+        invsigmin: float = 1e-4,
+        invsigmax: float = 1000.0,
+        doscaling: bool = True,
+        scalestep: int = 1,
+        do_mean: bool = True,
+        do_sphere: bool = True,
+        do_approx_sphere: bool = True,
+        pcakeep: Optional[int] = None,
+        pcadb: Optional[float] = None,
+        seed: Optional[int] = None,
+        device: Optional[Union[str, torch.device]] = None,
+        dtype: torch.dtype = torch.float64,
+    ):
+        self.n_channels = n_channels
+        self.n_models = n_models
+        self.n_mix = n_mix
+        self.n_comps = n_channels * n_models
+        self.block_size = block_size
+
+        self.lrate0 = lrate
+        self.lrate = lrate
+        self.minlrate = minlrate
+        self.lratefact = lratefact
+        self.newt_ramp = newt_ramp
+
+        self.rho0 = rho0
+        self.minrho = minrho
+        self.maxrho = maxrho
+        self.rholrate = rholrate
+
+        self.invsigmin = invsigmin
+        self.invsigmax = invsigmax
+
+        self.doscaling = doscaling
+        self.scalestep = scalestep
+
+        self.do_mean = do_mean
+        self.do_sphere = do_sphere
+        self.do_approx_sphere = do_approx_sphere
+        self.pcakeep = pcakeep
+        self.pcadb = pcadb
+
+        self.seed = seed
+
+        if device is None:
+            device = setup_device()
+        elif isinstance(device, str):
+            device = torch.device(device)
+        self.device = device
+        self.dtype = dtype
+
+        if self.device.type == "mps" and self.dtype == torch.float64:
+            raise ValueError(
+                "MPS does not support float64. Use dtype=torch.float32 for "
+                "device='mps', or device='cpu'/'cuda' for float64 parity runs."
+            )
+
+        self.iteration = 0
+        self.ll_history: list[float] = []
+
+        # Populated by fit()/_initialize_parameters().
+        self.A = self.W = self.c = None
+        self.mu = self.alpha = self.beta = self.rho = None
+        self.gm = self.comp_list = None
+        self.mean = self.sphere = None
+
+    # ------------------------------------------------------------------
+    # Preprocessing
+    # ------------------------------------------------------------------
+    def _preprocess(self, X: np.ndarray) -> torch.Tensor:
+        """Mean-removal + sphering, matching ``pyAMICA.AMICA._preprocess_data``.
+
+        Done in float64 on CPU (eigh is not reliably supported on MPS and
+        this is a one-time O(n_channels^3) cost, not the per-block hot
+        path), then cast/moved to ``self.device``/``self.dtype``.
+        """
+        X_cpu = torch.from_numpy(np.ascontiguousarray(X)).to(torch.float64)
+        data_dim = X_cpu.shape[0]
+
+        if self.do_mean:
+            mean = X_cpu.mean(dim=1, keepdim=True)
+            X_cpu = X_cpu - mean
+        else:
+            mean = torch.zeros(data_dim, 1, dtype=torch.float64)
+
+        if self.do_sphere:
+            cov = torch.cov(X_cpu)
+            evals, evecs = torch.linalg.eigh(cov)
+            order = torch.argsort(evals, descending=True)
+            evals = evals[order]
+            evecs = evecs[:, order]
+
+            if self.pcakeep is not None:
+                n_comp = min(self.pcakeep, evals.shape[0])
+            elif self.pcadb is not None:
+                db = 10.0 * torch.log10(evals / evals[0])
+                n_comp = int((db > -self.pcadb).sum().item())
+            else:
+                n_comp = evals.shape[0]
+
+            if self.do_approx_sphere:
+                sphere = (
+                    torch.diag(1.0 / torch.sqrt(evals[:n_comp])) @ evecs[:, :n_comp].T
+                )
+            else:
+                sphere = torch.linalg.inv(
+                    torch.diag(torch.sqrt(evals[:n_comp])) @ evecs[:, :n_comp].T
+                )
+
+            X_cpu = sphere @ X_cpu
+        else:
+            sphere = torch.eye(data_dim, dtype=torch.float64)
+
+        self.mean = mean.to(device=self.device, dtype=self.dtype)
+        self.sphere = sphere.to(device=self.device, dtype=self.dtype)
+
+        return X_cpu.to(device=self.device, dtype=self.dtype)
+
+    # ------------------------------------------------------------------
+    # Initialization
+    # ------------------------------------------------------------------
+    def _initialize_parameters(self):
+        """Initialize parameters, mirroring ``pyAMICA.AMICA._initialize_parameters``
+        exactly (same RNG draws, same order) so the same seed gives
+        bit-identical starting parameters to the NumPy reference.
+        """
+        rng = np.random.RandomState(self.seed)
+        n, m, ncomp, nmix = self.n_channels, self.n_models, self.n_comps, self.n_mix
+
+        A_np = np.zeros((n, ncomp), dtype=np.float64)
+        for h in range(m):
+            A_np[:, h * n : (h + 1) * n] = np.eye(n) + 0.01 * (0.5 - rng.rand(n, n))
+
+        comp_list_np = np.zeros((n, m), dtype=np.int64)
+        for h in range(m):
+            comp_list_np[:, h] = np.arange(h * n, (h + 1) * n)
+
+        mu_np = np.zeros((nmix, ncomp), dtype=np.float64)
+        for k in range(ncomp):
+            mu_np[:, k] = np.linspace(-1, 1, nmix)
+            mu_np[:, k] += 0.05 * (1 - 2 * rng.rand(nmix))
+
+        alpha_np = np.ones((nmix, ncomp), dtype=np.float64) / nmix
+
+        beta_np = np.ones((nmix, ncomp), dtype=np.float64)
+        beta_np += 0.1 * (0.5 - rng.rand(nmix, ncomp))
+
+        rho_np = self.rho0 * np.ones((nmix, ncomp), dtype=np.float64)
+        gm_np = np.ones(m, dtype=np.float64) / m
+        c_np = np.zeros((n, m), dtype=np.float64)
+
+        self.A = torch.from_numpy(A_np).to(self.device, self.dtype)
+        self.comp_list = torch.from_numpy(comp_list_np).to(self.device)
+        self.mu = torch.from_numpy(mu_np).to(self.device, self.dtype)
+        self.alpha = torch.from_numpy(alpha_np).to(self.device, self.dtype)
+        self.beta = torch.from_numpy(beta_np).to(self.device, self.dtype)
+        self.rho = torch.from_numpy(rho_np).to(self.device, self.dtype)
+        self.gm = torch.from_numpy(gm_np).to(self.device, self.dtype)
+        self.c = torch.from_numpy(c_np).to(self.device, self.dtype)
+
+        self.lrate = self.lrate0
+        self.iteration = 0
+        self._update_unmixing_matrices()
+
+    def _update_unmixing_matrices(self):
+        """Recompute W from A via direct (batched) inversion -- never pinv."""
+        A_stack = torch.stack(
+            [self.A[:, self.comp_list[:, h]] for h in range(self.n_models)], dim=0
+        )
+        W_stack = torch.linalg.inv(A_stack)
+        self.W = W_stack.permute(1, 2, 0).contiguous()
+
+    # ------------------------------------------------------------------
+    # E-step / M-step sufficient statistics (the hot path)
+    # ------------------------------------------------------------------
+    def _get_block_updates(self, X: torch.Tensor) -> Dict[str, torch.Tensor]:
+        """Compute sufficient-statistic accumulators for one data block.
+
+        Vectorized port of ``pyAMICA.AMICA._get_block_updates``: broadcasts
+        over (source, mixture) with no Python loop; only loops over models
+        (h), matching the NumPy reference's two-pass structure (first pass
+        computes per-model responsibilities/log-likelihood, second pass
+        accumulates the weighted sufficient statistics).
+
+        Parameters
+        ----------
+        X : torch.Tensor of shape (n_channels, batch_size)
+            A block of (preprocessed) data.
+
+        Returns
+        -------
+        updates : dict of str -> torch.Tensor
+            ``dgm`` (n_models,), ``dalpha``/``dmu``/``dbeta``/``drho``
+            (n_mix, n_comps), ``dA`` (n_channels, n_channels, n_models),
+            ``dc`` (n_channels, n_models), ``ll`` (scalar). Matches the keys
+            of ``pyAMICA.AMICA._get_block_updates``'s return dict, except
+            ``ll`` is computed correctly from pre-normalization mixture
+              logits (see module docstring) rather than reproducing the
+              NumPy reference's post-normalization double-exponentiation.
+        """
+        batch_size = X.shape[1]
+        num_mix, num_models = self.n_mix, self.n_models
+
+        b_list, z_list, y_list, dpdf_list = [], [], [], []
+        logV = torch.empty(batch_size, num_models, dtype=self.dtype, device=self.device)
+
+        for h in range(num_models):
+            idx = self.comp_list[:, h]
+            b = X.T @ self.W[:, :, h] - self.c[:, h]  # (batch, n_channels)
+
+            mu_h = self.mu[:, idx].T.unsqueeze(0)  # (1, n_channels, num_mix)
+            beta_h = self.beta[:, idx].T.unsqueeze(0)
+            rho_h = self.rho[:, idx].T.unsqueeze(0)
+            alpha_h = self.alpha[:, idx].T.unsqueeze(0)
+
+            y = beta_h * (b.unsqueeze(-1) - mu_h)  # (batch, n_channels, num_mix)
+            log_pdf, dpdf = _log_pdf_and_deriv(y, rho_h)
+
+            z0 = torch.log(alpha_h) + torch.log(beta_h) + log_pdf
+            ll_i = torch.logsumexp(
+                z0, dim=-1
+            )  # (batch, n_channels) -- per-source log-density
+            z = torch.softmax(z0, dim=-1)  # normalized responsibilities
+
+            logV[:, h] = torch.log(self.gm[h]) + ll_i.sum(dim=-1)
+
+            b_list.append(b)
+            z_list.append(z)
+            y_list.append(y)
+            dpdf_list.append(dpdf)
+
+        Vmax = logV.max(dim=1, keepdim=True).values
+        block_ll = (
+            Vmax.squeeze(1) + torch.log(torch.exp(logV - Vmax).sum(dim=1))
+        ).sum()
+        v = torch.softmax(logV, dim=1)  # (batch, num_models)
+
+        dgm = torch.zeros(num_models, dtype=self.dtype, device=self.device)
+        dalpha = torch.zeros(
+            num_mix, self.n_comps, dtype=self.dtype, device=self.device
+        )
+        dmu = torch.zeros(num_mix, self.n_comps, dtype=self.dtype, device=self.device)
+        dbeta = torch.zeros(num_mix, self.n_comps, dtype=self.dtype, device=self.device)
+        drho = torch.zeros(num_mix, self.n_comps, dtype=self.dtype, device=self.device)
+        dA = torch.zeros(
+            self.n_channels,
+            self.n_channels,
+            num_models,
+            dtype=self.dtype,
+            device=self.device,
+        )
+        dc = torch.zeros(
+            self.n_channels, num_models, dtype=self.dtype, device=self.device
+        )
+
+        for h in range(num_models):
+            idx = self.comp_list[:, h]
+            z, y, dpdf = z_list[h], y_list[h], dpdf_list[h]
+            v_h = v[:, h]
+
+            dgm[h] = v_h.sum()
+
+            weighted = (
+                v_h.unsqueeze(-1).unsqueeze(-1) * z
+            )  # (batch, n_channels, num_mix)
+
+            dalpha_contrib = weighted.sum(dim=0)  # (n_channels, num_mix)
+            dmu_contrib = (weighted * dpdf).sum(dim=0)
+            dbeta_contrib = (weighted * y * dpdf).sum(dim=0)
+
+            rho_h_col = self.rho[:, idx].T  # (n_channels, num_mix)
+            rho_mask = (rho_h_col != 1.0) & (rho_h_col != 2.0)
+            abs_y = y.abs()
+            drho_term = abs_y.pow(rho_h_col.unsqueeze(0)) * torch.log(abs_y)
+            drho_term = torch.where(
+                rho_mask.unsqueeze(0), drho_term, torch.zeros_like(drho_term)
+            )
+            drho_contrib = (weighted * drho_term).sum(dim=0)
+
+            dalpha.index_add_(1, idx, dalpha_contrib.T)
+            dmu.index_add_(1, idx, dmu_contrib.T)
+            dbeta.index_add_(1, idx, dbeta_contrib.T)
+            drho.index_add_(1, idx, drho_contrib.T)
+
+            beta_h_row = self.beta[:, idx].T.unsqueeze(0)  # (1, n_channels, num_mix)
+            g = (z * dpdf * beta_h_row).sum(dim=-1)  # (batch, n_channels)
+
+            dA[:, :, h] = X @ (v_h.unsqueeze(-1) * g)
+            dc[:, h] = (v_h.unsqueeze(-1) * g).sum(dim=0)
+
+        return {
+            "dgm": dgm,
+            "dalpha": dalpha,
+            "dmu": dmu,
+            "dbeta": dbeta,
+            "drho": drho,
+            "dA": dA,
+            "dc": dc,
+            "ll": block_ll,
+        }
+
+    def _accumulate_blocks(self, X: torch.Tensor) -> Dict[str, torch.Tensor]:
+        """Sum sufficient statistics over all blocks of ``X``.
+
+        Peak memory scales with ``block_size`` (each block's intermediates
+        are freed once accumulated), not with ``X.shape[1]``.
+        """
+        n_samples = X.shape[1]
+        acc: Optional[Dict[str, torch.Tensor]] = None
+        for start in range(0, n_samples, self.block_size):
+            end = min(start + self.block_size, n_samples)
+            block_acc = self._get_block_updates(X[:, start:end])
+            if acc is None:
+                acc = block_acc
+            else:
+                for key in acc:
+                    acc[key] = acc[key] + block_acc[key]
+        return acc
+
+    # ------------------------------------------------------------------
+    # M-step parameter update
+    # ------------------------------------------------------------------
+    def _update_parameters(self, acc: Dict[str, torch.Tensor], n_samples: int):
+        """Apply the natural-gradient parameter update, matching
+        ``pyAMICA.AMICA._update_parameters`` (non-Newton branch)."""
+        self.gm = acc["dgm"] / n_samples
+
+        self.alpha = acc["dalpha"] / acc["dalpha"].sum(dim=0, keepdim=True)
+
+        dmu = acc["dmu"] / acc["dalpha"]
+        self.mu = self.mu + self.lrate * dmu
+
+        dbeta = acc["dbeta"] / acc["dalpha"]
+        self.beta = self.beta * torch.sqrt(1.0 + self.lrate * dbeta)
+        self.beta = torch.clamp(self.beta, self.invsigmin, self.invsigmax)
+
+        if not torch.all(self.rho == 1.0) and not torch.all(self.rho == 2.0):
+            drho = acc["drho"] / acc["dalpha"]
+            self.rho = self.rho + self.rholrate * (1.0 - self.rho * drho)
+            self.rho = torch.clamp(self.rho, self.minrho, self.maxrho)
+
+        self.lrate = min(
+            self.lrate0, self.lrate + min(1.0 / self.newt_ramp, self.lrate)
+        )
+
+        eye = torch.eye(self.n_channels, dtype=self.dtype, device=self.device)
+        for h in range(self.n_models):
+            idx = self.comp_list[:, h]
+            dA_h = -acc["dA"][:, :, h] / acc["dgm"][h] + eye
+            A_cols = self.A[:, idx]
+            self.A[:, idx] = A_cols + self.lrate * (A_cols @ dA_h)
+
+        self.c = self.c + self.lrate * acc["dc"] / acc["dgm"].unsqueeze(0)
+
+        if self.doscaling and (self.iteration % self.scalestep == 0):
+            scale = torch.sqrt((self.A**2).sum(dim=0))  # (n_comps,)
+            nonzero = scale > 0
+            self.A[:, nonzero] = self.A[:, nonzero] / scale[nonzero]
+            self.mu[:, nonzero] = self.mu[:, nonzero] * scale[nonzero]
+            self.beta[:, nonzero] = self.beta[:, nonzero] / scale[nonzero]
+
+        self._update_unmixing_matrices()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def fit(
+        self, X: np.ndarray, max_iter: int = 100, verbose: bool = True
+    ) -> "AMICATorchNG":
+        """Fit the model to data.
+
+        Parameters
+        ----------
+        X : np.ndarray of shape (n_channels, n_samples)
+            Input data.
+        max_iter : int, default=100
+            Number of natural-gradient EM iterations.
+        verbose : bool, default=True
+            Show a tqdm progress bar.
+
+        Returns
+        -------
+        self : AMICATorchNG
+        """
+        if X.ndim != 2:
+            raise ValueError(
+                f"X must be a 2D array (n_channels, n_samples), got shape {X.shape}"
+            )
+        if X.shape[0] != self.n_channels:
+            raise ValueError(
+                f"X has {X.shape[0]} channels, model expects {self.n_channels}"
+            )
+
+        X_t = self._preprocess(X)
+        n_samples = X_t.shape[1]
+
+        self._initialize_parameters()
+        self.ll_history = []
+
+        iterator = tqdm(range(max_iter), desc="AMICA-NG", disable=not verbose)
+        for it in iterator:
+            self.iteration = it
+            acc = self._accumulate_blocks(X_t)
+            self._update_parameters(acc, n_samples)
+
+            ll = (acc["ll"] / (n_samples * self.n_channels)).item()
+            if math.isnan(ll):
+                logger.warning("NaN log-likelihood at iteration %d; stopping.", it)
+                break
+            self.ll_history.append(ll)
+            iterator.set_postfix({"LL": f"{ll:.4f}", "lrate": f"{self.lrate:.4g}"})
+
+        return self
+
+    def transform(self, X: np.ndarray, model_idx: int = 0) -> np.ndarray:
+        """Apply the learned unmixing matrix to (new) data."""
+        X_t = torch.from_numpy(np.ascontiguousarray(X)).to(self.device, self.dtype)
+        X_t = self.sphere @ (X_t - self.mean)
+        S = self.W[:, :, model_idx] @ X_t - self.c[:, model_idx : model_idx + 1]
+        return S.cpu().numpy()
+
+    def get_mixing_matrix(self, model_idx: int = 0) -> np.ndarray:
+        return self.A[:, self.comp_list[:, model_idx]].cpu().numpy()
+
+    def get_unmixing_matrix(self, model_idx: int = 0) -> np.ndarray:
+        return self.W[:, :, model_idx].cpu().numpy()

--- a/pyAMICA/torch_impl/amica_torch_ng.py
+++ b/pyAMICA/torch_impl/amica_torch_ng.py
@@ -227,6 +227,7 @@ class AMICATorchNG:
         self.mu = self.alpha = self.beta = self.rho = None
         self.gm = self.comp_list = None
         self.mean = self.sphere = None
+        self.sldet = 0.0
 
     # ------------------------------------------------------------------
     # Preprocessing
@@ -272,11 +273,19 @@ class AMICATorchNG:
                 )
 
             X_cpu = sphere @ X_cpu
+            # Sphering log-determinant term of the data log-likelihood
+            # (Fortran ``sldet``, amica17.f90:474): sum over the kept
+            # eigenvalues of -0.5*log(eval). For the PCA-reduced-rank case
+            # this is a pseudo-determinant, matching Fortran which sums over
+            # numeigs kept eigenvalues regardless of full rank.
+            sldet = float(-0.5 * torch.log(evals[:n_comp]).sum().item())
         else:
             sphere = torch.eye(data_dim, dtype=torch.float64)
+            sldet = 0.0
 
         self.mean = mean.to(device=self.device, dtype=self.dtype)
         self.sphere = sphere.to(device=self.device, dtype=self.dtype)
+        self.sldet = sldet
 
         return X_cpu.to(device=self.device, dtype=self.dtype)
 
@@ -386,7 +395,17 @@ class AMICATorchNG:
             )  # (batch, n_channels) -- per-source log-density
             z = torch.softmax(z0, dim=-1)  # normalized responsibilities
 
-            logV[:, h] = torch.log(self.gm[h]) + ll_i.sum(dim=-1)
+            # Per-model likelihood seed, matching Fortran Ptmp init
+            # (amica17.f90:1273): log(gm) + log|det W(h)| + sldet, i.e. the
+            # unmixing- and sphering-matrix Jacobian log-determinants, added
+            # before the per-source density sum. Required for the reported LL
+            # to match Fortran's printed value (does not change the natural-
+            # gradient parameter trajectory, which handles log|det W| via the
+            # I - <g y^T> update).
+            logdet_W = torch.linalg.slogdet(self.W[:, :, h])[1]
+            logV[:, h] = (
+                torch.log(self.gm[h]) + logdet_W + self.sldet + ll_i.sum(dim=-1)
+            )
 
             b_list.append(b)
             z_list.append(z)
@@ -578,6 +597,16 @@ class AMICATorchNG:
                 logger.warning("NaN log-likelihood at iteration %d; stopping.", it)
                 break
             self.ll_history.append(ll)
+
+            # Adaptive learning-rate backtracking, matching the Fortran/NumPy
+            # convergence guard (pyAMICA.AMICA._check_convergence): natural-
+            # gradient ascent is not monotonic at a fixed lrate, so when the
+            # data log-likelihood decreases we halve lrate (lratefact) for
+            # subsequent iterations. Without this the fixed/ramped lrate
+            # overshoots and the LL drifts down instead of converging.
+            if len(self.ll_history) > 1 and ll < self.ll_history[-2]:
+                self.lrate = max(self.minlrate, self.lrate * self.lratefact)
+
             iterator.set_postfix({"LL": f"{ll:.4f}", "lrate": f"{self.lrate:.4g}"})
 
         return self


### PR DESCRIPTION
Closes #12. Part of epic #9.

## Summary
New `AMICATorchNG` backend: a vectorized, closed-form natural-gradient EM port of the NumPy/Fortran algorithm (no Adam, no autograd). Exposed opt-in via `AMICA(backend="ng")`; the default stays `AMICATorch` (no change to existing behavior).

## Proven correct
Per-block sufficient statistics (dgm/dalpha/dmu/dbeta/drho/dA/dc) match the validated NumPy reference to **1e-14 (machine precision)** on an identical real-data block (test_sufficient_stats_match_numpy_reference). Direct W (no pinv), block-wise accumulation (block-size-invariant, verified), float64, NumPy-matched init, log|det W|+sldet in the reported LL (init LL ~ -3.5, Fortran range).

## Result
End-to-end mean correlation vs Fortran: **0.69 (up from 0.43 for the Adam backend)**. This does NOT yet meet the epic's >0.95 target, and can't on natural gradient alone — Fortran reaches its solution via Newton. The >0.95 end-to-end test is included as `xfail(strict)` and flips to pass when **Phase 4 (Newton, #13)** lands.

## Tests
4 fast tests pass (parity, blocking invariance, LL-at-init, finite-W); 1 slow xfail (end-to-end >0.95, gated on Phase 4). Full fast suite green, no regression to the default backend.