### PR TITLE
Document issue #21 M-step divergence root cause

### DIFF
--- a/.context/issue-21/corrected_mstep_prototype.py
+++ b/.context/issue-21/corrected_mstep_prototype.py
@@ -1,0 +1,312 @@
+"""VALIDATED reference prototype for the issue #21 fix (do not ship as-is; port
+these methods into amica_torch_ng.py and pyAMICA.py -- see handoff.md).
+
+`CorrectedNG` subclasses the shipped `AMICATorchNG` and overrides the M-step with the
+Fortran-faithful version that this session validated:
+
+  * score `fp` (not the density derivative `dpdf`) in g/dA, dmu, dbeta
+  * exact-EM updates:  mu += dmu_numer/dmu_denom ; sbeta *= sqrt(dbeta_numer/dbeta_denom)
+  * source-space natural gradient:  dWtmp = g^T b ;  A -= lrate*A*(I - <g b^T>/dgm)
+  * symmetric ZCA sphere  V diag(1/sqrt(eval)) V^T  (Fortran do_approx_sphere=True)
+  * rho update with the 1/psi(1+1/rho) digamma factor
+  * transpose fix: the TRUE unmixing is self.W.T (get_unmixing_matrix / transform / compare)
+
+Run `uv run python .context/issue-21/corrected_mstep_prototype.py` to reproduce the two
+decisive validations (fixed-point test + short fit). Fortran line refs are in the comments.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from pyAMICA.torch_impl import AMICATorchNG
+from pyAMICA.torch_impl.amica_torch_ng import _score
+from pyAMICA.torch_impl.utils import load_eeglab_data
+
+NW, FIELD, SEED = 32, 30504, 42
+SAMPLE = Path(__file__).resolve().parents[2] / "pyAMICA" / "sample_data"
+AO = SAMPLE / "amicaout"
+
+
+class CorrectedNG(AMICATorchNG):
+    do_rho = True
+
+    # --- symmetric ZCA sphere (Fortran amica17.f90:480-481, do_approx_sphere=True path) ---
+    def _preprocess(self, X):
+        Xc = torch.from_numpy(np.ascontiguousarray(X)).to(torch.float64)
+        if self.do_mean:
+            mean = Xc.mean(1, keepdim=True)
+        else:
+            mean = torch.zeros(Xc.shape[0], 1, dtype=torch.float64)
+        Xc = Xc - mean
+        if self.do_sphere:
+            ev, V = torch.linalg.eigh(torch.cov(Xc))
+            sphere = V @ torch.diag(1.0 / torch.sqrt(ev)) @ V.T  # V D^-1/2 V^T
+            self.sldet = float(-0.5 * torch.log(ev).sum().item())
+        else:
+            sphere = torch.eye(Xc.shape[0], dtype=torch.float64)
+            self.sldet = 0.0
+        Xc = sphere @ Xc
+        self.mean = mean.to(self.device, self.dtype)
+        self.sphere = sphere.to(self.device, self.dtype)
+        return Xc.to(self.device, self.dtype)
+
+    # --- Fortran-faithful sufficient statistics (amica17.f90:1437-1592) ---
+    def _get_block_updates(self, X):
+        nmix, nm = self.n_mix, self.n_models
+        logV, b_list, z_list, y_list, _ = self._forward(X)
+        v = torch.softmax(logV, dim=1)  # (batch, nm)
+        block_ll = torch.logsumexp(logV, dim=1).sum()
+        dev, dt = self.device, self.dtype
+
+        def z(*s):
+            return torch.zeros(*s, dtype=dt, device=dev)
+
+        dgm = z(nm)
+        dalpha_n = z(nmix, self.n_comps)  # dalpha_numer = sum(u)
+        dmu_n = z(nmix, self.n_comps)
+        dmu_d = z(nmix, self.n_comps)
+        dbeta_n = z(nmix, self.n_comps)
+        dbeta_d = z(nmix, self.n_comps)
+        drho_n = z(nmix, self.n_comps)
+        dWtmp = z(NW, NW, nm)
+        dc = z(NW, nm)
+        newton = self.do_newton
+        if newton:
+            dsig = z(NW, nm)
+            dkap = z(nmix, NW, nm)
+            dlam = z(nmix, NW, nm)
+        tiny = torch.finfo(dt).tiny
+
+        for h in range(nm):
+            idx = self.comp_list[:, h]
+            b, zr, y = b_list[h], z_list[h], y_list[h]  # zr = mixture responsibility
+            v_h = v[:, h]
+            beta_h = self.beta[:, idx].T.unsqueeze(0)  # sbeta, (1,nw,nmix)
+            rho_h = self.rho[:, idx].T  # (nw,nmix)
+            fp = _score(y, rho_h.unsqueeze(0))  # score, NOT dpdf (:1467)
+            u = v_h.unsqueeze(-1).unsqueeze(-1) * zr  # u = v*z (:1439)
+            ufp = u * fp  # (:1485)
+
+            dgm[h] = v_h.sum()
+            dalpha_n.index_add_(1, idx, u.sum(0).T)
+            dmu_n.index_add_(1, idx, ufp.sum(0).T)  # sum(ufp) (:1532)
+            dmu_d.index_add_(
+                1, idx, (beta_h.squeeze(0) * (ufp / y).sum(0)).T
+            )  # sbeta*sum(ufp/y) (:1537)
+            dbeta_n.index_add_(1, idx, u.sum(0).T)  # sum(u) (:1550)
+            dbeta_d.index_add_(1, idx, (ufp * y).sum(0).T)  # sum(ufp*y) (:1556)
+            # drho_numer = sum(u * |y|^rho * log|y|)  (non-MKL branch, :1578)
+            ay = y.abs()
+            mask = (rho_h != 1.0) & (rho_h != 2.0)
+            term = torch.where(
+                mask.unsqueeze(0),
+                ay.pow(rho_h.unsqueeze(0)) * torch.log(ay.clamp_min(tiny)),
+                torch.zeros_like(ay),
+            )
+            drho_n.index_add_(1, idx, (u * term).sum(0).T)
+
+            g = (beta_h * ufp).sum(-1)  # g_i = sum_j sbeta*ufp (:1493)
+            dWtmp[:, :, h] = g.T @ b  # source-space sum g_t b_t^T (:1592)
+            dc[:, h] = g.sum(0)
+            if newton:
+                dsig[:, h] = (v_h.unsqueeze(-1) * b.pow(2)).sum(0)  # (:1419)
+                dkap[:, :, h] = (
+                    (u * fp.pow(2)).sum(0) * beta_h.squeeze(0).pow(2)
+                ).T  # (:1500)
+                dlam[:, :, h] = (u * (fp * y - 1.0).pow(2)).sum(0).T  # (:1511)
+
+        out = {
+            "dgm": dgm,
+            "dalpha_n": dalpha_n,
+            "dmu_n": dmu_n,
+            "dmu_d": dmu_d,
+            "dbeta_n": dbeta_n,
+            "dbeta_d": dbeta_d,
+            "drho_n": drho_n,
+            "dWtmp": dWtmp,
+            "dc": dc,
+            "ll": block_ll,
+        }
+        if newton:
+            out.update(dsigma2_numer=dsig, dkappa_numer=dkap, dlambda_numer=dlam)
+        return out
+
+    def _finalize_newton_stats(self, acc):
+        dgm = acc["dgm"].unsqueeze(0)
+        sigma2 = acc["dsigma2_numer"] / dgm
+        kappa = acc["dkappa_numer"].sum(0) / dgm
+        mu_at = self.mu[:, self.comp_list]
+        lam = (acc["dlambda_numer"] + acc["dkappa_numer"] * mu_at.pow(2)).sum(0) / dgm
+        return sigma2, lam, kappa
+
+    # --- Fortran-faithful M-step (amica17.f90:1890-1993) ---
+    def _update_parameters(self, acc, n_samples):
+        self.gm = acc["dgm"] / n_samples
+        self.alpha = acc["dalpha_n"] / acc["dalpha_n"].sum(0, keepdim=True)  # (:1891)
+        self.mu = self.mu + acc["dmu_n"] / acc["dmu_d"]  # (:1978)
+        self.beta = torch.clamp(
+            self.beta * torch.sqrt(acc["dbeta_n"] / acc["dbeta_d"]),
+            self.invsigmin,
+            self.invsigmax,
+        )  # (:1993)
+        rho = self.rho
+        if self.do_rho and not torch.all(rho == 1.0) and not torch.all(rho == 2.0):
+            drho = acc["drho_n"] / acc["dalpha_n"].clamp_min(1e-8)
+            psi = torch.special.digamma(1.0 + 1.0 / rho)  # (:2013-2014)
+            nr = rho + self.rholrate * (1.0 - (rho / psi) * drho)
+            self.rho = torch.clamp(
+                torch.nan_to_num(nr, nan=1.5), self.minrho, self.maxrho
+            )
+
+        newton_active = self.do_newton and self.iteration >= self.newt_start
+        if newton_active:
+            sigma2, lam, kappa = self._finalize_newton_stats(acc)
+        eye = torch.eye(NW, dtype=self.dtype, device=self.device)
+        dirs, no_newt = [], False
+        for h in range(self.n_models):
+            dA_h = (
+                -acc["dWtmp"][:, :, h] / acc["dgm"][h] + eye
+            )  # I - <g b^T>/dgm (:1800-1807)
+            if newton_active:
+                H, posdef = self._newton_direction(
+                    dA_h, sigma2[:, h], lam[:, h], kappa[:, h]
+                )
+                dirs.append(H if posdef else dA_h)
+                no_newt |= not posdef
+            else:
+                dirs.append(dA_h)
+        if newton_active and no_newt:
+            self.n_newton_fallbacks += 1
+        if newton_active and not no_newt:
+            self.lrate = min(
+                self.newtrate, self.lrate + min(1.0 / self.newt_ramp, self.lrate)
+            )
+        else:
+            self.lrate = min(
+                self.lrate_cap, self.lrate + min(1.0 / self.newt_ramp, self.lrate)
+            )
+        for h in range(self.n_models):
+            idx = self.comp_list[:, h]
+            A_cols = self.A[:, idx]
+            self.A[:, idx] = A_cols - self.lrate * (
+                A_cols @ dirs[h]
+            )  # A += -lrate*A*dir (:1909/1916)
+        if self.doscaling and (self.iteration % self.scalestep == 0):
+            s = torch.sqrt((self.A**2).sum(0))
+            nz = s > 0
+            self.A[:, nz] = self.A[:, nz] / s[nz]
+            self.mu[:, nz] = self.mu[:, nz] * s[nz]
+            self.beta[:, nz] = self.beta[:, nz] / s[nz]
+        self._update_unmixing_matrices()
+
+    # --- transpose fix: the TRUE unmixing is self.W.T ---
+    def get_unmixing_matrix(self, model_idx: int = 0) -> np.ndarray:
+        return self.W[:, :, model_idx].T.cpu().numpy()
+
+
+# ---------------------------------------------------------------------------
+# Validations (the guard the in-code implementation must reproduce).
+# ---------------------------------------------------------------------------
+def _load(name, shape):
+    return np.fromfile(AO / name, dtype=np.float64).reshape(shape, order="F")
+
+
+def _corr(A, B):
+    from scipy.optimize import linear_sum_assignment
+
+    a = A / np.linalg.norm(A, axis=1, keepdims=True)
+    b = B / np.linalg.norm(B, axis=1, keepdims=True)
+    C = np.abs(a @ b.T)
+    r, c = linear_sum_assignment(1 - C)
+    return C[r, c].mean()
+
+
+def fixed_point_test():
+    """Seed Fortran's converged solution; assert it is a stable fixed point and
+    that the transpose-fixed unmixing matches Fortran to >0.99."""
+    raw = load_eeglab_data(
+        str(SAMPLE / "eeglab_data.fdt"), data_dim=NW, field_dim=FIELD
+    ).astype(np.float64)
+    W = _load("W", (NW, NW))
+    S = _load("S", (NW, NW))
+    mean = np.fromfile(AO / "mean", dtype=np.float64)
+    mu = _load("mu", (3, NW))
+    sbeta = _load("sbeta", (3, NW))
+    rho = _load("rho", (3, NW))
+    alpha = _load("alpha", (3, NW))
+    gm = np.fromfile(AO / "gm", dtype=np.float64)
+
+    m = CorrectedNG(
+        n_channels=NW,
+        n_models=1,
+        n_mix=3,
+        seed=0,
+        device="cpu",
+        dtype=torch.float64,
+        block_size=512,
+        do_newton=False,
+        lrate=0.05,
+    )
+    Xs = torch.tensor(S @ (raw - mean[:, None]))
+    m.sphere = torch.tensor(S)
+    m.mean = torch.tensor(mean[:, None])
+    ev = np.linalg.eigvalsh(np.cov(raw - mean[:, None]))
+    m.sldet = float(-0.5 * np.log(ev).sum())
+    m.comp_list = torch.arange(NW).unsqueeze(1)
+    m.A = torch.tensor(
+        np.linalg.inv(W.T)
+    )  # NOTE the transpose: Fortran W = inv(A_internal).T
+    m.mu = torch.tensor(mu)
+    m.beta = torch.tensor(sbeta)
+    m.rho = torch.tensor(rho)
+    m.alpha = torch.tensor(alpha)
+    m.gm = torch.tensor(gm)
+    m.c = torch.zeros(NW, 1, dtype=torch.float64)
+    m.iteration = 100
+    m.lrate = 0.05
+    m.lrate_cap = 0.05
+    m._update_unmixing_matrices()
+
+    n = Xs.shape[1]
+    ll0 = float(m._accumulate_blocks(Xs)["ll"] / (n * NW))
+    for _ in range(10):
+        m._update_parameters(m._accumulate_blocks(Xs), n)
+    ll1 = float(m._accumulate_blocks(Xs)["ll"] / (n * NW))
+    Wt = m.get_unmixing_matrix(0)
+    print(
+        f"[fixed-point] seeded LL={ll0:.5f} (expect -3.40186); after 10 steps={ll1:.5f} (expect ~ -3.402)"
+    )
+    print(f"[fixed-point] corr(W.T, Fortran W)={_corr(Wt, W):.4f} (expect ~0.9997)")
+
+
+def short_fit():
+    raw = load_eeglab_data(
+        str(SAMPLE / "eeglab_data.fdt"), data_dim=NW, field_dim=FIELD
+    ).astype(np.float64)
+    m = CorrectedNG(
+        n_channels=NW,
+        n_models=1,
+        n_mix=3,
+        seed=SEED,
+        device="cpu",
+        dtype=torch.float64,
+        block_size=512,
+        do_newton=False,
+        lrate=0.05,
+        lratefact=1.0,
+        maxdecs=10**9,
+    )
+    m.fit(raw, max_iter=30, verbose=False)
+    print(
+        f"[short fit] LL i1={m.ll_history[1]:.4f} i10={m.ll_history[10]:.4f} "
+        f"i29={m.ll_history[-1]:.4f} (ascends from ~ -3.51; do NOT diverge)"
+    )
+
+
+if __name__ == "__main__":
+    fixed_point_test()
+    short_fit()

--- a/.context/issue-21/handoff.md
+++ b/.context/issue-21/handoff.md
@@ -1,0 +1,113 @@
+# Issue #21 implementation handoff
+
+Pick-up doc for implementing the NG-backend M-step fix (chosen path "b": implement the proven
+fixes in-code). Diagnosis is complete; this is the engineering plan.
+
+## Status in one paragraph
+
+The NG backend's first-order M-step diverges from iteration 1 because it uses the density
+derivative `dpdf` where Fortran uses the score `fp`; the fix (plus exact-EM mu/beta, source-space
+natural gradient, symmetric ZCA sphere, rho psi-factor, and a W-transpose in reporting) is fully
+diagnosed and validated against Fortran's converged solution. What remains is (1) porting the
+validated M-step into the production files and re-baselining the tests, and (2) the one open
+gate-blocker: Newton curvature bit-parity at lrate=1.0 (tracked as #24). See
+`root_cause.md` for the full evidence; this doc is the how-to.
+
+## Coordinates
+
+- **Branch:** `feature/issue-21-ng-mstep-parity` (off epic `feature/issue-9-epic-torch-parity`).
+- **PR:** #23 (draft, docs-only so far) -> epic branch.
+- **Issues:** #21 (this work), #24 (Newton bit-parity / init-basin verification via Fortran load_*).
+- **Env:** UV. Run parity work on CPU/float64: `PYTORCH_ENABLE_MPS_FALLBACK=1 uv run pytest ...`.
+  NG needs `device="cpu"` for float64 (MPS lacks it).
+- **Fortran reference solution:** `pyAMICA/sample_data/amicaout/` (200-iter run, LL -3.402).
+  Raw files (`W`, `S`, `mu`, `sbeta`, `rho`, `alpha`, `gm`, `c`, `mean`) are float64,
+  column-major (`np.fromfile(...).reshape(shape, order="F")`), in Fortran's internal order (NOT
+  re-sorted like loadmodout15.m).
+
+## The validated fix (port these into `amica_torch_ng.py`)
+
+The reference implementation is `corrected_mstep_prototype.py` in this folder -- it is a
+`AMICATorchNG` subclass that PASSES the fixed-point test. Port its method bodies into the real
+class. Each change with its Fortran line ref:
+
+1. **Score, not density derivative.** In `_get_block_updates`, use `fp = _score(y, rho)` for the
+   first-order terms, NOT `dpdf`. `p'(y) = -fp(y)*p(y)`, so `dpdf` inverts the update sign.
+   (`amica17.f90:1467`.) `_score` already exists in the module.
+
+2. **Exact-EM mu/beta (new accumulator contract).** Replace single `dmu`/`dbeta` with numer+denom:
+   - `dmu_numer = sum(u*fp)`, `dmu_denom = sbeta*sum(u*fp/y)`  ->  `mu += dmu_numer/dmu_denom`
+     (no lrate). (`:1532,1537,1978`)
+   - `dbeta_numer = sum(u)`, `dbeta_denom = sum(u*fp*y)`  ->  `sbeta *= sqrt(dbeta_numer/dbeta_denom)`.
+     (`:1550,1556,1993`)
+   - `alpha = dalpha_numer / sum_j dalpha_numer` (already correct in the shipped code). (`:1891`)
+   Here `u = v_h * z` (model-weighted mixture responsibility), `y = sbeta*(b-mu)`.
+
+3. **Source-space natural gradient + sign.** Replace data-space `dA = X @ (v*g)` with
+   `dWtmp[h] = g^T @ b` (g outer b, both source-indexed; `:1592`) and update
+   `A -= lrate * A @ (I - <g b^T>/dgm)` (SUBTRACT; `:1800-1917`). `g_i = sum_j sbeta_j*u*fp`
+   (`:1493`).
+
+4. **Symmetric ZCA sphere.** In `_preprocess`, `do_approx_sphere=True` must give `V D^-1/2 V^T`
+   (symmetric; Fortran's default, matches the amicaout `S` to 5e-6), NOT the current PCA
+   `D^-1/2 V^T`. The Python `do_approx_sphere` semantics are currently inverted vs Fortran
+   (`:480-481`). Note `sample_params.json` sets `do_approx_sphere: false` -- that is wrong for
+   parity with amicaout (which used Fortran's default = symmetric ZCA); set it true / omit it,
+   and make the gate test use the default.
+
+5. **rho psi-factor.** `rho += rholrate*(1 - (rho/psi(1+1/rho))*drho_numer/drho_denom)` with
+   `drho_numer = sum(u*|y|^rho*log|y|)`, `drho_denom = sum(u)`. The shipped code omits the
+   `1/psi(1+1/rho)` (digamma) factor. (`:2013-2014`) Floor the denom and nan_to_num for stability.
+
+6. **Transpose fix (reporting).** NG's internal `self.W` is the TRANSPOSE of the true unmixing
+   (`_forward` uses `X.T @ W`, which is correct; but `transform`, `get_unmixing_matrix`, and the
+   validation comparison are transposed). Return/compare `self.W.T`. At Fortran's solution this
+   takes correlation from ~0.5 to 0.9999. Fix `transform` to `self.W.T @ x` and
+   `get_unmixing_matrix` to `self.W.T`; `get_mixing_matrix` adjusts accordingly.
+
+## Ordered plan
+
+1. **Port the M-step** (changes 1-3,5) + **sphere** (4) + **transpose** (6) into
+   `amica_torch_ng.py`. Validate with a NEW in-code test that mirrors `fixed_point_test()` in the
+   prototype: seed amicaout, assert seeded LL == -3.40186, natural-grad holds -3.402 for 10 steps,
+   `corr(get_unmixing_matrix().T? -- already transposed, so compare directly)` >= 0.99. This is
+   the green milestone; commit here.
+2. **Re-baseline `tests/torch_tests/test_ng_backend.py`.** The current
+   `test_sufficient_stats_match_numpy_reference` / `test_newton_*_match_numpy_reference` assert
+   NG == NumPy on the OLD (buggy) accumulator keys (`dmu`, `dbeta`, `dA`). They must become
+   NG-vs-Fortran parity tests (the fixed-point test above is the right shape), because the NumPy
+   reference is equally buggy. Do not "fix" the tests to keep passing against NumPy.
+3. **Mirror the fix in `pyAMICA.py`** (same score/exact-EM/source-space/sphere/rho changes;
+   `_get_block_updates` ~611-755, `_update_parameters` ~757+). Keep NG and NumPy in sync.
+4. **Fix `validate_implementations.py::compare_results`** to compare the basis-invariant total
+   spatial filter `W@sphere` (with the transpose), not raw sphered-space `W` rows.
+5. **Newton bit-parity (#24, the gate-blocker).** With 1-4 done, the natural-gradient phase is
+   faithful (fixed-point stable) but plateaus ~-3.47; Fortran's Newton breaks through to -3.40 at
+   lrate=1.0 while ours overshoots (the 2x2 solve `H=(sk1*dA[i,k]-dA[k,i])/(sk1*sk2-1)` amplifies
+   the residual for near-marginal-posdef pairs). Ruled out: c-center (Fortran's converged c is
+   ~1e-16), sphere, mean. Next: build a per-iteration parity harness (Fortran `do_history` writes
+   only history/16 reliably -- prefer the deterministic-seed + `load_*` route from #24 to start
+   Fortran from the Python init) and diff the Newton curvature (`sigma2`/`kappa`/`lambda`) and the
+   lrate schedule (Fortran holds 0.05 through the NG phase, no ratchet decay; ramps to newtrate
+   under Newton; ratchets only after `max_decs` consecutive decreases -- the shipped fit() halves
+   on EVERY decrease, which starves Newton). Only when Newton reaches -3.40 does the >0.95 gate
+   flip (`test_end_to_end_correlation_vs_fortran`, currently strict xfail -- do NOT flip it early).
+
+## Gotchas
+
+- **Do not flip the xfail gate** until a real fit reaches >0.95; it is a strict xfail on purpose.
+- The accumulator-contract change breaks the current unit tests by design -- re-baseline against
+  Fortran, not NumPy.
+- `_forward` (`X.T @ W`) is already correct; do not "fix" it. The transpose is only in
+  transform/get_unmixing/compare.
+- Keep `device="cpu"`, `dtype=float64` for all parity runs and tests.
+- The reference prototype is a DIAGNOSTIC, not shippable as-is (it subclasses and duplicates); port
+  the logic, don't import it.
+
+## Validation commands
+
+```
+PYTORCH_ENABLE_MPS_FALLBACK=1 uv run python .context/issue-21/reproduce_root_cause.py      # score bug
+PYTORCH_ENABLE_MPS_FALLBACK=1 uv run python .context/issue-21/corrected_mstep_prototype.py # fixed-point + fit
+PYTORCH_ENABLE_MPS_FALLBACK=1 uv run pytest pyAMICA/tests/torch_tests/test_ng_backend.py
+```

--- a/.context/issue-21/reproduce_root_cause.py
+++ b/.context/issue-21/reproduce_root_cause.py
@@ -1,0 +1,81 @@
+"""Reproduce issue #21's root cause: the NG first-order M-step uses the density
+derivative `dpdf = p'(y)` where Fortran uses the score `fp = rho*sign(y)*|y|^(rho-1)`.
+Because `p'(y) = -fp(y)*p(y)`, this flips the update sign, so the log-likelihood
+DESCENDS from iteration 1 (the divergence issue #21 mislabels as a "0.68 plateau").
+
+Run from the repo root:  uv run python .context/issue-21/reproduce_root_cause.py
+
+Expected output:
+  BEFORE (dpdf): LL goes DOWN every iteration (-3.51, -3.54, -3.58, ...), Newton
+                 never fires (posdef guard fails every iteration).
+  AFTER  (score fp): LL goes UP for the first iterations, tracking Fortran
+                 (-3.512 -> -3.501 -> -3.484), and Newton becomes positive-definite.
+
+This is a DIAGNOSTIC, not the fix. The full fix (score fp + exact-EM mu/beta +
+source-space natural gradient + symmetric ZCA sphere + rho psi-factor) is tracked in
+.context/issue-21/root_cause.md.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import torch
+
+import pyAMICA.torch_impl.amica_torch_ng as ng_mod
+from pyAMICA.torch_impl import AMICATorchNG
+from pyAMICA.torch_impl.utils import load_eeglab_data
+
+SAMPLE = Path(__file__).resolve().parents[2] / "pyAMICA" / "sample_data"
+NW, FIELD, SEED = 32, 30504, 42
+
+_orig = ng_mod._log_pdf_and_deriv
+
+
+def _patched(y, rho):
+    """Return the score fp in the slot the M-step reads as `dpdf`."""
+    log_pdf, _ = _orig(y, rho)
+    return log_pdf, ng_mod._score(y, rho)
+
+
+def _traj(ll, idxs):
+    return "  ".join(f"i{i}={ll[i]:+.4f}" if i < len(ll) else f"i{i}=--" for i in idxs)
+
+
+def _run(patch, **kw):
+    ng_mod._log_pdf_and_deriv = _patched if patch else _orig
+    try:
+        m = AMICATorchNG(
+            n_channels=NW,
+            n_models=1,
+            n_mix=3,
+            seed=SEED,
+            device="cpu",
+            dtype=torch.float64,
+            block_size=512,
+            **kw,
+        )
+        m.fit(data, max_iter=60, verbose=False)
+    finally:
+        ng_mod._log_pdf_and_deriv = _orig
+    return m
+
+
+if __name__ == "__main__":
+    data = load_eeglab_data(
+        str(SAMPLE / "eeglab_data.fdt"), data_dim=NW, field_dim=FIELD
+    ).astype(np.float64)
+    idxs = [0, 1, 2, 5, 10, 20, 40, 59]
+    print(
+        "Fortran reference (natural-gradient phase): i1=-3.513 i10=-3.450 i40=-3.442\n"
+    )
+
+    m = _run(patch=False, do_newton=False)
+    print(f"BEFORE (dpdf, current code): {_traj(m.ll_history, idxs)}")
+    print("  -> log-likelihood DESCENDS: the M-step update direction is inverted.\n")
+
+    m = _run(patch=True, do_newton=True, newt_start=20, newtrate=1.0, lrate=0.05)
+    print(f"AFTER  (score fp): {_traj(m.ll_history, idxs)}")
+    print(
+        f"  -> ascends early (tracks Fortran); Newton fallbacks = {m.n_newton_fallbacks} "
+        "(was 68/68 before the fix)."
+    )

--- a/.context/issue-21/root_cause.md
+++ b/.context/issue-21/root_cause.md
@@ -1,0 +1,100 @@
+# Issue #21 root cause: NG-backend M-step diverges (dpdf vs score, gradient vs exact-EM)
+
+**Date:** 2026-07-02. **Status:** root cause proven; full >0.95 re-port in progress.
+
+## TL;DR
+
+Issue #21 frames the ~0.68 correlation as a *subtle fixed-point gap* (blaming
+initialization, iteration count, or the E-step). That is wrong. **The NG backend's
+natural-gradient M-step diverges from iteration 1.** With `lrate` held at Fortran's 0.05
+(where Fortran *ascends* -3.51 -> -3.44), NG's log-likelihood goes monotonically *down*:
+-3.51, -3.54, -3.58, -3.93, -4.83, ... The Phase-4 lrate ratchet only *masked* this by
+collapsing `lrate` to ~1e-6 and freezing parameters at a bad point (the "-3.477 plateau"
+prior sessions recorded). The initial LL matches Fortran (-3.512 vs -3.513), so the E-step,
+data scaling, and init are fine; only the M-step *update direction* is broken.
+
+This overturns:
+- the earlier note "Newton is posdef 50/50 / the cause is outside the update equations"
+  (memory `amica-ng-fixed-point-gap`, now corrected);
+- AGENTS.md's premise that the NumPy `pyAMICA.py` "is the faithful spec" -- it shares the
+  bug, which is why `test_ng_backend.py::test_sufficient_stats_match_numpy_reference`
+  passes (it only asserts NG == NumPy, never NG == Fortran).
+
+## Bug 1 (critical): score `fp` vs density derivative `dpdf`
+
+The first-order updates -- natural-gradient `g`/`dA`, `dmu`, `dbeta` -- use the density
+derivative `dpdf = p'(y)` (2nd return of `amica_torch_ng._log_pdf_and_deriv`), but Fortran
+uses the **score** `fp = rho*sign(y)*|y|^(rho-1)`:
+
+- `amica17.f90:1467` `fp = rho*sign(y)*|y|^(rho-1)`
+- `:1485` `ufp = u*fp` (u = v*z, the model-weighted mixture responsibility)
+- `:1493` `g(i) += sbeta_j * ufp`  (natural-gradient score)
+- `:1532` `dmu_numer = sum(ufp)`
+
+Since `p'(y) = -fp(y)*p(y)` for the generalized Gaussian, substituting `dpdf` for `fp`
+**flips the update sign** -> descent. (Phase 4 already fixed exactly this for the *Newton*
+curvature terms, `pyAMICA.py:726` "use the score fp ... NOT dpdf", but never fixed the
+first-order terms.)
+
+**Proof:** monkeypatching `_log_pdf_and_deriv` to return `(_log_pdf, _score)` turns
+monotonic descent into monotonic ascent tracking Fortran (i0=-3.512, i1=-3.501, i5=-3.484)
+and makes Newton positive-definite (0 fallbacks vs 68/68 before). See
+`reproduce_root_cause.py`.
+
+## Bug 2: gradient-style vs exact-EM mu/beta
+
+NG uses `mu += lrate*dmu/dalpha`, `beta *= sqrt(1+lrate*dbeta)`. Fortran uses exact-EM
+closed forms with **no lrate** (`amica17.f90:1978,1993`):
+
+    mu    = mu + dmu_numer/dmu_denom          dmu_numer=sum(ufp), dmu_denom=sbeta*sum(ufp/y)
+    sbeta = sbeta*sqrt(dbeta_numer/dbeta_denom) dbeta_numer=sum(u), dbeta_denom=sum(ufp*y)
+    alpha = dalpha_numer/sum_j dalpha_numer     (NG already does this correctly)
+
+With only Bug 1 fixed, LL ascends then explodes (overshoot); porting the exact-EM forms too
+gives stable convergence and Newton posdef every iteration.
+
+## Further confirmed faithfulness gaps (needed for full >0.95)
+
+- **Natural-gradient space/sign.** NG builds `dA = X @ (v*g)` (DATA-space `sum x g^T`, then
+  ADD). Fortran builds `dWtmp = g^T b` (SOURCE-space `sum g_t b_t^T`, b=Wx, `:1592`) and
+  applies `A += -lrate*A*(I - <g b^T>/dgm)` (SUBTRACT, `:1800-1917`).
+- **Sphere.** Fortran S is symmetric ZCA `V diag(1/sqrt(eval)) V^T` (verified: S == that to
+  5e-6; S symmetric to 2e-17; `:480-481`, `do_approx_sphere=True` path). NG/NumPy compute
+  PCA `D^-1/2 V^T` (approx=True) or `V D^-1/2` (approx=False) -- neither symmetric, and the
+  Python `do_approx_sphere` semantics are inverted vs Fortran. Also `sample_params.json`
+  sets `do_approx_sphere=false` while the gate test `_fresh_ng()` uses the default True.
+- **rho update** omits Fortran's `1/psi(1+1/rho)` digamma factor (`:2013-2014` vs
+  `amica_torch_ng.py:768`).
+- **c update** differs (Fortran `c = sum(v*x)/sum(v)`, data-space, `:1900`; NG
+  `c += lrate*dc/dgm`). Negligible for 1 model + do_mean (c ~ 0).
+- **fit() lrate ratchet** halves on every LL decrease; Fortran reduces only after
+  `max_decs` consecutive decreases.
+
+## Measurement artifact (separate from the algorithm)
+
+`validate_implementations.py::compare_results` correlates raw `W` rows, i.e. the
+*sphered-space* unmixing, but NG and Fortran sphere in different bases, so even an identical
+decomposition scores low. The basis-invariant metric is the total spatial filter `W@S`
+(Fortran's own mixing is `pinv(W*S)`, `loadmodout15.m:257`). The harness should compare
+`W @ sphere` rows, not `W` rows.
+
+## Remaining work
+
+The confirmed fixes remove the divergence and make Newton fire, but a residual per-iteration
+co-adaptation drift still leaves the natural-gradient phase at ~-3.47 vs Fortran's -3.44 (and
+Newton overshoots at lrate=1.0 from that off-track point). Closing it needs a per-iteration
+comparison against Fortran ground truth (re-run the binary with `do_history=1`/`histstep=1`,
+seed the Python model from Fortran's own per-iteration state + sphere, and diff a single
+M-step to localize the drift). Fix recipe, ordered:
+
+1. First-order M-step re-port: score `fp` + source-space NG + exact-EM mu/beta/alpha + rho
+   psi-factor + c update.
+2. Symmetric ZCA sphere; correct `do_approx_sphere` semantics.
+3. Revalidate Newton finalization against Fortran's baralpha/denominator terms (the base
+   class's "denominators cancel to dgm" simplification is algebraically correct -- verified --
+   but must be rechecked once the first-order params are on-track).
+4. Fortran-faithful lrate control (hold 0.05 in the NG phase, ramp to `newtrate` under Newton,
+   ratchet only after `max_decs`).
+5. Apply the same fixes to `pyAMICA.py`; re-baseline `test_ng_backend.py` tests against
+   Fortran, not the (buggy) NumPy reference.
+6. Fix the validation-harness metric to compare `W@sphere`.

