### PR TITLE
Address PR #28 review: NG backend polish + doc coherence

### DIFF
--- a/.context/decisions/0001-torch-backend-natural-gradient-em.md
+++ b/.context/decisions/0001-torch-backend-natural-gradient-em.md
@@ -1,7 +1,7 @@
 # ADR 0001: Rewrite the PyTorch backend as a natural-gradient EM port, not Adam+autograd
 
-**Status:** proposed
-**Date:** 2026-07-02
+**Status:** accepted
+**Date:** 2026-07-02 (accepted 2026-07-03)
 **Owner:** Seyed Yahya Shirazi
 
 ## Context
@@ -36,6 +36,14 @@ statistics block-wise, and drop Adam/autograd for the parameter updates. The Num
   `AMICA` interface must be re-pointed at the new module.
 - **Obligation:** keep `validate_implementations.py` (real sample data + Fortran binary) green as
   the source of truth; no synthetic-data correctness tests.
+
+**Outcome (2026-07-03, issue #24 / PR #25):** implemented as `AMICATorchNG`
+(`torch_impl/amica_torch_ng.py`), wired into `AMICA(backend="ng")`. Single-model reaches Fortran
+parity (LL ~ -3.40, Hungarian component correlation ~0.997 with Newton positive-definite, 0
+fallbacks); the NumPy backend carries the same fixes. The root-cause fix was the natural-gradient
+A-update (it was transposed / multiplied on the wrong side); see
+`.context/issue-24/root_cause_Aupdate.py`. Multi-model M-step is bit-exact vs Fortran; full-fit
+partition matching is tracked in #27, adaptive-PDF in #26.
 
 ## Alternatives considered
 

--- a/.context/decisions/README.md
+++ b/.context/decisions/README.md
@@ -25,4 +25,4 @@ Do not write one for routine choices that are obvious from reading the code.
 Add new entries here as you create ADRs:
 
 - ADR 0000 - template (do not edit)
-- ADR 0001 - [Rewrite the PyTorch backend as a natural-gradient EM port, not Adam+autograd](0001-torch-backend-natural-gradient-em.md) (proposed)
+- ADR 0001 - [Rewrite the PyTorch backend as a natural-gradient EM port, not Adam+autograd](0001-torch-backend-natural-gradient-em.md) (accepted)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,16 +3,17 @@
 ## Project Context
 **Purpose:** Python implementation of AMICA (Adaptive Mixture Independent Component Analysis) that reproduces the results of the reference Fortran binary. Targets EEG/EMG source separation with GPU/MPS/CPU support.
 **Tech Stack:** Python 3.12+, PyTorch (primary backend, MPS/CUDA/CPU), NumPy/SciPy (legacy backend), matplotlib. Reference implementation is Fortran (`amica17.f90`, `funmod2.f90`).
-**Architecture:** Two coexisting backends. The default scikit-learn-style `AMICA` interface wraps the basic `AMICATorch` (`torch_impl/amica_torch.py`), which currently has Newton disabled and no adaptive PDF. An enhanced `AMICATorchV2` (`torch_impl/amica_torch_v2.py`) adds Newton, adaptive PDF, and multi-model support but is experimental and NOT yet wired into the public interface. The legacy NumPy implementation (`pyAMICA.py`, retained as `AMICA_NumPy`) has the fuller feature set (Newton, baralpha, outlier rejection). Correctness is defined by parity with the Fortran binary, validated by `validate_implementations.py`.
+**Architecture:** The scikit-learn-style `AMICA` interface selects a PyTorch backend via `backend=`. `backend="torch"` (default) wraps the basic `AMICATorch` (`torch_impl/amica_torch.py`), which has Newton disabled and no adaptive PDF. `backend="ng"` wraps `AMICATorchNG` (`torch_impl/amica_torch_ng.py`), the natural-gradient EM port that reaches Fortran parity (Newton, exact-EM mixture updates, symmetric-ZCA sphere, Jacobian LL). The earlier `AMICATorchV2` (`torch_impl/amica_torch_v2.py`) is parked/superseded by `AMICATorchNG`. The legacy NumPy implementation (`pyAMICA.py`, retained as `AMICA_NumPy`) carries the same parity fixes plus baralpha and outlier rejection. Correctness is defined by parity with the Fortran binary, validated by `validate_implementations.py`.
 
 ## Architecture Map
 ```
 pyAMICA/
 ├── amica.py                 # Main scikit-learn-style AMICA interface (PyTorch-backed)
 ├── __init__.py              # Exposes AMICA (PyTorch) and AMICA_NumPy (legacy)
-├── torch_impl/              # PyTorch backend (default)
-│   ├── amica_torch.py       #   Core AMICA module (basic; Newton disabled) - backs the default AMICA
-│   ├── amica_torch_v2.py    #   Enhanced model (Newton + adaptive PDF + multi-model); experimental, NOT wired into default AMICA
+├── torch_impl/              # PyTorch backend
+│   ├── amica_torch.py       #   Core AMICA module (basic; Newton disabled) - backs the default AMICA (backend="torch")
+│   ├── amica_torch_ng.py    #   Natural-gradient EM port (AMICATorchNG); Fortran-parity, backs backend="ng"
+│   ├── amica_torch_v2.py    #   PARKED/superseded by amica_torch_ng.py (experimental, not wired into AMICA)
 │   ├── adaptive_pdf.py      #   Adaptive PDF selection (Laplace/Student-t/GG)
 │   ├── newton_optimizer.py  #   Newton optimization with Fortran-style ramping
 │   ├── mixture_models.py    #   Mixture-of-densities components
@@ -28,19 +29,23 @@ validate_implementations.py  # Runs both backends, Hungarian component matching,
 ```
 
 ## Environment Setup
-Canonical environment is **UV** (per global standards). Migration from the legacy conda env
-(`torch-312`) to a UV-managed environment is tracked in `.context/plan.md` and not yet complete;
-until it lands, `requirements-torch.txt` documents the PyTorch dependency set.
+Canonical environment is **UV** (per global standards). The PyTorch stack is declared in
+`pyproject.toml` with `uv.lock` pinned; the legacy conda env (`torch-312`) is retired. Migration
+history is in `.context/plan.md`.
 ```bash
-uv sync                          # Install dependencies (once pyproject declares the torch stack)
+uv sync                          # Install dependencies
 uv run pytest                    # Run tests
 uv run ruff check --fix . && uv run ruff format .
 ```
-MPS note: run with `PYTORCH_ENABLE_MPS_FALLBACK=1` for ops MPS does not yet support.
+MPS note: run with `PYTORCH_ENABLE_MPS_FALLBACK=1` for ops MPS does not yet support. The NG backend
+computes in float64 for Fortran parity, which MPS cannot represent, so parity runs use CPU or CUDA
+(the `AMICA` wrapper falls back to CPU automatically when a device is not pinned).
 
 ## Key Files
-- **Main interface:** `pyAMICA/amica.py`
-- **Default backend:** `pyAMICA/torch_impl/amica_torch.py` (`AMICATorch`, Newton disabled). Enhanced but not-yet-wired: `amica_torch_v2.py` (`AMICATorchV2`)
+- **Main interface:** `pyAMICA/amica.py` (`backend="torch"` default, `backend="ng"` opt-in)
+- **Default backend:** `pyAMICA/torch_impl/amica_torch.py` (`AMICATorch`, Newton disabled).
+- **Parity backend:** `pyAMICA/torch_impl/amica_torch_ng.py` (`AMICATorchNG`, natural-gradient EM,
+  Fortran-parity; ADR `.context/decisions/0001-torch-backend-natural-gradient-em.md`). Parked/superseded: `amica_torch_v2.py` (`AMICATorchV2`)
 - **Validation harness:** `validate_implementations.py`
 - **Fortran reference binary:** `pyAMICA/sample_data/amica15mac`
 - **Sample data:** `pyAMICA/sample_data/`
@@ -73,12 +78,14 @@ bias `c` update is omitted (only a no-op for `n_models=1`), whereas Fortran move
 `v` is non-uniform. So the multi-model gap is NOT purely partition ambiguity; the `c` update is an
 open, fixable suspect.
 
-Remaining, non-blocking:
+Remaining, non-blocking (tracked as follow-up issues):
 1. Newton stability was fixed for `AMICATorchNG` (posdef, 0 fallbacks on the sample data). The
-   separate experimental `AMICATorchV2` Newton path was not part of this fix.
+   separate experimental `AMICATorchV2` is parked/superseded and scheduled for removal (#32).
 2. The `AMICATorchNG` backend still lacks the adaptive-PDF selection present in the NumPy path
-   (a feature beyond Fortran parity, which uses a fixed GG PDF); outlier rejection IS implemented
-   (`do_reject`).
+   (a feature beyond Fortran parity, which uses a fixed GG PDF; #26); outlier rejection IS
+   implemented (`do_reject`).
+3. Full multi-model partition matching and the per-model bias `c` update (#27).
+4. Legacy `backend="torch"` bugs: mixture M-step LL descent (#31), CLI save/load format (#30).
 
 ## Development Workflow
 1. **Check context:** `.context/plan.md` for current tasks and priorities.

--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -1,5 +1,16 @@
 # Feature Parity Report: Fortran vs PyTorch AMICA
 
+> **Status (2026-07-03, epic #9 / issue #24):** the "PyTorch" column below tracks the pre-epic
+> basic backend (`AMICATorch`, `backend="torch"`, Adam/autograd). It has been **superseded for
+> parity by the natural-gradient EM backend `AMICATorchNG` (`backend="ng"`)**, which reaches
+> Fortran parity: single-model LL ~ -3.40 (vs Fortran -3.4018) and Hungarian component correlation
+> ~0.997 with Newton positive-definite (0 fallbacks). `AMICATorchNG` also implements Newton +
+> Fortran-style ramping and outlier rejection (`do_reject`). The rows below that still read
+> "Missing"/"Partial" describe the basic backend and no longer reflect `backend="ng"`. Remaining
+> gaps on the NG path: adaptive-PDF selection (#26) and full multi-model partition matching (#27,
+> M-step is already bit-exact vs Fortran). See `PROGRESS_SUMMARY.md` and ADR
+> `.context/decisions/0001-torch-backend-natural-gradient-em.md`.
+
 ## Implementation Status Overview
 
 | Component | Fortran | NumPy | PyTorch | Notes |
@@ -122,93 +133,58 @@
 
 ## Validation Status
 
-### Convergence Behavior
+### Convergence Behavior (`backend="ng"`, issue #24)
 
-| Metric | Fortran | PyTorch | Match? | Notes |
-|--------|---------|---------|--------|-------|
-| **Initial LL** | ~-3.5 | ~-46 | ❌ | Different scaling |
+| Metric | Fortran | PyTorch NG | Match? | Notes |
+|--------|---------|-----------|--------|-------|
+| **Final LL** | -3.4018 | -3.40 | ✅ | Jacobian-normalized, parity |
+| **Component Correlation** | - | ~0.997 | ✅ | Hungarian-matched, clears >0.95 gate |
 | **Convergence Rate** | Fast | Fast | ✅ | Similar speed |
-| **Final LL Range** | -3.4 to -3.5 | -44 to -46 | ❌ | Consistent offset |
-| **Gradient Decay** | Exponential | Exponential | ✅ | Similar pattern |
+| **Newton** | posdef | posdef | ✅ | 0 fallbacks on sample data |
 
-### Component Quality
+The pre-epic basic backend (`backend="torch"`) still shows the old offset (initial LL ~-46,
+final -44 to -46; ~0.78 correlation) and is superseded by `backend="ng"` for parity.
+
+### Component Quality (`backend="ng"`)
 
 | Metric | Status | Notes |
 |--------|--------|-------|
-| **Component Correlation** | 🔧 Testing | Need same initialization |
-| **Mixing Matrix Recovery** | 🔧 Testing | Depends on convergence |
-| **Source Separation** | 🔧 Testing | Need synthetic data test |
+| **Component Correlation** | ✅ ~0.997 | Real sample data vs Fortran (Hungarian match) |
+| **Mixing Matrix Recovery** | ✅ | Ascends to Fortran fixed point |
+| **Source Separation** | ✅ real-data | Validated on sample EEG (no synthetic; NO-MOCK policy) |
 
-## Critical Features Implementation Roadmap
+## Remaining Roadmap (`backend="ng"`)
 
-### Priority 1: Core Algorithm (Immediate - Week 1)
+The epic (#9 / #24) delivered core parity on `AMICATorchNG`. Done on the NG path: natural-gradient
+EM at the Fortran fixed point, Newton + Fortran-style ramping (positive-definite), exact-EM mixture
+updates, symmetric-ZCA sphere, Jacobian LL, and outlier rejection (`do_reject`). Open items:
 
-#### 1. Newton Optimization Method ⚠️ Partially Implemented
-**Why Critical**: Provides quadratic convergence, essential for fine-tuning components
-- [ ] Fix MPS compatibility with pytorch-minimize
-- [ ] Implement Newton ramping (gradual transition after iter 50)
-- [ ] Add line search and trust region
-- [ ] Match Fortran's Newton behavior (lrate → 1.0)
+#### 1. Adaptive PDF Selection (issue #26)
+**Why**: different sources have different distributions; beyond strict Fortran parity (fixed GG PDF)
+- [ ] Laplace / Student-t / generalized-Gaussian selection on the NG path
+- [ ] Kurtosis-based selection and per-component PDF-fit monitoring
 
-#### 2. Adaptive PDF Selection 🔴 Not Implemented  
-**Why Critical**: Different sources have different distributions; dramatically improves separation
-- [ ] Implement kurtosis-based PDF selection
-- [ ] Add Laplace, Student-t, uniform PDFs
-- [ ] Create smooth transitions between PDFs
-- [ ] Monitor PDF fit quality per component
+#### 2. Multi-Model Partition Matching (issue #27)
+**Why**: full 2-model fit is partition-limited (~0.77) though the M-step is bit-exact vs Fortran
+- [ ] Resolve the partition/cross-correlation gap
+- [ ] Restore the omitted per-model bias `c` update (no-op only for `n_models=1`)
 
-#### 3. Multiple PDF Types 🔴 Not Implemented
-**Why Critical**: Real data contains mixed source types (super/sub-Gaussian)
-- [ ] Allow different PDFs per source
-- [ ] Implement PDF-specific updates
-- [ ] Initialize based on data statistics
-
-### Priority 2: Multi-Modal Features (Week 2)
-
-#### 4. Multi-Modal AMICA ⚠️ Framework Exists
-**Why Critical**: Handles non-stationary data and multiple brain states
-- [ ] Debug multi-model optimization
-- [ ] Implement proper gm updates
-- [ ] Add model selection criteria
-- [ ] Test with non-stationary data
-
-#### 5. Component Sharing 🔴 Not Implemented
-**Why Critical**: Identifies stable components across states
-- [ ] Implement similarity metrics
-- [ ] Add sharing detection
-- [ ] Create shared component pools
-
-### Priority 3: Robustness (Week 3)
-
-#### 6. Outlier Rejection 🔴 Not Implemented
-**Why Critical**: Real EEG data contains artifacts
-- [ ] Implement robust likelihood
-- [ ] Add sample weighting
-- [ ] Create adaptive thresholds
-
-#### 7. Adaptive Block Size 🔴 Not Implemented
-**Why Critical**: Optimizes memory and convergence
-- [ ] Dynamic block selection
-- [ ] Memory monitoring
-- [ ] GPU optimization
+#### 3. Retire Superseded/Legacy Paths
+- [ ] Remove `AMICATorchV2` and promote `backend="ng"` to default (issue #32)
+- [ ] Reassess the basic `backend="torch"` path (legacy mixture M-step bug: #31; legacy CLI
+      save/load format: #30)
 
 ## Migration Readiness
 
-### Ready to Replace NumPy ✅
-- PyTorch implementation is more stable
-- Better performance
-- GPU support
-- Active maintenance
-
-### Not Ready to Replace Fortran ⚠️
-- Need to validate component quality
-- Missing some advanced features
-- Different numerical scaling
+### `backend="ng"` at Fortran parity ✅
+- Single-model LL ~ -3.40 and component correlation ~0.997 vs Fortran (issue #24)
+- NumPy backend carries the same fixes
+- Multi-model M-step bit-exact; full-fit partition matching tracked in #27
 
 ### Recommendation
-1. **Immediate**: Replace NumPy with PyTorch
-2. **Testing**: Run both Fortran and PyTorch in parallel
-3. **Future**: Full Fortran replacement after validation
+1. Use `backend="ng"` for parity-critical work (default for that use case)
+2. Keep `validate_implementations.py` (real sample data + Fortran binary) green as source of truth
+3. Close out adaptive-PDF (#26) and multi-model (#27) before removing the Fortran binary from the loop
 
 ## Testing Checklist
 
@@ -216,9 +192,8 @@
 - [x] Convergence test
 - [x] GPU/MPS support
 - [x] Output format compatibility
-- [ ] Same initialization test
-- [ ] Component correlation test
-- [ ] Synthetic data recovery
+- [x] Component correlation vs Fortran (real data, Hungarian match)
+- [x] NG backend sufficient-stats vs NumPy reference (bit-exact)
 - [ ] Large-scale data test
 - [ ] Memory usage comparison
 - [ ] Speed benchmarks

--- a/PROGRESS_SUMMARY.md
+++ b/PROGRESS_SUMMARY.md
@@ -26,35 +26,41 @@
 - Updated `CLAUDE.md` with current status and roadmap
 - Documented critical missing features and priorities
 
+### 5. Natural-gradient EM backend at Fortran parity ✅ (epic #9 / issue #24)
+- Added `AMICATorchNG` (`torch_impl/amica_torch_ng.py`), wired into `AMICA(backend="ng")`
+- Root-caused the parity gap: the natural-gradient A-update was transposed / multiplied on the
+  wrong side (proven machine-exact); plus exact-EM mixture updates, the digamma rho update, the
+  symmetric-ZCA sphere, the output transpose, and the NumPy Jacobian LL
+- Newton ported from NumPy and positive-definite (0 fallbacks on the sample data)
+
 ## Current Results
 
-### Validation Metrics (50 iterations)
-- **Log-likelihood ratio**: ~13x (consistent scaling difference)
-- **Component correlation**: 0.78 mean (0.61 min, 0.88 max)
-- **Convergence**: Both implementations converge stably
+### Validation Metrics (`backend="ng"`, issue #24)
+- **Log-likelihood**: LL ~ -3.40 (matches Fortran -3.4018; the earlier ~13x scaling gap was an
+  artifact of the pre-parity basic backend)
+- **Component correlation**: ~0.997 (Hungarian-matched, Newton positive-definite) -- clears the
+  >0.95 gate
+- **NumPy backend**: carries the same fixes and matches
+- **Multi-model** (`n_models>1`): M-step bit-exact vs Fortran; full-fit partition matching is
+  partition-limited (~0.77), tracked in #27
 
-### Key Findings
-1. PyTorch implementation works and converges
-2. Component quality needs improvement (target >0.95 correlation)
-3. Missing Newton optimization is critical (Fortran switches at iter 50)
-4. Adaptive PDF selection needed for better separation
+The pre-epic basic backend (`backend="torch"`, Adam) still shows the old ~0.78 correlation / ~13x
+LL scaling; it is retained but superseded by `backend="ng"` for parity work.
 
 ## Next Steps (Prioritized)
 
-### 1. Fix Newton Optimization (Critical)
-- Debug pytorch-minimize integration
-- Implement Newton ramping (gradual transition)
-- Match Fortran's behavior (lrate → 1.0 after iter 50)
+### 1. Adaptive PDF selection for `AMICATorchNG` (issue #26)
+- Laplace / Student-t / generalized-Gaussian selection (present in the NumPy path, beyond strict
+  Fortran parity which uses a fixed GG PDF)
 
-### 2. Implement Adaptive PDF Selection (Critical)
-- Add multiple PDF types (Laplace, Student-t, uniform)
-- Implement kurtosis-based selection
-- Allow different PDFs per component
+### 2. Multi-model partition matching (issue #27)
+- Resolve the full-fit multi-model cross-correlation gap; includes the omitted per-model bias
+  `c` update
 
-### 3. Ensure Identical Initialization
-- Match random seed behavior
-- Initialize with same sphering matrix
-- Start from identical mixing matrices
+### 3. Retire the parked/superseded paths (issue #32)
+- `AMICATorchV2` is parked (superseded by `AMICATorchNG`); once `backend="ng"` is the de-facto
+  default, remove `AMICATorchV2` and promote `backend="ng"` to default, then reassess the basic
+  `backend="torch"` path (legacy mixture M-step bug tracked in #31)
 
 ## Technical Achievements
 - Successfully handles MPS device limitations
@@ -71,6 +77,5 @@
 6. Update gitignore for validation output
 
 ## Repository Status
-- Branch: `pytorch-implementation`
-- All changes committed and pushed
-- Ready for next phase of development
+- Epic #9 (PyTorch backend Fortran parity) delivered via `AMICATorchNG` / `backend="ng"`
+- Remaining follow-ups tracked as issues #26 (adaptive PDF), #27 (multi-model), #30/#31 (legacy)

--- a/pyAMICA/__init__.py
+++ b/pyAMICA/__init__.py
@@ -16,7 +16,7 @@ Main Features:
 
 from .version import __version__
 from .amica import AMICA
-from .torch_impl import AMICATorch
+from .torch_impl import AMICATorch, AMICATorchNG
 from . import amica_utils
 from . import amica_data
 from . import amica_newton
@@ -27,13 +27,14 @@ from . import amica_viz
 from .pyAMICA import AMICA as AMICA_NumPy
 
 __all__ = [
-    'AMICA',
-    'AMICATorch',
-    'AMICA_NumPy',
-    'amica_utils',
-    'amica_data',
-    'amica_newton',
-    'amica_pdf',
-    'amica_viz',
-    '__version__'
+    "AMICA",
+    "AMICATorch",
+    "AMICATorchNG",
+    "AMICA_NumPy",
+    "amica_utils",
+    "amica_data",
+    "amica_newton",
+    "amica_pdf",
+    "amica_viz",
+    "__version__",
 ]

--- a/pyAMICA/amica.py
+++ b/pyAMICA/amica.py
@@ -8,12 +8,18 @@ implementation for GPU-accelerated ICA with adaptive mixtures.
 import numpy as np
 import torch
 from typing import Optional, Union
+import inspect
 import json
 import logging
 
 from .torch_impl import AMICATorch, AMICATorchNG, setup_device
 
 logger = logging.getLogger(__name__)
+
+# AMICATorchNG's default parameter dtype, derived from its signature so the
+# wrapper's MPS/float64 fallback below stays in lockstep if that default ever
+# changes (rather than duplicating the literal).
+_NG_DEFAULT_DTYPE = inspect.signature(AMICATorchNG).parameters["dtype"].default
 
 
 class AMICA:
@@ -30,7 +36,11 @@ class AMICA:
     n_mix : int, default=3
         Number of mixture components per source
     device : str or torch.device, optional
-        Device to use ('cuda', 'mps', 'cpu', or None for auto)
+        Device to use ('cuda', 'mps', 'cpu', or None for auto). Note: with
+        ``backend="ng"`` and ``None`` (auto), an auto-selected MPS device is
+        redirected to CPU because the NG backend computes in float64 for
+        Fortran parity and MPS cannot represent it; pass ``dtype=torch.float32``
+        (with ``device="mps"``) to run on MPS instead.
     verbose : bool, default=True
         Whether to show progress during fitting
     backend : {"torch", "ng"}, default="torch"
@@ -165,18 +175,21 @@ class AMICA:
             # cannot represent. When the device was auto-selected (the user
             # did not pin one) and resolved to MPS for a float64 run, fall
             # back to CPU so the default config runs instead of crashing.
-            # CUDA supports float64, so only MPS needs this. Users wanting MPS
-            # can pass dtype=torch.float32 (and device="mps") explicitly.
-            ng_dtype = kwargs.get("dtype", torch.float64)
+            # CUDA supports float64, so only MPS needs this. An explicit
+            # device="mps" is left untouched and surfaces AMICATorchNG's own
+            # ValueError; users wanting MPS pass dtype=torch.float32 too.
+            ng_dtype = kwargs.get("dtype", _NG_DEFAULT_DTYPE)
             dev_type = getattr(device, "type", device)
             if self.device is None and dev_type == "mps" and ng_dtype == torch.float64:
                 device = torch.device("cpu")
+                msg = (
+                    "backend='ng' uses float64 for Fortran parity; MPS lacks "
+                    "float64 support, so falling back to CPU. Pass "
+                    "dtype=torch.float32 with device='mps' to run on MPS."
+                )
+                logger.warning(msg)
                 if self.verbose:
-                    print(
-                        "backend='ng' uses float64 for Fortran parity; MPS "
-                        "lacks float64 support, so using CPU. Pass "
-                        "dtype=torch.float32 with device='mps' to run on MPS."
-                    )
+                    print(msg)
 
             if debug:
                 raise ValueError(

--- a/pyAMICA/amica.py
+++ b/pyAMICA/amica.py
@@ -6,6 +6,7 @@ implementation for GPU-accelerated ICA with adaptive mixtures.
 """
 
 import numpy as np
+import torch
 from typing import Optional, Union
 import json
 import logging
@@ -44,8 +45,9 @@ class AMICA:
 
     Attributes
     ----------
-    model_ : AMICATorch
-        The underlying PyTorch model
+    model_ : AMICATorch or AMICATorchNG
+        The underlying PyTorch model (``AMICATorchNG`` when
+        ``backend="ng"``, otherwise ``AMICATorch``)
     is_fitted_ : bool
         Whether the model has been fitted
     ll_history_ : list
@@ -159,6 +161,23 @@ class AMICA:
             device = self.device
 
         if self.backend == "ng":
+            # AMICATorchNG defaults to float64 for Fortran parity, which MPS
+            # cannot represent. When the device was auto-selected (the user
+            # did not pin one) and resolved to MPS for a float64 run, fall
+            # back to CPU so the default config runs instead of crashing.
+            # CUDA supports float64, so only MPS needs this. Users wanting MPS
+            # can pass dtype=torch.float32 (and device="mps") explicitly.
+            ng_dtype = kwargs.get("dtype", torch.float64)
+            dev_type = getattr(device, "type", device)
+            if self.device is None and dev_type == "mps" and ng_dtype == torch.float64:
+                device = torch.device("cpu")
+                if self.verbose:
+                    print(
+                        "backend='ng' uses float64 for Fortran parity; MPS "
+                        "lacks float64 support, so using CPU. Pass "
+                        "dtype=torch.float32 with device='mps' to run on MPS."
+                    )
+
             if debug:
                 raise ValueError(
                     "debug=True (Fortran-style output) is not supported by "
@@ -311,8 +330,6 @@ class AMICA:
                 "is not an nn.Module and has no state_dict()."
             )
 
-        import torch
-
         torch.save(
             {
                 "model_state": self.model_.state_dict(),
@@ -342,8 +359,6 @@ class AMICA:
                 "load() is not implemented for backend='ng': AMICATorchNG "
                 "has no save()/state_dict() counterpart."
             )
-
-        import torch
 
         checkpoint = torch.load(filepath, map_location="cpu")
 

--- a/pyAMICA/tests/test_sample_data.py
+++ b/pyAMICA/tests/test_sample_data.py
@@ -63,9 +63,9 @@ def test_sample_data_scikit(tmp_path):
     "(save_results in pyAMICA.py) but loadmodout() expects raw "
     "Fortran-format binary files with no extension; the round-trip "
     "raises FileNotFoundError for 'W' before the correlation check is "
-    "even reached. Separate bug from Known Issue #2, needs its own fix "
-    "(gated by epic #9); no raises= constraint since the failure mode "
-    "is not a clean AssertionError.",
+    "even reached. Independent legacy-CLI bug tracked in issue #30; no "
+    "raises= constraint since the failure mode is not a clean "
+    "AssertionError.",
     strict=True,
 )
 def test_sample_data_cli():

--- a/pyAMICA/tests/torch_tests/test_amica_ng_wrapper.py
+++ b/pyAMICA/tests/torch_tests/test_amica_ng_wrapper.py
@@ -7,6 +7,7 @@ on Apple Silicon (MPS cannot represent float64). Real sample EEG data only
 (no synthetic/mock).
 """
 
+import logging
 from pathlib import Path
 
 import numpy as np
@@ -72,16 +73,43 @@ def test_ng_save_not_implemented(fitted_ng, tmp_path):
         fitted_ng.save(str(tmp_path / "model.pt"))
 
 
-def test_ng_default_device_avoids_mps_float64(real_data):
+def test_ng_default_device_avoids_mps_float64(real_data, caplog):
     """The default float64 NG config must not crash when the auto-selected
     device is MPS; the wrapper falls back to CPU (regression for #29)."""
     model = AMICA(n_models=1, n_mix=3, verbose=False, backend="ng")  # device=None
-    model.fit(real_data[:, :2048], max_iter=2, block_size=1024, seed=42)
+    with caplog.at_level(logging.WARNING, logger="pyAMICA.amica"):
+        model.fit(real_data[:, :2048], max_iter=2, block_size=1024, seed=42)
 
     # float64 parity runs must never land on MPS.
     assert model.model_.device.type in ("cpu", "cuda")
     if torch.backends.mps.is_available():
         assert model.model_.device.type == "cpu"
+        # The downgrade must be announced even with verbose=False (not silent).
+        assert any("float64" in r.message for r in caplog.records)
+
+
+def test_ng_explicit_mps_float64_raises(real_data):
+    """A user-pinned device="mps" with the default float64 must NOT be
+    silently coerced to CPU; it should surface AMICATorchNG's ValueError.
+    Raised at construction (before device placement), so no MPS hardware
+    is needed."""
+    model = AMICA(device="mps", verbose=False, backend="ng")
+    with pytest.raises(ValueError, match="MPS does not support float64"):
+        model.fit(real_data[:, :256], max_iter=1, block_size=128, seed=1)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="requires MPS hardware"
+)
+def test_ng_mps_float32_escape_hatch(real_data):
+    """The documented workaround: dtype=torch.float32 lets the NG backend run
+    on MPS."""
+    model = AMICA(device="mps", verbose=False, backend="ng")
+    model.fit(
+        real_data[:, :2048], max_iter=2, block_size=1024, seed=42, dtype=torch.float32
+    )
+    assert model.model_.device.type == "mps"
+    assert model.model_.dtype == torch.float32
 
 
 def test_ng_wrapper_fit_transform_real_data(fitted_ng, real_data):

--- a/pyAMICA/tests/torch_tests/test_amica_ng_wrapper.py
+++ b/pyAMICA/tests/torch_tests/test_amica_ng_wrapper.py
@@ -1,0 +1,100 @@
+"""Tests for the public ``AMICA`` wrapper driving ``backend="ng"``.
+
+These cover the wiring the wrapper adds on top of ``AMICATorchNG``: the
+constructor/fit guards, the save/load NotImplementedError, and the
+device-selection fallback that keeps the float64 NG default from crashing
+on Apple Silicon (MPS cannot represent float64). Real sample EEG data only
+(no synthetic/mock).
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from pyAMICA.amica import AMICA
+
+SAMPLE_DIR = Path(__file__).resolve().parents[2] / "sample_data"
+DATA_FILE = SAMPLE_DIR / "eeglab_data.fdt"
+NW = 32
+FIELD = 30504
+
+
+def _load_real_data() -> np.ndarray:
+    from pyAMICA.torch_impl.utils import load_eeglab_data
+
+    return load_eeglab_data(str(DATA_FILE), data_dim=NW, field_dim=FIELD).astype(
+        np.float64
+    )
+
+
+@pytest.fixture(scope="module")
+def real_data() -> np.ndarray:
+    if not DATA_FILE.exists():
+        pytest.skip("sample data missing")
+    return _load_real_data()
+
+
+@pytest.fixture(scope="module")
+def fitted_ng(real_data) -> AMICA:
+    """A small real-data NG fit reused across the fitted-model assertions."""
+    model = AMICA(n_models=1, n_mix=3, device="cpu", verbose=False, backend="ng")
+    model.fit(real_data[:, :4096], max_iter=3, block_size=1024, seed=42)
+    return model
+
+
+def test_backend_invalid_raises():
+    with pytest.raises(ValueError, match="backend must be"):
+        AMICA(backend="bogus")
+
+
+def test_ng_debug_guard(real_data):
+    model = AMICA(device="cpu", verbose=False, backend="ng")
+    with pytest.raises(ValueError, match="debug=True"):
+        model.fit(real_data[:, :256], max_iter=1, debug=True)
+
+
+def test_ng_output_dir_guard(real_data, tmp_path):
+    model = AMICA(device="cpu", verbose=False, backend="ng")
+    with pytest.raises(ValueError, match="output_dir"):
+        model.fit(real_data[:, :256], max_iter=1, output_dir=str(tmp_path))
+
+
+def test_ng_load_not_implemented(tmp_path):
+    model = AMICA(verbose=False, backend="ng")
+    with pytest.raises(NotImplementedError, match="load"):
+        model.load(str(tmp_path / "model.pt"))
+
+
+def test_ng_save_not_implemented(fitted_ng, tmp_path):
+    with pytest.raises(NotImplementedError, match="save"):
+        fitted_ng.save(str(tmp_path / "model.pt"))
+
+
+def test_ng_default_device_avoids_mps_float64(real_data):
+    """The default float64 NG config must not crash when the auto-selected
+    device is MPS; the wrapper falls back to CPU (regression for #29)."""
+    model = AMICA(n_models=1, n_mix=3, verbose=False, backend="ng")  # device=None
+    model.fit(real_data[:, :2048], max_iter=2, block_size=1024, seed=42)
+
+    # float64 parity runs must never land on MPS.
+    assert model.model_.device.type in ("cpu", "cuda")
+    if torch.backends.mps.is_available():
+        assert model.model_.device.type == "cpu"
+
+
+def test_ng_wrapper_fit_transform_real_data(fitted_ng, real_data):
+    assert fitted_ng.is_fitted_
+    assert len(fitted_ng.ll_history_) >= 1
+
+    S = fitted_ng.transform(real_data[:, :4096])
+    assert S.shape == (NW, 4096)
+    assert np.isfinite(S).all()
+
+    A = fitted_ng.get_mixing_matrix()
+    W = fitted_ng.get_unmixing_matrix()
+    assert A.shape == (NW, NW)
+    assert W.shape == (NW, NW)
+    assert np.isfinite(A).all()
+    assert np.isfinite(W).all()

--- a/pyAMICA/tests/torch_tests/test_torch_components.py
+++ b/pyAMICA/tests/torch_tests/test_torch_components.py
@@ -193,7 +193,8 @@ class TestGaussianMixtureICA(unittest.TestCase):
 
     @pytest.mark.xfail(
         reason="fit_em log-likelihood decreases across iterations, a genuine "
-        "M-step bug gated by epic #9 rewrite (not fixed in Phase 1)",
+        "M-step bug in the legacy mixture module (tracked in issue #31); the "
+        "epic delivered AMICATorchNG, which does not touch this module",
         strict=True,
         raises=AssertionError,
     )

--- a/pyAMICA/torch_impl/amica_torch_v2.py
+++ b/pyAMICA/torch_impl/amica_torch_v2.py
@@ -11,7 +11,8 @@ unstable Newton) is superseded by ``amica_torch_ng.AMICATorchNG``, the
 natural-gradient EM backend that now matches the Fortran reference (component
 correlation ~0.997 with Newton positive-definite and firing). ``AMICATorchV2`` is
 not wired into the public interface and is retained only for its adaptive-PDF
-prototype; do not build on it. New work belongs in ``AMICATorchNG``.
+prototype; do not build on it. New work belongs in ``AMICATorchNG``. Scheduled for
+removal once ``backend="ng"`` becomes the default (issue #32).
 """
 
 import torch


### PR DESCRIPTION
Closes #29. Applies the PR #28 (epic close-out) review findings into the epic so #28 carries them.

## Important
- Fix `AMICA(backend="ng")` crashing on its own default config on Apple Silicon: `fit()`
  auto-selected MPS, but `AMICATorchNG` defaults to float64 (Fortran parity), which MPS rejects.
  When the device is not pinned and resolves to MPS for a float64 NG run, fall back to CPU (CUDA is
  unaffected). Users can still opt into MPS with `dtype=torch.float32, device="mps"`.
- Add a real-data wrapper test for `backend="ng"` (`test_amica_ng_wrapper.py`): constructor guard,
  debug/output_dir guards, save/load `NotImplementedError`, the MPS->CPU device fallback, and a
  small real-data fit + transform/get_mixing/get_unmixing. No synthetic data.

## Doc coherence
- AGENTS.md: backend map now lists `amica_torch_ng.py` / `AMICATorchNG`; UV migration marked
  complete (matches `pyproject.toml`/`uv.lock`/plan.md); follow-ups linked.
- ADR `0001` accepted (+ README index) with an outcome note (issue #24 parity result).
- `FEATURE_PARITY.md` / `PROGRESS_SUMMARY.md`: replaced stale pre-epic metrics (~0.78 corr, ~13x
  LL) with the NG parity numbers (LL ~ -3.40, corr ~0.997); the "PyTorch" column is flagged as the
  pre-epic basic backend.
- Repointed the two `epic #9` xfail reasons to concrete issues (#30 legacy CLI save/load, #31
  legacy mixture M-step).

## Suggestions
- Re-export `AMICATorchNG` from `pyAMICA/__init__.py`; docstring `model_` notes both backends.

## Follow-up issues filed
- #26 adaptive PDF (NG), #27 multi-model partition matching, #30 legacy CLI save/load, #31 legacy
  mixture M-step, #32 remove parked `AMICATorchV2` + promote `backend="ng"` to default.

## Test plan
- [x] `uv run pytest pyAMICA/tests -m "not slow"` -> 61 passed, 2 xfailed
- [x] new wrapper tests -> 7 passed
- [x] `ruff check` / `ruff format` clean