### PR TITLE
Ratchet the learning rate on LL decrease (#41)

### DIFF
--- a/pyAMICA/pyAMICA.py
+++ b/pyAMICA/pyAMICA.py
@@ -205,6 +205,9 @@ class AMICA:
         self.pcadb = params.get("pcadb")
         self.writestep = params.get("writestep", 100)
         self.max_decs = params.get("max_decs", 5)
+        # Consecutive small-increase iterations tolerated before stopping
+        # (Fortran maxincs, amica17.f90:1087).
+        self.maxincs = params.get("maxincs", 5)
         # Restart-on-NaN (Fortran amica17.f90:1027-1060): if the LL goes
         # non-finite at iter <= restartiter, reinitialize and start over, up to
         # maxrestarts times; a later NaN stops the fit (Fortran exits too).
@@ -1114,11 +1117,19 @@ class AMICA:
                         if self.verbose or not self.use_tqdm:
                             self.logger.info(detailed_log)
 
-                # Check convergence
-                converged, reason = self._check_convergence(numdecs, numincs)
+                # Check convergence (threads numdecs/numincs back so they
+                # accumulate across iterations, and ratchets the lrate ceiling).
+                converged, reason, numdecs, numincs = self._check_convergence(
+                    numdecs, numincs
+                )
                 if converged:
                     convergence_reason = reason
                     break
+
+                # Reset the decrease counter when Newton turns on (Fortran
+                # amica17.f90:1105-1108).
+                if self.do_newton and iter == self.newt_start:
+                    numdecs = 0
 
                 # Reject outliers if requested
                 if (
@@ -1181,61 +1192,106 @@ class AMICA:
 
     def _check_convergence(
         self, numdecs: int, numincs: int
-    ) -> Tuple[bool, Optional[str]]:
+    ) -> Tuple[bool, Optional[str], int, int]:
         """
-        Check convergence criteria.
+        Check convergence criteria and ratchet the learning rate.
+
+        Mirrors Fortran's per-iteration convergence handling
+        (amica17.f90:1062-1103). On a likelihood decrease Fortran does NOT stop
+        at ``maxdecs``; it lowers the learning-rate *ceiling* (``lrate0``, and
+        ``newtrate``/``rholrate0`` under Newton) and continues, which is what
+        keeps a long run from oscillating and drifting past its converged
+        solution (issue #41). The updated ``numdecs``/``numincs`` counters are
+        returned so they accumulate across iterations (they previously did not).
 
         Parameters
         ----------
         numdecs : int
-            Number of consecutive likelihood decreases
+            Consecutive-decrease counter (Fortran ``numdecs``).
         numincs : int
-            Number of consecutive small likelihood increases
+            Consecutive small-increase counter (Fortran ``numincs``).
 
         Returns
         -------
         converged : bool
-            True if optimization should stop
+            True if optimization should stop.
         reason : str or None
-            Reason for convergence if converged, None otherwise
+            Reason for stopping, or None.
+        numdecs, numincs : int
+            The updated counters (must be threaded back into the loop).
         """
         if len(self.ll) == 0:
-            return False, None
+            return False, None, numdecs, numincs
 
         # Check for non-finite LL: a singular W makes logdet -> -inf (not NaN),
         # so guard on isfinite, not isnan alone, or a degenerate model would run
         # to max_iter undetected.
         if not np.isfinite(self.ll[-1]):
-            return True, "Non-finite likelihood (NaN/-inf) encountered"
+            return (
+                True,
+                "Non-finite likelihood (NaN/-inf) encountered",
+                numdecs,
+                numincs,
+            )
 
         # The remaining checks compare consecutive iterations; skip until there
         # are two LL values -- the first iteration, or the first iteration after
         # a restart cleared the LL history (guard on len, not self.iter, which
         # keeps counting across restarts).
         if len(self.ll) < 2:
-            return False, None
+            return False, None, numdecs, numincs
 
-        # Check for likelihood decrease
+        grad_norm = self.nd[-1] if (self.use_grad_norm and len(self.nd) > 0) else None
+
+        # Likelihood decrease (Fortran amica17.f90:1062-1083): reduce the current
+        # lrate, and once maxdecs decreases have accrued, ratchet the ceiling
+        # (lrate0, plus newtrate/rholrate0 under Newton) down and continue --
+        # NOT stop. Only a lrate/gradient floor terminates on a decrease.
         if self.ll[-1] < self.ll[-2]:
-            numdecs += 1
-            if self.lrate <= self.minlrate or numdecs >= self.max_decs:
-                return True, "Converged due to likelihood decrease"
+            if self.lrate <= self.minlrate or (
+                grad_norm is not None and grad_norm <= self.min_grad_norm
+            ):
+                return (
+                    True,
+                    "Converged: minimum change threshold met",
+                    numdecs,
+                    numincs,
+                )
             self.lrate *= self.lratefact
+            self.rholrate *= self.rholratefact
+            numdecs += 1
+            if numdecs >= self.max_decs:
+                self.lrate0 *= self.lratefact
+                if self.iter > self.newt_start:
+                    self.rholrate0 *= self.rholratefact
+                if self.do_newton and self.iter > self.newt_start:
+                    self.newtrate *= self.lratefact
+                numdecs = 0
 
-        # Check for small likelihood increase
+        # Small likelihood increase (Fortran :1084-1096): stop after maxincs
+        # consecutive tiny gains; reset on any larger gain.
         if self.use_min_dll:
             if self.ll[-1] - self.ll[-2] < self.min_dll:
                 numincs += 1
-                if numincs > self.max_decs:
-                    return True, "Converged due to small likelihood increase"
+                if numincs > self.maxincs:
+                    return (
+                        True,
+                        "Converged: small likelihood increase",
+                        numdecs,
+                        numincs,
+                    )
             else:
                 numincs = 0
 
-        # Check gradient norm
-        if self.use_grad_norm and self.nd[-1] < self.min_grad_norm:
-            return True, "Converged due to small gradient norm"
+        # Gradient-norm floor (Fortran :1097-1103).
+        if (
+            self.use_grad_norm
+            and grad_norm is not None
+            and grad_norm <= self.min_grad_norm
+        ):
+            return True, "Converged: small gradient norm", numdecs, numincs
 
-        return False, None
+        return False, None, numdecs, numincs
 
     def _reject_outliers(self):
         """Reject outlier data points based on likelihood."""

--- a/pyAMICA/pyAMICA.py
+++ b/pyAMICA/pyAMICA.py
@@ -1006,12 +1006,14 @@ class AMICA:
         # Store likelihood
         self.ll.append(updates["ll"])
 
-        # Compute gradient norm
-        if self.use_grad_norm:
-            dA = np.zeros_like(self.A)
-            for h in range(self.num_models):
-                dA[:, self.comp_list[:, h]] += self.gm[h] * updates["dWtmp"][:, :, h]
-            self.nd.append(np.sqrt(np.sum(dA**2) / (self.data_dim * self.num_comps)))
+        # Compute the weight-gradient norm every iteration (Fortran's ndtmpsum
+        # is always computed). _check_convergence uses it as the gradient floor
+        # in the decrease-stop condition regardless of use_grad_norm; the flag
+        # only gates the separate final gradient-norm stop.
+        dA = np.zeros_like(self.A)
+        for h in range(self.num_models):
+            dA[:, self.comp_list[:, h]] += self.gm[h] * updates["dWtmp"][:, :, h]
+        self.nd.append(np.sqrt(np.sum(dA**2) / (self.data_dim * self.num_comps)))
 
     def _optimize(self):
         """Main optimization loop."""
@@ -1241,7 +1243,10 @@ class AMICA:
         if len(self.ll) < 2:
             return False, None, numdecs, numincs
 
-        grad_norm = self.nd[-1] if (self.use_grad_norm and len(self.nd) > 0) else None
+        # Gradient norm is computed every iteration, so it is the decrease-stop
+        # floor unconditionally (Fortran's ndtmpsum); use_grad_norm only gates
+        # the separate final gradient-norm stop below.
+        grad_norm = self.nd[-1] if len(self.nd) > 0 else None
 
         # Likelihood decrease (Fortran amica17.f90:1062-1083): reduce the current
         # lrate, and once maxdecs decreases have accrued, ratchet the ceiling

--- a/pyAMICA/tests/test_sample_data.py
+++ b/pyAMICA/tests/test_sample_data.py
@@ -374,6 +374,43 @@ def test_restart_gives_up_after_maxrestarts(tmp_path):
     assert not np.isfinite(model.ll[-1])
 
 
+def test_check_convergence_ratchets_lrate_on_decrease():
+    """After max_decs consecutive LL decreases, _check_convergence lowers the
+    learning-rate ceiling (lrate0, and newtrate under Newton) and resets numdecs
+    -- it does NOT stop -- matching Fortran's ratchet (#41). Drives the
+    convergence handler directly with a decreasing LL history.
+    """
+    model = AMICA(
+        num_models=1,
+        num_mix=3,
+        do_newton=True,
+        newt_start=10,
+        max_decs=2,
+        lratefact=0.5,
+        use_grad_norm=False,
+        use_min_dll=False,
+    )
+    model.iter = 100  # past newt_start, so the Newton-rate ratchet applies
+    model.nd = [1.0]  # gradient norm well above min_grad_norm (no floor stop)
+    lrate0_before = model.lrate0
+    newtrate_before = model.newtrate
+
+    # First decrease: numdecs -> 1 (below max_decs), so just reduce lrate.
+    model.ll = [-3.0, -3.1]
+    conv, _, numdecs, numincs = model._check_convergence(0, 0)
+    assert conv is False
+    assert numdecs == 1
+
+    # Second consecutive decrease: numdecs hits max_decs=2 -> ratchet ceilings,
+    # reset numdecs, and CONTINUE (not converged).
+    model.ll = [-3.1, -3.2]
+    conv, _, numdecs, numincs = model._check_convergence(numdecs, 0)
+    assert conv is False
+    assert numdecs == 0
+    assert model.lrate0 == lrate0_before * 0.5
+    assert model.newtrate == newtrate_before * 0.5
+
+
 @pytest.mark.skipif(not op.exists(eeglab_data_file), reason="sample data missing")
 def test_cli_subprocess_output_loadable(tmp_path):
     """The actual amica_cli entrypoint writes loadmodout-readable output.

--- a/pyAMICA/tests/test_sample_data.py
+++ b/pyAMICA/tests/test_sample_data.py
@@ -59,26 +59,28 @@ def test_sample_data_scikit(tmp_path):
 
 @pytest.mark.slow
 @pytest.mark.xfail(
-    reason="Progress, not passing: the #30 format bug is fixed (loadmodout reads "
-    "the CLI output) and the #39 NaN is handled (pinned seed=0 + restart-on-NaN "
-    "complete all 2000 iters with a finite LL, no early stop). The remaining "
-    "failure is the #41 long-run drift: at ~150 iters seed=0 matches Fortran "
-    "32/32 (min corr 0.92), but by 2000 iters the LL degrades (-3.404 -> -3.409) "
-    "and some component correlations drop below the 0.8 gate. Un-xfail once #41 "
-    "(long-run convergence-schedule parity) is fixed.",
+    reason="Progress, not passing. Fixed: the #30 format, the #39 NaN (seed pin + "
+    "restart), and the #41 LL degradation -- the lrate-ceiling ratchet "
+    "(_check_convergence) now keeps the long run improving (seed=0 LL -3.399 at "
+    "2000 iters, better than the ~150-iter -3.404 and Fortran's -3.402; 150-iter "
+    "mean-corr parity preserved). Remaining: this test's strict all-32-components "
+    ">0.8 gate still fails (~27/32) because pyAMICA converges to a comparable/"
+    "slightly-better-LL but different-partition solution than the Fortran "
+    "reference on a few ill-determined components -- a solution-basin difference "
+    "(cf. the single-model tail of #27), not a drift. The project's other parity "
+    "test (test_sample_data_numpy_vs_fortran) uses the more appropriate mean>0.9 "
+    "bar and passes.",
     strict=True,
 )
 def test_sample_data_cli():
     """Full CLI-vs-Fortran integration test (issue #30 format + #39/#41 stability).
 
     Runs the real amica_cli entrypoint for the full 2000-iter sample config and
-    Hungarian-matches the loadmodout-read W against the Fortran reference. A
-    fixed seed is pinned: the NumPy backend can diverge to a non-finite
-    likelihood on unlucky random inits (a stochastic instability shared with
-    Fortran, which restarts early NaNs and exits late ones; #39), so an
-    integration test must not depend on a random draw. seed=0 is a stable basin
-    that finishes 2000 iters; the restart-on-NaN mechanism (#39) additionally
-    recovers early NaNs. Currently xfail on the #41 long-run drift (see above).
+    Hungarian-matches the loadmodout-read W against the Fortran reference with a
+    strict all-32-components > 0.8 gate. A fixed seed is pinned so the test does
+    not depend on a random init (see #39). Currently xfail on a residual
+    solution-basin difference (see the xfail reason above); the LL-degradation
+    drift itself is fixed (#41).
     """
     import subprocess
     import sys


### PR DESCRIPTION
## Summary
The NumPy long fit degraded past ~150 iters (LL decreasing, component match dropping) because pyAMICA's convergence handling diverged from Fortran in two ways:

1. **`numdecs`/`numincs` never accumulated.** `_check_convergence` incremented them locally but never returned them, so the caller's counters stayed at their initial values — the decrease handling effectively reset every iteration.
2. **On `numdecs >= max_decs` pyAMICA stopped**, whereas Fortran (`amica17.f90:1062-1108`) lowers the learning-rate **ceiling** (`lrate0`, plus `newtrate`/`rholrate0` under Newton), resets `numdecs`, and **continues**. Without the ceiling ratchet, `lrate` kept ramping back up (it's raised each iter in `_update_parameters`) and the fit oscillated/drifted.

## Changes
- Rewrote `_check_convergence` to match Fortran: thread `numdecs`/`numincs` back into the loop, ratchet `lrate0`/`newtrate`/`rholrate0` down at `max_decs` and **continue** (only a lrate/gradient floor terminates on a decrease), stop after `maxincs` consecutive small increases (new `maxincs` param, Fortran default 5), and reset `numdecs` when Newton starts.

## Effect
- seed=0: the LL now **improves** over the long run — **-3.399** at 2000 iters, vs the pre-fix -3.409 and the ~150-iter -3.404 (and better than Fortran's -3.402). No more degradation.
- The 150-iter `test_sample_data_numpy_vs_fortran` (mean-corr > 0.9) still passes — no parity regression.
- Non-slow suite: 36 passed, 1 xfailed.

## Honest status on `test_sample_data_cli`
Still **xfail**. The #41 **LL-degradation drift is fixed**, but the test's strict *all-32-components* > 0.8 gate still fails (~27/32): at full convergence pyAMICA reaches a comparable/slightly-better-LL but **different-partition** solution than the Fortran reference on a few ill-determined components — a solution-basin difference (the single-model tail of #27's partition theme), not the drift. The project's other parity test uses the more appropriate `mean > 0.9` bar and passes. The xfail reason documents this.

## Related
- Addresses #41 (LL-degradation drift fixed; the numdecs accumulation bug and the missing lrate ratchet).