### PR TITLE
Write CLI results in Fortran binary format (#30)

### DIFF
--- a/pyAMICA/amica_data.py
+++ b/pyAMICA/amica_data.py
@@ -9,7 +9,7 @@ algorithm. It handles:
    - Mean removal
    - Sphering (whitening) using PCA
    - Dimensionality reduction
-3. Result saving and loading with optional compression
+3. Loading saved results (raw Fortran binary format; see load_results)
 
 The preprocessing steps are crucial for AMICA's performance:
 - Mean removal centers the data, removing DC offset
@@ -194,96 +194,6 @@ def preprocess_data(
         sphere = np.eye(data_dim)
 
     return data, mean, sphere
-
-
-def save_results(
-    outdir: str,
-    A: np.ndarray,
-    W: np.ndarray,
-    c: np.ndarray,
-    mu: np.ndarray,
-    alpha: np.ndarray,
-    beta: np.ndarray,
-    rho: np.ndarray,
-    gm: np.ndarray,
-    mean: np.ndarray,
-    sphere: np.ndarray,
-    comp_list: np.ndarray,
-    ll: List[float],
-    nd: Optional[List[float]] = None,
-    compress: bool = False,
-):
-    """
-    Save AMICA results to disk.
-
-    Parameters
-    ----------
-    outdir : str
-        Output directory
-    A : ndarray
-        Mixing matrix
-    W : ndarray
-        Unmixing matrices
-    c : ndarray
-        Bias terms
-    mu : ndarray
-        Component means
-    alpha : ndarray
-        Mixture weights
-    beta : ndarray
-        Scale parameters
-    rho : ndarray
-        Shape parameters
-    gm : ndarray
-        Model weights
-    mean : ndarray
-        Data mean
-    sphere : ndarray
-        Sphering matrix
-    comp_list : ndarray
-        Component assignments
-    ll : list
-        Log likelihood history
-    nd : list, optional
-        Gradient norm history
-    compress : bool
-        Whether to compress saved files
-    """
-    outdir = Path(outdir)
-    if not outdir.exists():
-        outdir.mkdir(parents=True)
-
-    # Save parameters
-    params = {
-        "A": A,
-        "W": W,
-        "c": c,
-        "mu": mu,
-        "alpha": alpha,
-        "beta": beta,
-        "rho": rho,
-        "gm": gm,
-        "mean": mean,
-        "sphere": sphere,
-        "comp_list": comp_list,
-    }
-
-    for name, param in params.items():
-        if compress:
-            np.savez_compressed(outdir / f"{name}.npz", param)
-        else:
-            np.save(outdir / f"{name}.npy", param)
-
-    # Save optimization history
-    history = {"ll": np.array(ll)}
-    if nd is not None:
-        history["nd"] = np.array(nd)
-
-    for name, hist in history.items():
-        if compress:
-            np.savez_compressed(outdir / f"{name}.npz", hist)
-        else:
-            np.save(outdir / f"{name}.npy", hist)
 
 
 def load_results(indir: str, compressed: bool = False) -> dict:

--- a/pyAMICA/amica_data.py
+++ b/pyAMICA/amica_data.py
@@ -290,45 +290,81 @@ def load_results(indir: str, compressed: bool = False) -> dict:
     """
     Load saved AMICA results from disk.
 
+    Reads the raw little-endian binary files written by ``AMICA._write_results``
+    -- the Fortran AMICA output layout that ``amica_load.loadmodout`` and the
+    reference binary use (issue #30) -- and returns them in AMICA's internal
+    array shapes, which the ``amica_viz`` helpers consume.
+
     Parameters
     ----------
     indir : str
-        Input directory containing saved results
-    compressed : bool
-        Whether files are compressed
+        Input directory containing saved results.
+    compressed : bool, default=False
+        Accepted for call-site compatibility and ignored: the on-disk format is
+        uncompressed raw binary (issue #30), not ``.npz``.
 
     Returns
     -------
     results : dict
-        Dictionary of loaded parameters and history
+        Dictionary of loaded parameters (``A``, ``W``, ``c``, ``mu``, ``alpha``,
+        ``beta``, ``rho``, ``gm``, ``mean``, ``sphere``, ``comp_list``, ``ll``).
     """
+    del compressed  # legacy no-op; the format is raw binary, never .npz
     indir = Path(indir)
-    results = {}
 
-    # Parameter names to load
-    param_names = [
-        "A",
-        "W",
-        "c",
-        "mu",
-        "alpha",
-        "beta",
-        "rho",
-        "gm",
-        "mean",
-        "sphere",
-        "comp_list",
-        "ll",
-        "nd",
-    ]
+    def _read(name, dtype=np.float64):
+        path = indir / name
+        return np.fromfile(path, dtype=dtype) if path.exists() else None
 
-    # Load each parameter
-    for name in param_names:
-        filepath = indir / f"{name}.{'npz' if compressed else 'npy'}"
-        if filepath.exists():
-            if compressed:
-                results[name] = np.load(filepath)["arr_0"]
-            else:
-                results[name] = np.load(filepath)
+    gm = _read("gm")
+    if gm is None:
+        raise FileNotFoundError(f"No AMICA output in {indir} (missing 'gm')")
+    num_models = len(gm)
+
+    W = _read("W")
+    if W is None:
+        raise FileNotFoundError(f"No 'W' in {indir}")
+    nw = int(round(np.sqrt(len(W) / num_models)))
+    num_comps = nw * num_models
+
+    results = {"gm": gm, "W": W.reshape(nw, nw, num_models)}
+
+    A = _read("A")
+    if A is not None:
+        results["A"] = A.reshape(
+            len(A) // num_comps, num_comps
+        )  # (data_dim, num_comps)
+
+    # Mixture params are stored (num_mix, num_comps); Fortran names 'sbeta'.
+    for fname, key in (
+        ("alpha", "alpha"),
+        ("mu", "mu"),
+        ("sbeta", "beta"),
+        ("rho", "rho"),
+    ):
+        arr = _read(fname)
+        if arr is not None:
+            results[key] = arr.reshape(-1, num_comps)
+
+    comp_list = _read("comp_list", dtype=np.int32)
+    if comp_list is not None:
+        # Stored 1-based (Fortran convention); restore AMICA's 0-based indices.
+        results["comp_list"] = comp_list.reshape(nw, num_models) - 1
+
+    c = _read("c")
+    if c is not None:
+        results["c"] = c.reshape(nw, num_models)
+
+    mean = _read("mean")
+    if mean is not None:
+        results["mean"] = mean
+
+    S = _read("S")
+    if S is not None:
+        results["sphere"] = S.reshape(nw, nw)
+
+    ll = _read("LL")
+    if ll is not None:
+        results["ll"] = ll
 
     return results

--- a/pyAMICA/amica_data.py
+++ b/pyAMICA/amica_data.py
@@ -222,7 +222,7 @@ def load_results(indir: str, compressed: bool = False) -> dict:
     del compressed  # legacy no-op; the format is raw binary, never .npz
     indir = Path(indir)
 
-    def _read(name, dtype=np.float64):
+    def _read(name, dtype: type = np.float64):
         path = indir / name
         return np.fromfile(path, dtype=dtype) if path.exists() else None
 
@@ -276,5 +276,15 @@ def load_results(indir: str, compressed: bool = False) -> dict:
     ll = _read("LL")
     if ll is not None:
         results["ll"] = ll
+
+    # Fail loudly on a partially-written / interrupted output directory rather
+    # than letting a downstream KeyError surface deep in a viz helper.
+    required = {"A", "W", "alpha", "mu", "beta", "rho", "comp_list", "ll"}
+    missing = required - results.keys()
+    if missing:
+        raise FileNotFoundError(
+            f"Incomplete AMICA output in {indir}: missing {sorted(missing)}. "
+            "The directory may be from an interrupted or partial run."
+        )
 
     return results

--- a/pyAMICA/amica_viz.py
+++ b/pyAMICA/amica_viz.py
@@ -43,7 +43,7 @@ from .amica_data import load_results
 def plot_convergence(
     results_dir: Union[str, Path],
     figsize: Tuple[int, int] = (10, 5),
-    compressed: bool = False
+    compressed: bool = False,
 ) -> None:
     """
     Plot convergence metrics (likelihood and gradient norm).
@@ -63,19 +63,19 @@ def plot_convergence(
 
     # Plot log likelihood
     ax = axes[0]
-    ax.plot(results['ll'], 'b-')
-    ax.set_xlabel('Iteration')
-    ax.set_ylabel('Log Likelihood')
-    ax.set_title('Convergence: Log Likelihood')
+    ax.plot(results["ll"], "b-")
+    ax.set_xlabel("Iteration")
+    ax.set_ylabel("Log Likelihood")
+    ax.set_title("Convergence: Log Likelihood")
     ax.grid(True)
 
     # Plot gradient norm if available
-    if 'nd' in results:
+    if "nd" in results:
         ax = axes[1]
-        ax.plot(results['nd'], 'r-')
-        ax.set_xlabel('Iteration')
-        ax.set_ylabel('Gradient Norm')
-        ax.set_title('Convergence: Gradient Norm')
+        ax.plot(results["nd"], "r-")
+        ax.set_xlabel("Iteration")
+        ax.set_ylabel("Gradient Norm")
+        ax.set_title("Convergence: Gradient Norm")
         ax.grid(True)
 
     plt.tight_layout()
@@ -86,7 +86,7 @@ def plot_components(
     data: Optional[np.ndarray] = None,
     max_comps: int = 20,
     figsize: Optional[Tuple[int, int]] = None,
-    compressed: bool = False
+    compressed: bool = False,
 ) -> None:
     """
     Plot learned components and their activations.
@@ -107,7 +107,7 @@ def plot_components(
     results = load_results(results_dir, compressed)
 
     # Get number of components to plot
-    n_comps = min(results['A'].shape[1], max_comps)
+    n_comps = min(results["A"].shape[1], max_comps)
 
     if figsize is None:
         figsize = (12, 2 * n_comps)
@@ -118,20 +118,20 @@ def plot_components(
     for i in range(n_comps):
         # Plot mixing vector
         ax = axes[i, 0]
-        ax.plot(results['A'][:, i], 'b-')
-        ax.set_title(f'Component {i+1}: Mixing Vector')
-        ax.set_xlabel('Channel')
-        ax.set_ylabel('Weight')
+        ax.plot(results["A"][:, i], "b-")
+        ax.set_title(f"Component {i + 1}: Mixing Vector")
+        ax.set_xlabel("Channel")
+        ax.set_ylabel("Weight")
         ax.grid(True)
 
         # Plot activation if data provided
         if data is not None:
             ax = axes[i, 1]
-            activation = np.dot(results['W'][i, :, 0], data)
+            activation = np.dot(results["W"][i, :, 0], data)
             ax.hist(activation, bins=50, density=True)
-            ax.set_title(f'Component {i+1}: Activation Distribution')
-            ax.set_xlabel('Activation')
-            ax.set_ylabel('Density')
+            ax.set_title(f"Component {i + 1}: Activation Distribution")
+            ax.set_xlabel("Activation")
+            ax.set_ylabel("Density")
             ax.grid(True)
 
     plt.tight_layout()
@@ -142,7 +142,7 @@ def plot_model_comparison(
     data: np.ndarray,
     n_examples: int = 5,
     figsize: Optional[Tuple[int, int]] = None,
-    compressed: bool = False
+    compressed: bool = False,
 ) -> None:
     """
     Plot data reconstructions from different models.
@@ -163,7 +163,7 @@ def plot_model_comparison(
     results = load_results(results_dir, compressed)
 
     # Get reconstructions for each model
-    n_models = results['W'].shape[2]
+    n_models = results["W"].shape[2]
 
     if figsize is None:
         figsize = (12, 3 * n_examples)
@@ -177,10 +177,10 @@ def plot_model_comparison(
     for i, t in enumerate(times):
         # Plot original data
         ax = axes[i, 0]
-        ax.plot(data[:, t], 'k-')
-        ax.set_title('Original' if i == 0 else '')
-        ax.set_xlabel('Channel')
-        ax.set_ylabel('Value')
+        ax.plot(data[:, t], "k-")
+        ax.set_title("Original" if i == 0 else "")
+        ax.set_xlabel("Channel")
+        ax.set_ylabel("Value")
         ax.grid(True)
 
         # Plot reconstructions
@@ -188,21 +188,20 @@ def plot_model_comparison(
             ax = axes[i, h + 1]
 
             # Get reconstruction
-            S = np.dot(results['W'][:, :, h], data[:, t:t + 1])
-            X_hat = np.dot(results['A'][:, results['comp_list'][:, h]], S)
+            S = np.dot(results["W"][:, :, h], data[:, t : t + 1])
+            X_hat = np.dot(results["A"][:, results["comp_list"][:, h]], S)
 
-            ax.plot(X_hat, 'r-')
-            ax.plot(data[:, t], 'k--', alpha=0.5)
-            ax.set_title(f'Model {h+1}' if i == 0 else '')
-            ax.set_xlabel('Channel')
+            ax.plot(X_hat, "r-")
+            ax.plot(data[:, t], "k--", alpha=0.5)
+            ax.set_title(f"Model {h + 1}" if i == 0 else "")
+            ax.set_xlabel("Channel")
             ax.grid(True)
 
     plt.tight_layout()
 
 
 def plot_component_sharing(
-    results_dir: Union[str, Path],
-    compressed: bool = False
+    results_dir: Union[str, Path], compressed: bool = False
 ) -> None:
     """
     Plot component sharing matrix.
@@ -217,19 +216,19 @@ def plot_component_sharing(
     results = load_results(results_dir, compressed)
 
     # Create sharing matrix
-    n_models = results['comp_list'].shape[1]
-    n_comps = results['A'].shape[1]
+    n_models = results["comp_list"].shape[1]
+    n_comps = results["A"].shape[1]
     sharing = np.zeros((n_comps, n_models))
 
     for h in range(n_models):
-        sharing[results['comp_list'][:, h], h] = 1
+        sharing[results["comp_list"][:, h], h] = 1
 
     plt.figure(figsize=(8, 8))
-    plt.imshow(sharing, cmap='binary', aspect='auto')
+    plt.imshow(sharing, cmap="binary", aspect="auto")
     plt.colorbar()
-    plt.xlabel('Model')
-    plt.ylabel('Component')
-    plt.title('Component Sharing Matrix')
+    plt.xlabel("Model")
+    plt.ylabel("Component")
+    plt.title("Component Sharing Matrix")
     plt.grid(True)
     plt.tight_layout()
 
@@ -240,7 +239,7 @@ def plot_pdf_fits(
     max_comps: int = 10,
     n_points: int = 1000,
     figsize: Optional[Tuple[int, int]] = None,
-    compressed: bool = False
+    compressed: bool = False,
 ) -> None:
     """
     Plot PDF fits for each component.
@@ -260,12 +259,13 @@ def plot_pdf_fits(
     compressed : bool
         Whether results are compressed
     """
-    from amica_pdf import compute_pdf
+    from .amica_pdf import compute_pdf
+
     results = load_results(results_dir, compressed)
 
     # Get number of components to plot
-    n_comps = min(results['A'].shape[1], max_comps)
-    n_mix = results['alpha'].shape[0]
+    n_comps = min(results["A"].shape[1], max_comps)
+    n_mix = results["alpha"].shape[0]
 
     if figsize is None:
         figsize = (12, 3 * n_comps)
@@ -275,13 +275,13 @@ def plot_pdf_fits(
         axes = [axes]
 
     # Get activations
-    S = np.dot(results['W'][:, :, 0], data)
+    S = np.dot(results["W"][:, :, 0], data)
 
     for i in range(n_comps):
         ax = axes[i]
 
         # Plot activation histogram
-        ax.hist(S[i, :], bins=50, density=True, alpha=0.5, label='Data')
+        ax.hist(S[i, :], bins=50, density=True, alpha=0.5, label="Data")
 
         # Plot fitted PDFs
         x = np.linspace(S[i, :].min(), S[i, :].max(), n_points)
@@ -289,24 +289,29 @@ def plot_pdf_fits(
 
         for j in range(n_mix):
             # Get mixture parameters
-            alpha = results['alpha'][j, i]
-            mu = results['mu'][j, i]
-            beta = results['beta'][j, i]
-            rho = results['rho'][j, i]
+            alpha = results["alpha"][j, i]
+            mu = results["mu"][j, i]
+            beta = results["beta"][j, i]
+            rho = results["rho"][j, i]
 
             # Compute PDF
             y = beta * (x - mu)
             pdf, _ = compute_pdf(y, rho)
             pdf = alpha * beta * pdf
 
-            ax.plot(x, pdf, '--', alpha=0.5,
-                    label=f'Mix {j+1} (α={alpha:.2f}, ρ={rho:.2f})')
+            ax.plot(
+                x,
+                pdf,
+                "--",
+                alpha=0.5,
+                label=f"Mix {j + 1} (α={alpha:.2f}, ρ={rho:.2f})",
+            )
             pdf_total += pdf
 
-        ax.plot(x, pdf_total, 'r-', label='Total')
-        ax.set_title(f'Component {i+1}: PDF Fit')
-        ax.set_xlabel('Activation')
-        ax.set_ylabel('Density')
+        ax.plot(x, pdf_total, "r-", label="Total")
+        ax.set_title(f"Component {i + 1}: PDF Fit")
+        ax.set_xlabel("Activation")
+        ax.set_ylabel("Density")
         ax.legend()
         ax.grid(True)
 
@@ -317,7 +322,7 @@ def create_report(
     results_dir: Union[str, Path],
     data: Optional[np.ndarray] = None,
     output_file: Optional[str] = None,
-    compressed: bool = False
+    compressed: bool = False,
 ) -> None:
     """
     Create comprehensive visualization report combining all analysis plots.
@@ -344,7 +349,8 @@ def create_report(
     """
     if output_file is not None:
         import matplotlib
-        matplotlib.use('Agg')
+
+        matplotlib.use("Agg")
 
     # Create figure
     plt.figure(figsize=(15, 10))

--- a/pyAMICA/amica_viz.py
+++ b/pyAMICA/amica_viz.py
@@ -55,7 +55,8 @@ def plot_convergence(
     figsize : tuple
         Figure size (width, height)
     compressed : bool
-        Whether results are compressed
+        Legacy no-op kept for signature compatibility; results are read from the
+        raw Fortran binary format, never compressed .npz (issue #30).
     """
     results = load_results(results_dir, compressed)
 
@@ -102,7 +103,8 @@ def plot_components(
     figsize : tuple
         Figure size (width, height)
     compressed : bool
-        Whether results are compressed
+        Legacy no-op kept for signature compatibility; results are read from the
+        raw Fortran binary format, never compressed .npz (issue #30).
     """
     results = load_results(results_dir, compressed)
 
@@ -158,7 +160,8 @@ def plot_model_comparison(
     figsize : tuple
         Figure size (width, height)
     compressed : bool
-        Whether results are compressed
+        Legacy no-op kept for signature compatibility; results are read from the
+        raw Fortran binary format, never compressed .npz (issue #30).
     """
     results = load_results(results_dir, compressed)
 
@@ -211,7 +214,8 @@ def plot_component_sharing(
     results_dir : str or Path
         Directory containing results
     compressed : bool
-        Whether results are compressed
+        Legacy no-op kept for signature compatibility; results are read from the
+        raw Fortran binary format, never compressed .npz (issue #30).
     """
     results = load_results(results_dir, compressed)
 
@@ -257,7 +261,8 @@ def plot_pdf_fits(
     figsize : tuple
         Figure size (width, height)
     compressed : bool
-        Whether results are compressed
+        Legacy no-op kept for signature compatibility; results are read from the
+        raw Fortran binary format, never compressed .npz (issue #30).
     """
     from .amica_pdf import compute_pdf
 
@@ -345,7 +350,8 @@ def create_report(
     output_file : str, optional
         Output file path (if None, show plots)
     compressed : bool
-        Whether results are compressed
+        Legacy no-op kept for signature compatibility; results are read from the
+        raw Fortran binary format, never compressed .npz (issue #30).
     """
     if output_file is not None:
         import matplotlib

--- a/pyAMICA/pyAMICA.py
+++ b/pyAMICA/pyAMICA.py
@@ -1170,27 +1170,50 @@ class AMICA:
         self.logger.info(f"Rejected {np.sum(outliers)} samples")
 
     def _write_results(self):
-        """Write current results to disk."""
+        """Write current results to disk in the Fortran AMICA binary format.
+
+        Writes raw little-endian float64 (and int32 ``comp_list``) files with no
+        extension, matching the byte layout that ``amica_load.loadmodout`` reads
+        and that the Fortran reference (``amicaout``) writes. This makes pyAMICA
+        output directly comparable to, and loadable by the same reader as, the
+        Fortran reference (issue #30). ``load_results`` reads this format back.
+        """
         if not self.outdir.exists():
             self.outdir.mkdir(parents=True)
 
-        # Save parameters
-        np.save(self.outdir / "A.npy", self.A)
-        np.save(self.outdir / "W.npy", self.W)
-        np.save(self.outdir / "c.npy", self.c)
-        np.save(self.outdir / "mu.npy", self.mu)
-        np.save(self.outdir / "alpha.npy", self.alpha)
-        np.save(self.outdir / "beta.npy", self.beta)
-        np.save(self.outdir / "rho.npy", self.rho)
-        np.save(self.outdir / "gm.npy", self.gm)
-        np.save(self.outdir / "mean.npy", self.mean)
-        np.save(self.outdir / "sphere.npy", self.sphere)
-        np.save(self.outdir / "comp_list.npy", self.comp_list)
+        def _w(name, arr, dtype=np.float64):
+            np.ascontiguousarray(arr, dtype=dtype).tofile(self.outdir / name)
 
-        # Save optimization history
-        np.save(self.outdir / "ll.npy", self.ll)
-        if self.use_grad_norm:
-            np.save(self.outdir / "nd.npy", self.nd)
+        # gm: (num_models,)
+        _w("gm", self.gm)
+        # A: mixing matrix (data_dim, num_comps). Not part of the Fortran output
+        # (loadmodout derives A from W and S), but written here so load_results
+        # can restore it directly for the viz helpers; loadmodout ignores it.
+        _w("A", self.A)
+        # W: internal (nw, nw, num_models); a C-order dump matches the Fortran
+        # 'W' byte layout (the internal-vs-true-unmixing transpose of issue #24
+        # cancels against Fortran's column-major storage).
+        _w("W", self.W)
+        # Sphering and mean.
+        _w("S", self.sphere)
+        _w("mean", self.mean)
+        # Per-model bias: (nw, num_models).
+        _w("c", self.c)
+        # Mixture params: (num_mix, num_comps). loadmodout maps columns to
+        # sources via comp_list, so column order is the component index.
+        _w("alpha", self.alpha)
+        _w("mu", self.mu)
+        _w("sbeta", self.beta)  # Fortran's 'sbeta' is pyAMICA's beta (scale)
+        _w("rho", self.rho)
+        # comp_list is 1-based in the Fortran format (loadmodout subtracts 1
+        # when indexing); pyAMICA stores it 0-based.
+        _w("comp_list", self.comp_list + 1, dtype=np.int32)
+        # Log-likelihood history (per iteration).
+        _w("LL", np.asarray(self.ll))
+        # Note: the Fortran 'nd' file is a per-component weight-change history
+        # (max_iter, nw, num_models); pyAMICA's self.nd is a per-iteration
+        # gradient-norm scalar, a different quantity, so it is not emitted in
+        # the Fortran format (loadmodout treats 'nd' as optional).
 
     def _write_history(self):
         """Write optimization history at current iteration."""

--- a/pyAMICA/pyAMICA.py
+++ b/pyAMICA/pyAMICA.py
@@ -407,6 +407,15 @@ class AMICA:
         # Main optimization loop
         self._optimize()
 
+        # Always persist the final converged result. _write_results is otherwise
+        # only called on writestep boundaries during the loop, so a run whose
+        # last iteration is not a writestep multiple (or that stops early) would
+        # never save the final state. Guard on a finite likelihood so a run that
+        # diverged to a non-finite LL (issue #39) does not overwrite the last
+        # good on-disk result with NaNs.
+        if len(self.ll) > 0 and np.isfinite(self.ll[-1]):
+            self._write_results()
+
         return self
 
     def _preprocess_data(self, data: np.ndarray):
@@ -1173,10 +1182,18 @@ class AMICA:
         """Write current results to disk in the Fortran AMICA binary format.
 
         Writes raw little-endian float64 (and int32 ``comp_list``) files with no
-        extension, matching the byte layout that ``amica_load.loadmodout`` reads
-        and that the Fortran reference (``amicaout``) writes. This makes pyAMICA
-        output directly comparable to, and loadable by the same reader as, the
-        Fortran reference (issue #30). ``load_results`` reads this format back.
+        extension, in the layout that ``amica_load.loadmodout`` reads (and that
+        ``load_results`` reads back), so pyAMICA output is loadable by the same
+        reader as the Fortran reference (issue #30).
+
+        For ``num_models == 1`` (the CLI/sample-data case) the bytes are
+        identical to the Fortran ``amicaout`` ``W``/``c``/``comp_list`` files, so
+        the two are directly comparable. For ``num_models > 1`` the per-model
+        axis nesting differs from genuine Fortran column-major storage: the
+        output stays self-consistent (``loadmodout``/``load_results`` recover it
+        losslessly, matching ``loadmodout``'s own C-order model-axis convention),
+        but is not byte-identical to multi-model Fortran output. Multi-model
+        Fortran interop is out of scope here (see #27).
         """
         if not self.outdir.exists():
             self.outdir.mkdir(parents=True)
@@ -1190,9 +1207,11 @@ class AMICA:
         # (loadmodout derives A from W and S), but written here so load_results
         # can restore it directly for the viz helpers; loadmodout ignores it.
         _w("A", self.A)
-        # W: internal (nw, nw, num_models); a C-order dump matches the Fortran
-        # 'W' byte layout (the internal-vs-true-unmixing transpose of issue #24
-        # cancels against Fortran's column-major storage).
+        # W: internal (nw, nw, num_models). For a single model the C-order dump
+        # is byte-identical to Fortran's 'W' (the internal-vs-true-unmixing
+        # transpose of issue #24 cancels against Fortran's column-major storage);
+        # for num_models>1 only the model-axis nesting differs (see the docstring
+        # note), and loadmodout reads it back with the matching C-order.
         _w("W", self.W)
         # Sphering and mean.
         _w("S", self.sphere)

--- a/pyAMICA/tests/test_sample_data.py
+++ b/pyAMICA/tests/test_sample_data.py
@@ -58,6 +58,15 @@ def test_sample_data_scikit(tmp_path):
 
 
 @pytest.mark.slow
+@pytest.mark.xfail(
+    reason="The #30 CLI save/load format mismatch is FIXED -- loadmodout now "
+    "reads the CLI output (covered by test_cli_output_format_roundtrip). This "
+    "full 2000-iter CLI run still fails because the NumPy backend diverges to a "
+    "non-finite likelihood ~iter 687 on the sample data (a separate long-fit "
+    "numerical-stability bug, issue #39); the early-stopped result no longer "
+    "matches Fortran.",
+    strict=True,
+)
 def test_sample_data_cli():
     """Test pyAMICA using CLI interface."""
     import subprocess

--- a/pyAMICA/tests/test_sample_data.py
+++ b/pyAMICA/tests/test_sample_data.py
@@ -58,16 +58,6 @@ def test_sample_data_scikit(tmp_path):
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(
-    reason="legacy AMICA._optimize() writes results as .npy files "
-    "(save_results in pyAMICA.py) but loadmodout() expects raw "
-    "Fortran-format binary files with no extension; the round-trip "
-    "raises FileNotFoundError for 'W' before the correlation check is "
-    "even reached. Independent legacy-CLI bug tracked in issue #30; no "
-    "raises= constraint since the failure mode is not a clean "
-    "AssertionError.",
-    strict=True,
-)
 def test_sample_data_cli():
     """Test pyAMICA using CLI interface."""
     import subprocess
@@ -215,6 +205,57 @@ def test_sample_data_numpy_vs_fortran(tmp_path):
     rows, cols = linear_sum_assignment(1 - corr)
     mean_corr = float(corr[rows, cols].mean())
     assert mean_corr > 0.9, f"NumPy vs Fortran component corr {mean_corr:.3f} <= 0.9"
+
+
+@pytest.mark.skipif(not op.exists(eeglab_data_file), reason="sample data missing")
+def test_cli_output_format_roundtrip(tmp_path):
+    """The Fortran-format writer round-trips through loadmodout and load_results,
+    and the viz helpers consume the result (issue #30; viz smoke for #15).
+
+    Real sample data, short fit -- this checks the on-disk format contract and
+    array shapes, not convergence (the full CLI-vs-Fortran correlation is
+    test_sample_data_cli). Fast, so not marked slow.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    from pyAMICA.amica_data import load_results
+    from pyAMICA import amica_viz
+
+    data = load_data_file(eeglab_data_file, 32, 30504, dtype=np.float32).astype(
+        np.float64
+    )[:, :4096]
+    outdir = tmp_path / "out"
+    model = AMICA(
+        use_tqdm=False,
+        num_models=1,
+        num_mix=3,
+        seed=1,
+        max_iter=15,
+        writestep=10000,
+        do_opt_block=False,
+        outdir=str(outdir),
+    )
+    model.fit(data)
+    model._write_results()
+
+    # loadmodout reads the Fortran-format output. Before issue #30 the CLI wrote
+    # .npy, so this raised FileNotFoundError for 'W'.
+    out = loadmodout(outdir)
+    assert out.W.shape == (32, 32, 1)
+
+    # load_results returns AMICA's internal shapes for the viz helpers.
+    r = load_results(str(outdir))
+    assert r["A"].shape == (32, 32)
+    assert r["W"].shape == (32, 32, 1)
+    assert r["alpha"].shape == (3, 32)
+    assert r["comp_list"].shape == (32, 1)
+    assert int(r["comp_list"].min()) == 0 and int(r["comp_list"].max()) == 31
+
+    # viz helpers run without error on the loaded results.
+    amica_viz.plot_convergence(str(outdir))
+    amica_viz.plot_components(str(outdir), data=None, max_comps=3)
+    amica_viz.plot_pdf_fits(str(outdir), data, max_comps=2)
 
 
 if __name__ == "__main__":

--- a/pyAMICA/tests/test_sample_data.py
+++ b/pyAMICA/tests/test_sample_data.py
@@ -245,8 +245,9 @@ def test_cli_output_format_roundtrip(tmp_path):
         do_opt_block=False,
         outdir=str(outdir),
     )
+    # fit() persists the final result even though max_iter (15) is not a
+    # writestep (10000) multiple -- exercises the unconditional final write.
     model.fit(data)
-    model._write_results()
 
     # loadmodout reads the Fortran-format output. Before issue #30 the CLI wrote
     # .npy, so this raised FileNotFoundError for 'W'.
@@ -261,10 +262,68 @@ def test_cli_output_format_roundtrip(tmp_path):
     assert r["comp_list"].shape == (32, 1)
     assert int(r["comp_list"].min()) == 0 and int(r["comp_list"].max()) == 31
 
+    # Value-level round-trip: the loaded arrays equal the in-memory ones. Guards
+    # against a transpose/axis-order or dtype regression that the shape checks
+    # above would miss.
+    np.testing.assert_allclose(r["W"], model.W)
+    np.testing.assert_allclose(r["A"], model.A)
+    np.testing.assert_allclose(r["alpha"], model.alpha)
+    np.testing.assert_array_equal(r["comp_list"], model.comp_list)
+
     # viz helpers run without error on the loaded results.
     amica_viz.plot_convergence(str(outdir))
     amica_viz.plot_components(str(outdir), data=None, max_comps=3)
     amica_viz.plot_pdf_fits(str(outdir), data, max_comps=2)
+
+
+@pytest.mark.skipif(not op.exists(eeglab_data_file), reason="sample data missing")
+def test_cli_subprocess_output_loadable(tmp_path):
+    """The actual amica_cli entrypoint writes loadmodout-readable output.
+
+    Runs the CLI as a module on a short, stable config (real sample data) and
+    confirms loadmodout reads the result -- the direct regression for the #30
+    FileNotFoundError (the CLI previously wrote .npy). Kept short (few
+    iterations, Newton off) so it stays fast and avoids the separate long-fit
+    NaN of #39; the full 2000-iter integration run is test_sample_data_cli.
+    """
+    import json
+    import subprocess
+    import sys
+
+    params = {
+        "files": [eeglab_data_file],
+        "data_dim": 32,
+        "field_dim": [30504],
+        "num_models": 1,
+        "num_mix": 3,
+        "max_iter": 8,
+        "writestep": 4,
+        "do_newton": False,
+        "do_opt_block": False,
+        "block_size": 512,
+    }
+    params_file = tmp_path / "params.json"
+    params_file.write_text(json.dumps(params))
+    outdir = tmp_path / "cli_out"
+
+    # amica_cli uses relative imports, so run it as a module from the repo root.
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pyAMICA.amica_cli",
+            str(params_file),
+            "--outdir",
+            str(outdir),
+        ],
+        check=True,
+        cwd=Path(__file__).parent.parent.parent,
+    )
+
+    # loadmodout reads the CLI output (previously raised FileNotFoundError).
+    out = loadmodout(outdir)
+    assert out.W.shape == (32, 32, 1)
+    assert np.all(np.isfinite(out.W))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
The legacy NumPy CLI wrote results as `.npy`, but `loadmodout` (and the tests/comparison path) expect raw Fortran-format binaries with no extension, so the round-trip raised `FileNotFoundError` for `W`. This converges pyAMICA on the single Fortran-binary format.

## Changes
- **`AMICA._write_results`** now writes raw little-endian float64 (int32 `comp_list`) files (`gm, A, W, S, mean, c, alpha, mu, sbeta, rho, comp_list, LL`) in `loadmodout`'s byte layout, so pyAMICA output is directly comparable to and loadable by the same reader as the Fortran `amicaout`. `comp_list` is written 1-based (Fortran convention).
- **`load_results`** now reads that raw-binary format back into AMICA's internal array shapes for the `amica_viz` helpers (the `compressed` flag is a documented no-op; the format is never `.npz`).
- Removed the dead `amica_data.save_results` (`.npy`/`.npz` writer, no callers) to finish converging on one format.
- Fixed a pre-existing broken import in `amica_viz.plot_pdf_fits` (`from amica_pdf` → `from .amica_pdf`).
- Added a fast, non-slow smoke test `test_cli_output_format_roundtrip` covering the format round-trip (`loadmodout` + `load_results` shapes) and all three viz helpers on real data (also viz coverage toward #15).

## Verification
- Round-trip: fit → `_write_results` → `loadmodout` Hungarian-matches the Fortran reference `W` at **min corr 0.95 / 32-of-32 bijective** (150-iter fit; the full run is higher).
- New smoke test passes (2.4s); non-slow suite green (33 passed, 1 xfailed).

## Honest status on `test_sample_data_cli`
The #30 format bug is fixed, but I kept `test_sample_data_cli` (the full 2000-iter CLI-vs-Fortran integration test) `xfail`: with the format fixed it now gets past the load step, but the **NumPy backend diverges to a non-finite likelihood ~iter 687** on the sample data and stops early, so the degraded result no longer matches Fortran. That is a **separate long-fit numerical-stability bug**, filed as **#39** (the torch `AMICATorchNG` default backend is unaffected; the NumPy backend is stable and matches Fortran at ~150 iters per the #37 parity test). The xfail reason now points at #39, and the format contract itself is covered by the new smoke test.

## Related
- Closes #30.
- Files #39 (NumPy long-fit NaN instability).