--- a/.context/issue-21/root_cause.md
+++ b/.context/issue-21/root_cause.md
@@ -78,6 +78,34 @@ decomposition scores low. The basis-invariant metric is the total spatial filter
 (Fortran's own mixing is `pinv(W*S)`, `loadmodout15.m:257`). The harness should compare
 `W @ sphere` rows, not `W` rows.
 
+## Update: fixed-point test + transpose bug (per-iteration parity grind)
+
+Seeding the corrected M-step with Fortran's *converged* `amicaout` solution (raw `W`, `S`,
+`mean`, `mu`, `sbeta`, `rho`, `alpha`) and running one M-step (fixed-point test) established:
+
+- **The corrected M-step is faithful.** Fortran's solution is a *stable* fixed point of the
+  natural gradient: seeded LL = -3.40186 (== Fortran -3.402), 15 steps at lrate=0.05 hold
+  -3.4019, and the stationarity condition `<g b^T>/dgm == I` holds to max 0.005. So score fp
+  + exact-EM mu/beta + source-space natural gradient are correct.
+
+- **W/A transpose bug (major, new).** Seeding required `A = inv(W_fortran.T)`: NG's internal
+  `W` is the *transpose* of the true unmixing. `_forward` (`b = X.T @ W`) uses it correctly,
+  but `transform` (`W @ X`), `get_unmixing_matrix` (returns `self.W`), and the validation
+  comparison are transposed. At Fortran's solution, `corr(self.W.T, Fortran W) = 0.9997`
+  vs `corr(self.W, Fortran W) ~ 0.5`. **Fix: report/compare `self.W.T`** (and fix `transform`
+  to `self.W.T @ x`). This shared-with-NumPy transpose is a dominant cause of the low
+  correlation number, independent of LL. (`amica_torch_ng.py:475` forward vs `:994` transform
+  vs `:1001` get_unmixing.)
+
+- **Newton is the remaining blocker.** At lrate ramping to 1.0, the Newton step diverges even
+  seeded at the fixed point (0 fallbacks -- it takes the Newton direction, then overshoots).
+  Root: the 2x2 solve `H[i,k] = (sk1*dA[i,k] - dA[k,i])/(sk1*sk2 - 1)` amplifies the small
+  residual `dA = I - <g b^T>/dgm` for source pairs whose `sk1*sk2` is barely > 1 (near-marginal
+  positive definiteness). Fortran is stable at lrate=1.0. Needs: match Fortran's Newton
+  curvature exactly at the fixed point (so the residual and marginal pairs vanish), and/or a
+  gentler ramp. Natural-gradient alone (no Newton) reaches ~-3.47 (vs Fortran's pre-Newton
+  -3.44) with ~0.5 correlation, so Newton is required for >0.95.
+
 ## Remaining work
 
 The confirmed fixes remove the divergence and make Newton fire, but a residual per-iteration

