### PR TITLE
test: hardening + branch coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,18 @@ jobs:
       # Exclude the "slow" parity tests: they invoke the macOS-only Fortran
       # reference binary (pyAMICA/sample_data/amica15mac), which cannot run on
       # the Linux runner. MPS-specific tests self-skip when MPS is absent.
+      # -n auto parallelizes the (independent) torch fits across runner cores;
+      # pytest-cov combines per-worker branch coverage automatically. Coverage
+      # config + the fail-under gate live in pyproject.toml / the flag below.
       - name: pytest (excluding slow / Fortran-binary parity tests)
-        run: uv run pytest -m "not slow"
+        run: uv run pytest -m "not slow" -n auto --cov-fail-under=78
+      - name: Upload coverage HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: htmlcov/
+          retention-days: 14
 
   build:
     name: Build + import (Python ${{ matrix.python-version }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       # pytest-cov combines per-worker branch coverage automatically. Coverage
       # config + the fail-under gate live in pyproject.toml / the flag below.
       - name: pytest (excluding slow / Fortran-binary parity tests)
-        run: uv run pytest -m "not slow" -n auto --cov-fail-under=78
+        run: uv run pytest -m "not slow" -n auto --cov-fail-under=80
       - name: Upload coverage HTML report
         if: always()
         uses: actions/upload-artifact@v4

--- a/pyAMICA/tests/test_amica.py
+++ b/pyAMICA/tests/test_amica.py
@@ -1,5 +1,7 @@
 """Tests for AMICA implementation."""
 
+import shutil
+import tempfile
 import numpy as np
 from pathlib import Path
 import unittest
@@ -21,10 +23,10 @@ class TestAMICA(unittest.TestCase):
         cls.num_samples = 1000
         cls.data = rng.randn(cls.data_dim, cls.num_samples)
 
-        # Save test data in Fortran format
-        cls.test_dir = Path("test_data")
-        if not cls.test_dir.exists():
-            cls.test_dir.mkdir()
+        # Save test data in Fortran format. Use a unique temp dir (not a shared
+        # relative "test_data/") so parallel workers (pytest-xdist -n auto) do
+        # not race on creating/removing the same path.
+        cls.test_dir = Path(tempfile.mkdtemp(prefix="pyamica_test_amica_"))
 
         data_file = cls.test_dir / "test.bin"
         with open(data_file, "wb") as f:
@@ -110,10 +112,8 @@ class TestAMICA(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        """Clean up test files."""
-        import shutil
-
-        shutil.rmtree(cls.test_dir)
+        """Clean up test files (ignore_errors: the temp dir may already be gone)."""
+        shutil.rmtree(cls.test_dir, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/pyAMICA/tests/test_sample_data.py
+++ b/pyAMICA/tests/test_sample_data.py
@@ -288,6 +288,9 @@ def test_cli_output_format_roundtrip(tmp_path):
     # viz helpers run without error on the loaded results.
     viz.plot_convergence(str(outdir))
     viz.plot_components(str(outdir), data=None, max_comps=3)
+    # Also exercise the activation branch (data provided), not just the
+    # mixing-vector-only path.
+    viz.plot_components(str(outdir), data=data, max_comps=3)
     viz.plot_pdf_fits(str(outdir), data, max_comps=2)
 
 

--- a/pyAMICA/tests/torch_tests/test_edge_cases.py
+++ b/pyAMICA/tests/torch_tests/test_edge_cases.py
@@ -1,0 +1,96 @@
+"""Edge-case and input-validation hardening for the AMICA wrapper (issue #61).
+
+Covers degenerate data shapes (single channel, single sample), input
+validation, and the ``from_params_file`` / ``load`` error branches. Real sample
+EEG only (thin slices), never synthetic data. The contract under test is
+*graceful* behavior: a clear exception or a model flagged unusable
+(``is_fitted_``/``converged_`` False), never a silent NaN model (issue #50).
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from pyAMICA.amica import AMICA
+from pyAMICA.torch_impl.utils import load_eeglab_data
+
+SAMPLE_DIR = Path(__file__).resolve().parents[2] / "sample_data"
+DATA_FILE = SAMPLE_DIR / "eeglab_data.fdt"
+PARAMS_FILE = SAMPLE_DIR / "sample_params.json"
+NW = 32
+FIELD = 30504
+
+
+@pytest.fixture(scope="module")
+def real_data() -> np.ndarray:
+    if not DATA_FILE.exists():
+        pytest.skip("sample data missing")
+    return load_eeglab_data(str(DATA_FILE), data_dim=NW, field_dim=FIELD).astype(
+        np.float64
+    )
+
+
+def test_fit_rejects_non_2d_input():
+    """A 1-D array must fail loudly at the shape check, not be misinterpreted."""
+    model = AMICA(n_models=1, n_mix=3, device="cpu", verbose=False)
+    with pytest.raises(ValueError, match="2D"):
+        model.fit(np.zeros(10))
+
+
+def test_single_channel_fit_is_graceful(real_data):
+    """A single-channel fit must not crash or silently return a NaN model."""
+    model = AMICA(n_models=1, n_mix=3, device="cpu", verbose=False)
+    x = real_data[:1, :2048]
+    try:
+        model.fit(x, max_iter=3, block_size=1024, seed=0)
+    except (ValueError, RuntimeError):
+        return  # a clear refusal is acceptable graceful behavior
+    if model.is_fitted_:
+        assert np.isfinite(model.get_unmixing_matrix()).all()
+        assert np.isfinite(model.get_mixing_matrix()).all()
+    else:
+        # Not fitted => flagged unusable, not a silent NaN model.
+        assert model.converged_ is False
+
+
+def test_single_sample_is_graceful(real_data):
+    """One time point => singular covariance; must refuse, not produce a usable
+    NaN model."""
+    model = AMICA(n_models=1, n_mix=3, device="cpu", verbose=False)
+    x = real_data[:, :1]
+    try:
+        # torch.linalg.LinAlgError subclasses RuntimeError, so it is covered.
+        model.fit(x, max_iter=3, seed=0)
+    except (ValueError, RuntimeError):
+        return  # clean failure is acceptable
+    assert not model.is_fitted_  # otherwise it must be flagged unusable
+
+
+def test_from_params_file_reads_and_overrides():
+    """AMICA.from_params_file picks up JSON settings and honors kwarg overrides."""
+    if not PARAMS_FILE.exists():
+        pytest.skip("sample params missing")
+    model = AMICA.from_params_file(str(PARAMS_FILE))
+    assert model.n_models == 1
+    assert model.n_mix == 3
+    # kwargs override the file.
+    overridden = AMICA.from_params_file(str(PARAMS_FILE), n_mix=5)
+    assert overridden.n_mix == 5
+
+
+def test_load_rejects_missing_backend_key(real_data, tmp_path):
+    """A save file missing the 'backend' section must fail loudly on load."""
+    import torch
+
+    model = AMICA(n_models=1, n_mix=3, device="cpu", verbose=False)
+    model.fit(real_data[:, :2048], max_iter=3, block_size=1024, seed=0)
+    path = str(tmp_path / "model.pt")
+    model.save(path)
+
+    payload = torch.load(path, weights_only=True)
+    del payload["backend"]
+    torch.save(payload, path)
+
+    with pytest.raises(ValueError, match="missing"):
+        AMICA.load(path)

--- a/pyAMICA/tests/torch_tests/test_ng_utils.py
+++ b/pyAMICA/tests/torch_tests/test_ng_utils.py
@@ -1,0 +1,139 @@
+"""Unit tests for ``pyAMICA.torch_impl.utils`` helpers.
+
+These exercise the preprocessing / device / comparison utilities that back the
+PyTorch path (previously ~20% covered). They are pure-function tests of linear
+algebra and device selection, not AMICA-vs-Fortran correctness checks (those
+live in the parity suite); where a matrix is needed it is derived from the real
+sample EEG rather than fabricated, per the NO-MOCK policy. Tensors carrying a
+literal NaN/Inf are inherent to testing the numerical-stability guards.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from pyAMICA.torch_impl.utils import (
+    check_numerical_stability,
+    compute_correlation_matrix,
+    find_best_permutation,
+    load_eeglab_data,
+    setup_device,
+    stabilize_log_probabilities,
+)
+
+SAMPLE_DIR = Path(__file__).resolve().parents[2] / "sample_data"
+DATA_FILE = SAMPLE_DIR / "eeglab_data.fdt"
+NW = 32
+FIELD = 30504
+
+
+@pytest.fixture(scope="module")
+def real_data() -> np.ndarray:
+    if not DATA_FILE.exists():
+        pytest.skip("sample data missing")
+    return load_eeglab_data(str(DATA_FILE), data_dim=NW, field_dim=FIELD).astype(
+        np.float64
+    )
+
+
+# --- setup_device -----------------------------------------------------------
+
+
+def test_setup_device_cpu_explicit():
+    assert setup_device("cpu").type == "cpu"
+
+
+def test_setup_device_auto_returns_valid_device():
+    dev = setup_device()
+    assert dev.type in {"cpu", "cuda", "mps"}
+
+
+def test_setup_device_cuda_falls_back_when_unavailable():
+    dev = setup_device("cuda")
+    # Honors the request only if CUDA is actually present; otherwise CPU.
+    if torch.cuda.is_available():
+        assert dev.type == "cuda"
+    else:
+        assert dev.type == "cpu"
+
+
+def test_setup_device_mps_falls_back_when_unavailable():
+    dev = setup_device("mps")
+    if torch.backends.mps.is_available():
+        assert dev.type == "mps"
+    else:
+        assert dev.type == "cpu"
+
+
+# --- check_numerical_stability ---------------------------------------------
+
+
+def test_check_numerical_stability_clean():
+    assert check_numerical_stability(torch.tensor([1.0, 2.0, 3.0])) is True
+
+
+def test_check_numerical_stability_flags_nan():
+    assert check_numerical_stability(torch.tensor([1.0, float("nan")])) is False
+
+
+def test_check_numerical_stability_flags_inf():
+    assert check_numerical_stability(torch.tensor([1.0, float("inf")])) is False
+
+
+def test_check_numerical_stability_raises_when_requested():
+    with pytest.raises(ValueError, match="NaN"):
+        check_numerical_stability(
+            torch.tensor([float("nan")]), name="w", raise_on_error=True
+        )
+
+
+# --- stabilize_log_probabilities -------------------------------------------
+
+
+def test_stabilize_log_probabilities_clamps_below_floor():
+    lp = torch.tensor([-2000.0, -100.0, 0.0])
+    out = stabilize_log_probabilities(lp)
+    assert out[0].item() == -1500.0  # clamped to default floor
+    assert out[1].item() == -100.0  # above floor, untouched
+    assert out[2].item() == 0.0
+
+
+def test_stabilize_log_probabilities_custom_floor():
+    lp = torch.tensor([-50.0, -5.0])
+    out = stabilize_log_probabilities(lp, min_log=-10.0)
+    assert out[0].item() == -10.0
+    assert out[1].item() == -5.0
+
+
+# --- compute_correlation_matrix / find_best_permutation ---------------------
+
+
+def test_compute_correlation_matrix_identity_on_self(real_data):
+    # Two identical component sets: absolute correlation diagonal must be ~1.
+    W = real_data[:8, :512]
+    corr = compute_correlation_matrix(W, W)
+    assert corr.shape == (8, 8)
+    np.testing.assert_allclose(np.diag(corr), np.ones(8), atol=1e-8)
+
+
+def test_find_best_permutation_recovers_shuffle_and_sign(real_data):
+    # Permute + sign-flip real component vectors, then recover the mapping.
+    W1 = real_data[:6, :512]
+    perm = np.array([2, 0, 5, 1, 4, 3])
+    signs = np.array([1.0, -1.0, 1.0, -1.0, 1.0, -1.0])
+    W2 = (W1[perm].T * signs).T
+    corr = compute_correlation_matrix(W1, W2, absolute=True)
+    col_ind, rec_signs = find_best_permutation(corr)
+    # W2 row j corresponds to W1 row perm[j]; the assignment must invert it.
+    np.testing.assert_array_equal(col_ind[perm], np.arange(6))
+    assert set(rec_signs) <= {-1.0, 1.0}
+
+
+# --- load_eeglab_data -------------------------------------------------------
+
+
+def test_load_eeglab_data_shape(real_data):
+    assert real_data.shape == (NW, FIELD)
+    assert np.isfinite(real_data).all()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,5 +49,26 @@ package-data = {"pyAMICA" = ["data/*"], "pyAMICA.numpy_impl" = ["params.json"]}
 dev = [
     "pytest>=9.1.1",
     "pytest-cov>=7.1.0",
+    "pytest-xdist>=3.6.1",
     "ruff>=0.15.0",
+]
+
+[tool.coverage.run]
+source = ["pyAMICA"]
+branch = true
+omit = [
+    "pyAMICA/tests/*",
+    # argparse CLI entrypoint: exercised via subprocess, not unit-covered here.
+    "pyAMICA/numpy_impl/cli.py",
+]
+
+[tool.coverage.report]
+show_missing = true
+precision = 1
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+    "@(abc\\.)?abstractmethod",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -222,6 +222,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.4"
 source = { registry = "https://pypi.org/simple" }
@@ -840,6 +849,7 @@ dependencies = [
 dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -857,6 +867,7 @@ requires-dist = [
 dev = [
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "ruff", specifier = ">=0.15.0" },
 ]
 
@@ -906,6 +917,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #61. Closes #64. Addresses #15.

Folds test hardening together with actionable code coverage, all self-contained in GitHub CI (no external service).

## Coverage tooling (#64)
- Added `[tool.coverage]` config: **branch** coverage, omit tests + the argparse CLI, exclude pragmas.
- Added `pytest-xdist`; CI now runs `pytest -m "not slow" -n auto --cov-fail-under=80` and uploads the HTML report as an artifact.
- **CI-time benchmark** (your ask): the suite is dominated by the real torch fits, not coverage. Parallel branch-coverage run is **2m36s** locally (14 cores) vs 4m31s serial no-coverage; CI on #62 was 6m44s serial. `-n auto` more than pays for coverage, so on GitHub's 4-vCPU runners this should land ~3-4 min.

## Test isolation fix (surfaced by -n auto)
`TestAMICA` used a shared relative `test_data/` dir and `rmtree`d it in teardown, racing across xdist workers (`FileNotFoundError`). Switched to a unique `mkdtemp` dir.

## Hardening tests
- **`test_ng_utils.py`** (new): `torch_impl/utils.py` device selection, numerical-stability guards, correlation/permutation (real-data-derived), and the `.fdt` loader. Module 20% -> 65% (remainder is the Fortran-dir integration helper).
- **`test_edge_cases.py`** (new, #61): non-2D input rejection, single-channel and single-sample **graceful** handling (clear error or unusable-flag, never a silent NaN model), `from_params_file` + override, and the `load` missing-key branch.
- Covered `plot_components` activation branch (#15).

## Coverage result
Total branch coverage **78.3% -> 81.1%**; `amica.py` 86% -> 96%. Suite 85 -> 103 tests, 0 errors.

## Note on #15
The `AMICA.save`/`load` roundtrip #15 asked for is **already covered** (`test_amica_ng_wrapper.py`, added under #36 after #15 was filed). `plot_components` builds a figure but never writes a file, so #15's 'assert files are written' does not literally apply; covered its activation branch instead.