### PR TITLE
Skip Python CI on docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,20 @@
 name: CI
 
+# Python jobs (lint/test/build) skip when a change touches only prose --
+# Markdown or docs (incl. a future mkdocs site). Spell-checking lives in the
+# separate typos.yml, which has no such filter so docs are always checked.
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "mkdocs.yml"
   pull_request:
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "mkdocs.yml"
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -24,13 +35,6 @@ jobs:
         run: uv run ruff check .
       - name: ruff format --check
         run: uv run ruff format --check .
-
-  typos:
-    name: Typos
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: crate-ci/typos@v1
 
   test:
     name: Test (Python 3.12)

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -2,7 +2,12 @@ name: Typos
 
 # Spell-check runs on every change (including Markdown/docs), so it is a
 # separate workflow from ci.yml, whose Python jobs skip prose-only changes.
-on: [push, pull_request]
+# Push is limited to main (feature-branch pushes are covered by pull_request)
+# to avoid a duplicate run per push, matching ci.yml.
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 concurrency:
   group: typos-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,17 @@
+name: Typos
+
+# Spell-check runs on every change (including Markdown/docs), so it is a
+# separate workflow from ci.yml, whose Python jobs skip prose-only changes.
+on: [push, pull_request]
+
+concurrency:
+  group: typos-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typos:
+    name: Typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@v1


### PR DESCRIPTION
Markdown/docs-only changes should not spin up the Python jobs.

- **`ci.yml`** (lint / test / build): add `paths-ignore` for `**.md`, `docs/**`, `mkdocs.yml`. A PR that touches only those paths skips all three Python jobs. (GitHub skips the workflow only when *every* changed file matches, so mixed code+docs PRs still run fully.)
- **`typos.yml`** (new): the typos job moved out of `ci.yml` into its own workflow with no path filter, so spell-checking still runs on Markdown/docs (it would otherwise be skipped by the same filter).

Ready for the mkdocs site later: docs edits under `docs/` will run typos only.