--- a/.context/research.md
+++ b/.context/research.md
@@ -3,6 +3,14 @@
 Fortran-vs-Python parity analysis. Fortran reference: `amica17.f90` (~3900 lines),
 `amica17_header.f90` (declarations), `funmod2.f90` (function modules).
 
+> **2026-07-02 - Issue #21 root cause (M-step diverges).** The NG backend's first-order
+> M-step uses the density derivative `dpdf = p'(y)` where Fortran uses the score
+> `fp = rho*sign(y)*|y|^(rho-1)`; since `p' = -fp*p`, the log-likelihood *descends* from
+> iteration 1. Plus gradient-style vs exact-EM mu/beta, PCA vs symmetric-ZCA sphere, and a
+> validation-metric artifact (sphered-space `W` vs basis-invariant `W@S`). Full analysis,
+> evidence, and fix recipe: [`issue-21/root_cause.md`](issue-21/root_cause.md); runnable
+> proof: `issue-21/reproduce_root_cause.py`.
+
 ## Core Data Structures (Fortran -> Python)
 | Fortran | Python | Status |
 |---|---|---|


### PR DESCRIPTION
## Summary

Root-cause diagnosis for #21 (NG backend parity plateau). Persists the analysis so it
is not lost; the code fix is a follow-up (this PR is docs only).

