### PR TITLE
ci: Codecov coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,16 @@ jobs:
           name: coverage-html
           path: htmlcov/
           retention-days: 14
+      # Codecov is informational (badge + PR coverage-diff comments); the hard
+      # gate is --cov-fail-under in the pytest step above, so a flaky upload
+      # (fail_ci_if_error: false) never breaks the build.
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          fail_ci_if_error: false
 
   build:
     name: Build + import (Python ${{ matrix.python-version }})

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # [WIP] AMICA: Adaptive Mixture ICA
 
+[![CI](https://github.com/neuromechanist/pyAMICA/actions/workflows/ci.yml/badge.svg)](https://github.com/neuromechanist/pyAMICA/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/neuromechanist/pyAMICA/branch/main/graph/badge.svg)](https://codecov.io/gh/neuromechanist/pyAMICA)
+
 Python implementation of the Adaptive Mixture ICA algorithm, based on the original Fortran implementation. This implementation is designed to be more user-friendly and easier to integrate with other Python libraries.
 
 NOTE: This is a work in progress and may not be fully functional yet. User should not rely on this implementation for any research or production purposes, as the results may not be accurate or reliable.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,25 @@
+# Codecov configuration. Coverage here is informational: the enforced gate is
+# `--cov-fail-under` in the CI pytest step (.github/workflows/ci.yml), so a
+# Codecov status never blocks a PR on its own.
+coverage:
+  status:
+    project:
+      default:
+        target: auto        # compare against the base commit
+        threshold: 1%       # allow small dips without a red status
+        informational: true # never fail the PR check
+    patch:
+      default:
+        informational: true
+
+# The Fortran-binary parity tests are excluded on CI (Linux cannot run the
+# macOS x86_64 reference), so their code paths are reported via local runs, not
+# Codecov. Keep the report focused on the package.
+ignore:
+  - "pyAMICA/tests/**"
+  - "validate_implementations.py"
+  - "benchmarks/**"
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: true      # only comment when coverage changes


### PR DESCRIPTION
Closes #66. Implements the Codecov option chosen for coverage reporting.

- Adds an **informational** Codecov upload step to the test job (uploads the `coverage.xml` pytest already produces). `fail_ci_if_error: false` so a flaky upload never breaks the build; the hard gate stays `--cov-fail-under=80` in the pytest step.
- Adds `codecov.yml`: informational project/patch statuses (never block a PR), 1% threshold, ignores tests/benchmarks/validate.
- Adds CI + Codecov badges to the README.

## Action required (owner)
Add the repo secret once so uploads authenticate (Codecov recommends a token even for public repos to avoid rate-limited tokenless uploads):

```
gh secret set CODECOV_TOKEN   # paste the token from codecov.io repo settings
```

The badge populates after the first `main` run with the token set. No test-time cost: the upload is a ~10s step.

Note: README badge change is docs, but ci.yml/codecov.yml trigger the Python CI.