**Finding:** the NG backend's first-order M-step diverges from iteration 1. It uses the
density derivative `dpdf = p'(y)` where Fortran uses the score
`fp = rho*sign(y)*|y|^(rho-1)` (`amica17.f90:1467,1485,1493,1532`). Since
`p'(y) = -fp(y)*p(y)`, the update sign is inverted, so with `lrate` held at Fortran's 0.05
(where Fortran ascends -3.51 -> -3.44) the log-likelihood instead descends
-3.51 -> -3.54 -> -3.58 -> -3.93. The Phase-4 lrate ratchet only masked this by collapsing
`lrate` and freezing parameters at a bad point (the "-0.68 / -3.477 plateau" earlier notes
recorded). Swapping `dpdf -> fp` turns descent into ascent and makes Newton positive-definite
(0 fallbacks vs 68/68).

This overturns the issue's stated hypotheses (init / iteration count / E-step) and the earlier
"cause is outside the update equations" conclusion. It also shows the NumPy reference
`pyAMICA.py` shares the bug (the unit tests only assert NG == NumPy, never NG == Fortran).

## Also confirmed (with file:line evidence in the doc)

- gradient-style vs exact-EM mu/beta (`amica17.f90:1978,1993`)
- data-space vs source-space natural gradient (`:1592,1800-1917`)
- PCA vs Fortran's symmetric-ZCA sphere (verified to 5e-6; `:480-481`)
- rho update missing the `1/psi(1+1/rho)` factor (`:2013`)
- validation-metric artifact: sphered-space `W` vs basis-invariant `W@S`

## Contents

- `.context/issue-21/root_cause.md` - full analysis + ordered fix recipe
- `.context/issue-21/reproduce_root_cause.py` - runnable proof (descent vs ascent)
- pointer added to `.context/research.md`

## Status / next

Confirmed fixes remove the divergence and make Newton fire, but a residual per-iteration
co-adaptation drift still leaves the NG phase at ~-3.47 vs Fortran -3.44. Closing it is the
next step: diff a single M-step against Fortran ground truth (do_history) seeded from Fortran's
own state. Tested: `uv run python .context/issue-21/reproduce_root_cause.py`.

Refs #21.
