### PR TITLE
feat: component sharing (share_comps) in AMICATorchNG

### DIFF
--- a/.context/feature_parity.md
+++ b/.context/feature_parity.md
@@ -8,8 +8,7 @@ and CLI. Living status is in `../AGENTS.md` (Known Issues); ADRs are in `decisio
 **Headline:** single-model parity is done (LL ~ -3.40 vs Fortran -3.4018; Hungarian component
 correlation ~0.997 with Newton positive-definite, 0 fallbacks). Adaptive PDF (#26), multi-model
 (#27, distributional equivalence), best-iterate (#51), and the degenerate-fit contract (#50) are
-done. The one unimplemented Fortran feature is component sharing; the one unverified success
-criterion is runtime.
+done, as is component sharing (#60). The one unverified success criterion is runtime.
 
 ## Core AMICA features
 
@@ -45,7 +44,7 @@ criterion is runtime.
 |---------|---------|--------------|--------|-------|
 | Outlier rejection | yes | yes | Complete | `do_reject` |
 | Adaptive PDF selection | yes | yes | Complete | 5 `pdftype` families + ext-Infomax switcher (#26) |
-| Component sharing | yes | **no** | **Missing** | `share_comps` reassignment not ported (torch `comp_list` is trivial per-model layout) |
+| Component sharing | yes | yes | Complete | `share_comps` multi-model merge ported (#60); off by default, behavior-validated (no bit-exact oracle) |
 | History tracking | yes | yes | Complete | `ll_history`, grad norms |
 
 ## Input/output
@@ -91,7 +90,7 @@ indistinguishable from Fortran's run-to-run distribution (#27, `.context/issue-2
 
 - [ ] **Performance benchmark** vs the Fortran binary (CPU/CUDA/MPS); verify or revise the 2-3x
       runtime criterion.
-- [ ] **Component sharing** (`share_comps`, `share_start`/`share_int`, `load_comp_list`,
-      `comp_used`) ported to `AMICATorchNG` and validated on real data.
+- [x] **Component sharing** (`share_comps`, `share_start`/`share_iter`, `comp_thresh`) ported to
+      `AMICATorchNG` (#60), off by default, behavior-validated on real data.
 - [ ] **Test hardening:** single-channel / single-sample edge cases, numerical-stability
       regression tests, and `save`/`load` + `plot_components` coverage (#15).

--- a/.context/plan.md
+++ b/.context/plan.md
@@ -42,7 +42,11 @@
       variance-driving seed peaked at -3.357 then crashed to -3.545 in its final iterations).
       Single-model #24 parity stays bit-exact (monotone => no restore). See ADR 0003,
       `.context/issue-51/`.
-- [ ] Component sharing
+- [x] Component sharing (issue #60): `share_comps` multi-model reassignment ported to
+      `AMICATorchNG` (de-sphered cosine-similarity merge, `share_start`/`share_iter`/`comp_thresh`
+      schedule + A-freeze). OFF by default so single-model (#24)/default multi-model (#27) parity is
+      byte-for-byte. No bit-exact oracle (reference `Spinv2` metric is dead code, like #26);
+      behavior-validated. See `tests/torch_tests/test_ng_sharing.py`.
 
 ### Priority 3: Testing & validation
 - [x] Real-data test suite exercising the PyTorch backend end-to-end (issue #7) - Phase 1, issue #10:

--- a/.context/progress_summary.md
+++ b/.context/progress_summary.md
@@ -47,6 +47,20 @@ what remains as of the v0.1.0 preparation.
   `stop_reason_`; `transform` / `get_mixing_matrix` / `get_unmixing_matrix` / `save` raise a clear
   degenerate error instead of returning NaN sources.
 
+### Component sharing (issue #60)
+- `share_comps` ported to `AMICATorchNG`: on the `share_start`/`share_iter` schedule, components
+  that are near-collinear across different models (cosine angle of their de-sphered mixing columns
+  above `comp_thresh`) are merged into one shared mixing column and density, with an A-freeze for
+  ~6 iterations after each merge (Fortran `identify_shared_comps`, amica15.f90:1898).
+- The M-step already sums sufficient statistics through `comp_list` (index_add), so shared
+  components update jointly; the A-update was refactored to accumulate shared columns the same way
+  (byte-identical to the per-model update when unshared).
+- OFF by default, and a no-op for `n_models=1`, so single-model (#24) and default multi-model (#27)
+  results are byte-for-byte unchanged (verified by the full torch suite). No bit-exact oracle: the
+  reference's `Spinv2` similarity metric is never initialized (dead code, like `do_choose_pdfs`,
+  #26), so the intended algorithm is implemented and behavior-validated. See
+  `tests/torch_tests/test_ng_sharing.py`.
+
 ### Structure and infrastructure
 - Module rename into `numpy_impl/` and `torch_impl/` with topic-based names (issue #34); the public
   import surface (`from pyAMICA import AMICA, AMICA_NumPy, AMICATorchNG`) is stable.
@@ -60,9 +74,6 @@ what remains as of the v0.1.0 preparation.
 
 - **Performance benchmark:** the "runtime within 2-3x of Fortran" success criterion has never been
   measured. Needs a repeatable NG-vs-Fortran benchmark across CPU/CUDA/MPS.
-- **Component sharing:** the last unimplemented Fortran feature. Torch `comp_list` is only the
-  trivial per-model block layout; `share_comps` reassignment (`share_start` / `share_int`,
-  `load_comp_list`, `comp_used`) is absent. NumPy has partial plumbing only.
 - **Test hardening:** no single-channel / single-sample edge tests, no numerical-stability
   regression tests (mincond / minlog / maxdble / mineig bounds); `AMICA.save`/`load` and
   `plot_components` remain untested (issue #15).

--- a/.context/progress_summary.md
+++ b/.context/progress_summary.md
@@ -53,12 +53,16 @@ what remains as of the v0.1.0 preparation.
   above `comp_thresh`) are merged into one shared mixing column and density, with an A-freeze for
   ~6 iterations after each merge (Fortran `identify_shared_comps`, amica15.f90:1898).
 - The M-step already sums sufficient statistics through `comp_list` (index_add), so shared
-  components update jointly; the A-update was refactored to accumulate shared columns the same way
-  (byte-identical to the per-model update when unshared).
+  components update jointly; the A-update was refactored to accumulate columns as Fortran's
+  `gm`-weighted average (`dAk/zeta`, so shared columns are averaged, not summed) -- byte-identical
+  to the per-model update when unshared.
+- `keep_best` (#51) is disabled under sharing (a merge changes the parameter count, so pre-/post-merge
+  LLs are not comparable and restoring an earlier snapshot would revert the merge); `fit` returns the
+  last, merged iterate like Fortran.
 - OFF by default, and a no-op for `n_models=1`, so single-model (#24) and default multi-model (#27)
   results are byte-for-byte unchanged (verified by the full torch suite). No bit-exact oracle: the
-  reference's `Spinv2` similarity metric is never initialized (dead code, like `do_choose_pdfs`,
-  #26), so the intended algorithm is implemented and behavior-validated. See
+  reference's `Spinv2` similarity metric is *declared but never allocated* (unrunnable, like the dead
+  `do_choose_pdfs`, #26), so the intended algorithm is implemented and behavior-validated. See
   `tests/torch_tests/test_ng_sharing.py`.
 
 ### Structure and infrastructure

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ pyAMICA/tests/torch_tests/_ng_e2e_tmp/
 
 # Benchmark run artifacts
 benchmarks/results/
+
+# Local secrets (never commit)
+.env
+.env.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,9 +92,10 @@ into one shared mixing column + density, with an A-freeze for ~6 iterations afte
 through `comp_list`; the A-update was refactored to accumulate shared columns the same way
 (byte-identical when unshared), and merged-away columns are frozen (avoiding 0/0 NaN that Fortran
 tolerates behind its `comp_used` mask). OFF by default and a no-op for `n_models=1`, so single-model
-(#24) and default multi-model (#27) parity stay byte-for-byte (full torch suite green). No bit-exact
-oracle: the reference `Spinv2` metric is dead code (like `do_choose_pdfs`, #26), so it is
-behavior-validated (`tests/torch_tests/test_ng_sharing.py`).
+(#24) and default multi-model (#27) parity stay byte-for-byte (full torch suite green). The A-update
+is the Fortran `gm`-weighted average (`dAk/zeta`), so shared columns are averaged not summed. No
+bit-exact oracle: the reference `Spinv2` metric is *declared but never allocated* (unrunnable, like
+the dead `do_choose_pdfs`, #26), so it is behavior-validated (`tests/torch_tests/test_ng_sharing.py`).
 
 **Open (non-blocking, tracked):**
 - **Multi-model (#27): VALIDATED by distributional equivalence.** Multi-model AMICA is not

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,18 @@ dead code even in amica15 (the moment buffers are never accumulated), so the aut
 bit-exact oracle and is validated by real-data LL. `pdftype=0` stays the default and is
 byte-for-byte unchanged. See `.context/decisions/` and `tests/torch_tests/test_ng_pdf_families.py`.
 
+**Component sharing (#60): DONE.** `share_comps` multi-model reassignment is ported to
+`AMICATorchNG`: on the `share_start`/`share_iter` schedule, components near-collinear across
+different models (cosine angle of their de-sphered mixing columns above `comp_thresh`) are merged
+into one shared mixing column + density, with an A-freeze for ~6 iterations after each merge
+(Fortran `identify_shared_comps`, amica15.f90:1898). The M-step already sums sufficient stats
+through `comp_list`; the A-update was refactored to accumulate shared columns the same way
+(byte-identical when unshared), and merged-away columns are frozen (avoiding 0/0 NaN that Fortran
+tolerates behind its `comp_used` mask). OFF by default and a no-op for `n_models=1`, so single-model
+(#24) and default multi-model (#27) parity stay byte-for-byte (full torch suite green). No bit-exact
+oracle: the reference `Spinv2` metric is dead code (like `do_choose_pdfs`, #26), so it is
+behavior-validated (`tests/torch_tests/test_ng_sharing.py`).
+
 **Open (non-blocking, tracked):**
 - **Multi-model (#27): VALIDATED by distributional equivalence.** Multi-model AMICA is not
   partition-identifiable, so exact partition parity with Fortran is the wrong acceptance bar (the

--- a/pyAMICA/tests/torch_tests/test_ng_sharing.py
+++ b/pyAMICA/tests/torch_tests/test_ng_sharing.py
@@ -1,0 +1,165 @@
+"""Component sharing (issue #60) for AMICATorchNG.
+
+Covers the ``share_comps`` reassignment ported from the Fortran
+``identify_shared_comps`` (amica15.f90:1898). There is no bit-exact oracle (the
+reference's similarity metric ``Spinv2`` is never initialized, like
+``do_choose_pdfs``, #26), so the merge *mechanism* is tested with controlled
+mixing matrices and the end-to-end behavior on real sample EEG. Sharing is
+multi-model only and OFF by default, so single-model parity is unchanged.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from pyAMICA.amica import AMICA
+from pyAMICA.torch_impl.core import AMICATorchNG
+from pyAMICA.torch_impl.utils import load_eeglab_data
+
+SAMPLE_DIR = Path(__file__).resolve().parents[2] / "sample_data"
+DATA_FILE = SAMPLE_DIR / "eeglab_data.fdt"
+NW = 32
+FIELD = 30504
+
+
+@pytest.fixture(scope="module")
+def real_data() -> np.ndarray:
+    if not DATA_FILE.exists():
+        pytest.skip("sample data missing")
+    return load_eeglab_data(str(DATA_FILE), data_dim=NW, field_dim=FIELD).astype(
+        np.float64
+    )
+
+
+def _controlled_ng(A: torch.Tensor, n_channels: int, n_models: int) -> AMICATorchNG:
+    """An NG with a fixed identity sphere and default comp_list, whose A is the
+    given (n_channels, n_channels*n_models) matrix -- so the sharing metric is a
+    plain cosine similarity on A's columns. No fit needed."""
+    ng = AMICATorchNG(
+        n_channels=n_channels,
+        n_models=n_models,
+        n_mix=3,
+        device="cpu",
+        share_comps=True,
+        comp_thresh=0.99,
+    )
+    ng.sphere = torch.eye(n_channels, dtype=torch.float64)
+    ng._spinv = None
+    ng.iteration = 0
+    cl = np.zeros((n_channels, n_models), dtype=np.int64)
+    for h in range(n_models):
+        cl[:, h] = np.arange(h * n_channels, (h + 1) * n_channels)
+    ng.comp_list = torch.from_numpy(cl)
+    ng.A = A.to(torch.float64)
+    return ng
+
+
+def test_single_model_byte_identical_with_share_toggled(real_data):
+    """Sharing is a no-op for n_models=1 (nothing to share), so a single-model
+    fit must be byte-for-byte identical with share_comps on vs off."""
+    x = real_data[:, :4096]
+    off = AMICA(n_models=1, n_mix=3, device="cpu", verbose=False)
+    off.fit(x, max_iter=8, seed=42, block_size=1024, do_newton=True)
+    on = AMICA(n_models=1, n_mix=3, device="cpu", verbose=False)
+    on.fit(
+        x,
+        max_iter=8,
+        seed=42,
+        block_size=1024,
+        do_newton=True,
+        share_comps=True,
+        share_start=3,
+        share_iter=3,
+    )
+    np.testing.assert_array_equal(off.get_mixing_matrix(0), on.get_mixing_matrix(0))
+    np.testing.assert_array_equal(off.get_unmixing_matrix(0), on.get_unmixing_matrix(0))
+    assert off.final_ll_ == on.final_ll_
+
+
+def test_identify_merges_one_collinear_pair():
+    """A single collinear cross-model column pair is merged; the others (random,
+    near-orthogonal) are left alone."""
+    torch.manual_seed(0)
+    n = 4
+    A = torch.randn(n, 2 * n, dtype=torch.float64)
+    A = A / A.norm(dim=0, keepdim=True)
+    # Force model-1 source 1 (global col 5) collinear with model-0 source 2 (col 2).
+    A[:, 5] = A[:, 2]
+    ng = _controlled_ng(A, n_channels=n, n_models=2)
+    assert int(ng.comp_used.sum()) == 2 * n  # all distinct to start
+    ng._identify_shared_comps()
+    assert int(ng.comp_used.sum()) == 2 * n - 1  # exactly one merge
+    # col 5 folded into col 2: source 1 of model 1 now points to comp 2.
+    assert int(ng.comp_list[1, 1]) == int(ng.comp_list[2, 0]) == 2
+
+
+def test_guard_prevents_within_model_collapse():
+    """When every column is collinear, sharing must NOT collapse a model's own
+    sources together: with 2 sources x 2 models it settles to 2 shared comps,
+    not 1 (Fortran's 'common presence in a model' guard, amica15.f90:1918)."""
+    n = 2
+    v = torch.tensor([1.0, 2.0], dtype=torch.float64)
+    A = torch.stack([v] * (2 * n), dim=1)  # all four columns collinear
+    ng = _controlled_ng(A, n_channels=n, n_models=2)
+    ng._identify_shared_comps()
+    assert int(ng.comp_used.sum()) == 2  # two shared comps, one per source slot
+    # each model's two sources stay distinct comps
+    assert ng.comp_list[0, 0] != ng.comp_list[1, 0]
+
+
+def test_default_multimodel_leaves_comps_unshared(real_data):
+    """With share_comps off (default), a 2-model fit keeps every component
+    distinct (comp_list stays the full block layout)."""
+    ng = AMICATorchNG(
+        n_channels=NW, n_models=2, n_mix=3, device="cpu", block_size=1024, seed=1
+    )
+    ng.fit(real_data[:, :4096], max_iter=10)
+    assert int(ng.comp_used.sum()) == ng.n_comps
+    assert torch.isfinite(ng.A).all()
+
+
+def test_two_model_share_fit_is_finite_and_shares(real_data):
+    """A full 2-model fit with sharing enabled runs to completion with finite
+    parameters and does not increase the unique-component count."""
+    ng = AMICATorchNG(
+        n_channels=NW,
+        n_models=2,
+        n_mix=3,
+        device="cpu",
+        block_size=1024,
+        seed=3,
+        do_newton=True,
+        share_comps=True,
+        share_start=5,
+        share_iter=5,
+        comp_thresh=0.9,
+    )
+    ng.fit(real_data[:, :4096], max_iter=25)
+    assert torch.isfinite(ng.A).all()
+    assert np.isfinite(ng.final_ll_)
+    assert int(ng.comp_used.sum()) <= ng.n_comps
+
+
+def test_share_config_and_comp_list_roundtrip(real_data, tmp_path):
+    """save/load preserves the share configuration and the (possibly merged)
+    comp_list."""
+    model = AMICA(n_models=2, n_mix=3, device="cpu", verbose=False)
+    model.fit(
+        real_data[:, :4096],
+        max_iter=12,
+        block_size=1024,
+        seed=3,
+        do_newton=True,
+        share_comps=True,
+        share_start=3,
+        share_iter=3,
+        comp_thresh=0.9,
+    )
+    path = str(tmp_path / "shared.pt")
+    model.save(path)
+    loaded = AMICA.load(path, device="cpu")
+    assert loaded.model_.share_comps is True
+    assert loaded.model_.share_start == 3 and loaded.model_.share_iter == 3
+    assert torch.equal(loaded.model_.comp_list, model.model_.comp_list)

--- a/pyAMICA/tests/torch_tests/test_ng_sharing.py
+++ b/pyAMICA/tests/torch_tests/test_ng_sharing.py
@@ -2,10 +2,11 @@
 
 Covers the ``share_comps`` reassignment ported from the Fortran
 ``identify_shared_comps`` (amica15.f90:1898). There is no bit-exact oracle (the
-reference's similarity metric ``Spinv2`` is never initialized, like
-``do_choose_pdfs``, #26), so the merge *mechanism* is tested with controlled
-mixing matrices and the end-to-end behavior on real sample EEG. Sharing is
-multi-model only and OFF by default, so single-model parity is unchanged.
+reference's ``Spinv2`` metric is declared but never allocated, like the dead
+``do_choose_pdfs`` switch, #26), so the merge *mechanism* is tested with
+controlled mixing matrices and the end-to-end behavior on real sample EEG.
+Sharing is multi-model only and OFF by default, so single-model parity is
+unchanged.
 """
 
 from pathlib import Path
@@ -56,9 +57,13 @@ def _controlled_ng(A: torch.Tensor, n_channels: int, n_models: int) -> AMICATorc
     return ng
 
 
+# --- default-path parity ----------------------------------------------------
+
+
 def test_single_model_byte_identical_with_share_toggled(real_data):
-    """Sharing is a no-op for n_models=1 (nothing to share), so a single-model
-    fit must be byte-for-byte identical with share_comps on vs off."""
+    """Sharing is a no-op for n_models=1, so a single-model fit must be
+    byte-for-byte identical with share_comps on vs off (the gm-weighted A-update
+    reduces to the plain update since gm=[1] cancels exactly)."""
     x = real_data[:, :4096]
     off = AMICA(n_models=1, n_mix=3, device="cpu", verbose=False)
     off.fit(x, max_iter=8, seed=42, block_size=1024, do_newton=True)
@@ -70,43 +75,12 @@ def test_single_model_byte_identical_with_share_toggled(real_data):
         block_size=1024,
         do_newton=True,
         share_comps=True,
-        share_start=3,
-        share_iter=3,
+        share_start=7,
+        share_iter=8,
     )
     np.testing.assert_array_equal(off.get_mixing_matrix(0), on.get_mixing_matrix(0))
     np.testing.assert_array_equal(off.get_unmixing_matrix(0), on.get_unmixing_matrix(0))
     assert off.final_ll_ == on.final_ll_
-
-
-def test_identify_merges_one_collinear_pair():
-    """A single collinear cross-model column pair is merged; the others (random,
-    near-orthogonal) are left alone."""
-    torch.manual_seed(0)
-    n = 4
-    A = torch.randn(n, 2 * n, dtype=torch.float64)
-    A = A / A.norm(dim=0, keepdim=True)
-    # Force model-1 source 1 (global col 5) collinear with model-0 source 2 (col 2).
-    A[:, 5] = A[:, 2]
-    ng = _controlled_ng(A, n_channels=n, n_models=2)
-    assert int(ng.comp_used.sum()) == 2 * n  # all distinct to start
-    ng._identify_shared_comps()
-    assert int(ng.comp_used.sum()) == 2 * n - 1  # exactly one merge
-    # col 5 folded into col 2: source 1 of model 1 now points to comp 2.
-    assert int(ng.comp_list[1, 1]) == int(ng.comp_list[2, 0]) == 2
-
-
-def test_guard_prevents_within_model_collapse():
-    """When every column is collinear, sharing must NOT collapse a model's own
-    sources together: with 2 sources x 2 models it settles to 2 shared comps,
-    not 1 (Fortran's 'common presence in a model' guard, amica15.f90:1918)."""
-    n = 2
-    v = torch.tensor([1.0, 2.0], dtype=torch.float64)
-    A = torch.stack([v] * (2 * n), dim=1)  # all four columns collinear
-    ng = _controlled_ng(A, n_channels=n, n_models=2)
-    ng._identify_shared_comps()
-    assert int(ng.comp_used.sum()) == 2  # two shared comps, one per source slot
-    # each model's two sources stay distinct comps
-    assert ng.comp_list[0, 0] != ng.comp_list[1, 0]
 
 
 def test_default_multimodel_leaves_comps_unshared(real_data):
@@ -120,9 +94,164 @@ def test_default_multimodel_leaves_comps_unshared(real_data):
     assert torch.isfinite(ng.A).all()
 
 
-def test_two_model_share_fit_is_finite_and_shares(real_data):
-    """A full 2-model fit with sharing enabled runs to completion with finite
-    parameters and does not increase the unique-component count."""
+# --- merge mechanism (controlled) ------------------------------------------
+
+
+def test_identify_merges_one_collinear_pair():
+    """A single collinear cross-model column pair is merged; the others (random,
+    near-orthogonal) are left alone."""
+    torch.manual_seed(0)
+    n = 4
+    A = torch.randn(n, 2 * n, dtype=torch.float64)
+    A = A / A.norm(dim=0, keepdim=True)
+    A[:, 5] = A[
+        :, 2
+    ]  # model-1 source 1 (col 5) collinear with model-0 source 2 (col 2)
+    ng = _controlled_ng(A, n_channels=n, n_models=2)
+    assert int(ng.comp_used.sum()) == 2 * n
+    ng._identify_shared_comps()
+    assert int(ng.comp_used.sum()) == 2 * n - 1
+    assert int(ng.comp_list[1, 1]) == int(ng.comp_list[2, 0]) == 2
+    assert not bool(ng.comp_used[5])  # col 5 is now unused
+
+
+def test_guard_prevents_within_model_collapse():
+    """When every column is collinear, sharing must NOT collapse a model's own
+    sources together: with 2 sources x 2 models it settles to 2 shared comps,
+    not 1 (Fortran's 'common presence in a model' guard, amica15.f90:1918)."""
+    n = 2
+    v = torch.tensor([1.0, 2.0], dtype=torch.float64)
+    A = torch.stack([v] * (2 * n), dim=1)
+    ng = _controlled_ng(A, n_channels=n, n_models=2)
+    ng._identify_shared_comps()
+    assert int(ng.comp_used.sum()) == 2
+    assert ng.comp_list[0, 0] != ng.comp_list[1, 0]
+
+
+def test_three_model_guard_and_merge():
+    """3-model scan (h<hh runs 3 pairs, with sequential mutation): a source
+    collinear across all three models collapses to ONE shared comp, while each
+    model's other source stays distinct."""
+    n = 2
+    torch.manual_seed(1)
+    A = torch.randn(n, 3 * n, dtype=torch.float64)
+    A = A / A.norm(dim=0, keepdim=True)
+    # source 0 of every model shares one direction; source 1 stays random.
+    shared = A[:, 0].clone()
+    A[:, 2] = shared  # model1 source0 (col 2)
+    A[:, 4] = shared  # model2 source0 (col 4)
+    ng = _controlled_ng(A, n_channels=n, n_models=3)
+    ng._identify_shared_comps()
+    # source-0 column shared by all 3 models -> one comp; three distinct source-1s.
+    assert int(ng.comp_list[0, 0]) == int(ng.comp_list[0, 1]) == int(ng.comp_list[0, 2])
+    assert int(ng.comp_used.sum()) == 4  # 1 shared + 3 distinct source-1 comps
+    # no model shares a comp between its own two sources
+    for h in range(3):
+        assert ng.comp_list[0, h] != ng.comp_list[1, h]
+
+
+def test_comp_thresh_one_merges_only_exact_duplicates():
+    """comp_thresh=1.0: an exact-duplicate column merges (cos==1), a merely
+    similar one does not."""
+    n = 3
+    torch.manual_seed(2)
+    A = torch.randn(n, 2 * n, dtype=torch.float64)
+    A = A / A.norm(dim=0, keepdim=True)
+    A[:, 3] = A[:, 0]  # exact duplicate across models
+    ng = _controlled_ng(A, n_channels=n, n_models=2)
+    ng.comp_thresh = 1.0
+    ng._identify_shared_comps()
+    assert int(ng.comp_list[0, 1]) == int(ng.comp_list[0, 0])  # duplicate merged
+    assert int(ng.comp_used.sum()) == 2 * n - 1
+
+
+# --- freeze schedule --------------------------------------------------------
+
+
+def test_a_frozen_window():
+    """A is frozen for the merge iteration + 5 after it, thawed for the rest of
+    each cycle, and frozen again at the next cycle boundary."""
+    ng = AMICATorchNG(
+        n_channels=4,
+        n_models=2,
+        device="cpu",
+        share_comps=True,
+        share_start=10,
+        share_iter=20,
+    )
+
+    def frozen(itf):
+        ng.iteration = itf - 1  # itf is the Fortran-style 1-indexed iteration
+        return ng._a_frozen()
+
+    assert not any(frozen(i) for i in range(1, 10))  # before share_start
+    assert all(frozen(i) for i in range(10, 16))  # merge + 5 (residue 0..5)
+    assert not any(frozen(i) for i in range(16, 30))  # thawed rest of cycle
+    assert all(frozen(i) for i in range(30, 36))  # next cycle boundary
+
+
+def test_a_frozen_off_for_single_model():
+    ng = AMICATorchNG(
+        n_channels=4,
+        n_models=1,
+        device="cpu",
+        share_comps=True,
+        share_start=2,
+        share_iter=8,
+    )
+    ng.iteration = 3
+    assert ng._a_frozen() is False
+
+
+# --- validation -------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        (dict(share_start=0), "share_start"),
+        (dict(share_iter=6), "share_iter"),
+        (dict(share_iter=1), "share_iter"),
+        (dict(comp_thresh=0.0), "comp_thresh"),
+        (dict(comp_thresh=1.5), "comp_thresh"),
+        (dict(pcakeep=10), "PCA"),
+        (dict(pcadb=30.0), "PCA"),
+    ],
+)
+def test_share_constructor_validation(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        AMICATorchNG(n_channels=8, n_models=2, share_comps=True, **kwargs)
+
+
+def test_singular_sphere_raises_on_share():
+    """Sharing on a rank-deficient (uninvertible) sphere fails loudly rather than
+    merging on a garbage metric."""
+    ng = AMICATorchNG(
+        n_channels=4,
+        n_models=2,
+        device="cpu",
+        share_comps=True,
+        share_start=1,
+        share_iter=8,
+    )
+    sphere = torch.zeros(4, 4, dtype=torch.float64)
+    sphere[0, 0] = sphere[1, 1] = 1.0  # rank 2 of 4 -> singular
+    ng.sphere = sphere
+    ng._spinv = None
+    ng.A = torch.randn(4, 8, dtype=torch.float64)
+    ng.comp_list = torch.tensor([[0, 4], [1, 5], [2, 6], [3, 7]])
+    ng.iteration = 0
+    with pytest.raises(RuntimeError, match="invertible|singular|non-finite"):
+        ng._identify_shared_comps()
+
+
+# --- end-to-end on real data ------------------------------------------------
+
+
+def test_two_model_share_fit_survives_merge(real_data):
+    """A full 2-model fit with sharing runs to completion with finite parameters
+    and the merge SURVIVES to the returned model (keep_best is disabled under
+    share_comps, so fit returns the merged last iterate, not a pre-merge peak)."""
     ng = AMICATorchNG(
         n_channels=NW,
         n_models=2,
@@ -132,34 +261,59 @@ def test_two_model_share_fit_is_finite_and_shares(real_data):
         seed=3,
         do_newton=True,
         share_comps=True,
-        share_start=5,
-        share_iter=5,
+        share_start=8,
+        share_iter=10,
         comp_thresh=0.9,
     )
-    ng.fit(real_data[:, :4096], max_iter=25)
+    ng.fit(real_data[:, :4096], max_iter=40)
     assert torch.isfinite(ng.A).all()
     assert np.isfinite(ng.final_ll_)
-    assert int(ng.comp_used.sum()) <= ng.n_comps
+    assert int(ng.comp_used.sum()) < ng.n_comps  # at least one merge survived
+
+
+def test_sharing_reduces_unique_count_without_degrading_ll(real_data):
+    """Enabling sharing on matched config strictly reduces the unique-component
+    count and does not materially degrade the log-likelihood."""
+    x = real_data[:, :4096]
+    common = dict(
+        n_channels=NW,
+        n_models=2,
+        n_mix=3,
+        device="cpu",
+        block_size=1024,
+        seed=7,
+        do_newton=True,
+    )
+    base = AMICATorchNG(**common)
+    base.fit(x, max_iter=40)
+    shared = AMICATorchNG(
+        **common, share_comps=True, share_start=8, share_iter=10, comp_thresh=0.9
+    )
+    shared.fit(x, max_iter=40)
+    assert int(base.comp_used.sum()) == base.n_comps
+    assert int(shared.comp_used.sum()) < base.n_comps
+    assert np.isfinite(shared.final_ll_)
+    assert shared.final_ll_ > base.final_ll_ - 0.3  # no material degradation
 
 
 def test_share_config_and_comp_list_roundtrip(real_data, tmp_path):
-    """save/load preserves the share configuration and the (possibly merged)
-    comp_list."""
+    """save/load preserves the share configuration and the merged comp_list."""
     model = AMICA(n_models=2, n_mix=3, device="cpu", verbose=False)
     model.fit(
         real_data[:, :4096],
-        max_iter=12,
+        max_iter=25,
         block_size=1024,
         seed=3,
         do_newton=True,
         share_comps=True,
-        share_start=3,
-        share_iter=3,
+        share_start=8,
+        share_iter=10,
         comp_thresh=0.9,
     )
+    assert int(model.model_.comp_used.sum()) < model.model_.n_comps  # a merge happened
     path = str(tmp_path / "shared.pt")
     model.save(path)
     loaded = AMICA.load(path, device="cpu")
     assert loaded.model_.share_comps is True
-    assert loaded.model_.share_start == 3 and loaded.model_.share_iter == 3
+    assert loaded.model_.share_start == 8 and loaded.model_.share_iter == 10
     assert torch.equal(loaded.model_.comp_list, model.model_.comp_list)

--- a/pyAMICA/torch_impl/core.py
+++ b/pyAMICA/torch_impl/core.py
@@ -306,7 +306,9 @@ class AMICATorchNG:
     share_start, share_iter : int
         Sharing schedule: first iteration to attempt merges and the interval
         between attempts (Fortran ``share_start``/``share_iter``). The A-update
-        is held for ~6 iterations after each merge so densities can settle.
+        is held for the first 6 iterations of every cycle (independent of whether
+        a merge fired) so densities can settle; ``share_iter`` must be ``> 6`` so
+        that window never consumes the whole cycle.
     comp_thresh : float, default=0.99
         Cosine-similarity cutoff (in the de-sphered/sensor-space metric) above
         which two mixing columns are identified and merged.
@@ -464,16 +466,15 @@ class AMICATorchNG:
         self.doscaling = doscaling
         self.scalestep = scalestep
 
-        # Component sharing (Fortran share_comps / identify_shared_comps,
-        # amica15.f90:1838-1945): periodically merge mixing columns that are
-        # near-collinear across DIFFERENT models so they share one density and
-        # one mixing column. Multi-model only (a model cannot share with
-        # itself); OFF by default so single-model (#24) and default multi-model
-        # (#27) parity stay byte-for-byte. There is no bit-exact oracle -- the
-        # reference's similarity metric (Spinv2) is never initialized, so its
-        # reassignment never fires (the do_choose_pdfs situation, #26); this is
-        # the intended algorithm, validated by real-data behavior (unique-count
-        # drops, log-likelihood does not degrade).
+        # Component sharing (Fortran share_comps / identify_shared_comps trigger
+        # amica15.f90:1838, subroutine :1898-1945): periodically merge mixing
+        # columns near-collinear across DIFFERENT models so they share one
+        # density and one mixing column. Multi-model only (a model cannot share
+        # with itself); OFF by default so single-model (#24) and default
+        # multi-model (#27) parity stay byte-for-byte. No bit-exact oracle -- the
+        # reference's Spinv2 metric is declared but never allocated, so its
+        # reassignment is unrunnable (the do_choose_pdfs situation, #26); this is
+        # the intended algorithm, validated by real-data behavior.
         self.share_comps = share_comps
         self.share_start = share_start
         self.share_iter = share_iter
@@ -482,10 +483,21 @@ class AMICATorchNG:
         if share_comps:
             if share_start < 1:
                 raise ValueError(f"share_start must be >= 1, got {share_start}")
-            if share_iter < 1:
-                raise ValueError(f"share_iter must be >= 1, got {share_iter}")
+            if share_iter <= 6:
+                # The A-freeze settle window is 6 iterations; a smaller cycle
+                # would freeze A permanently (never leaving room to update it).
+                raise ValueError(f"share_iter must be > 6, got {share_iter}")
             if not 0.0 < comp_thresh <= 1.0:
                 raise ValueError(f"comp_thresh must be in (0, 1], got {comp_thresh}")
+            if pcakeep is not None or pcadb is not None:
+                # PCA reduction makes the sphere rank-deficient, so the
+                # de-sphering metric used for the merge decision is not
+                # invertible. Reject up front rather than crash mid-fit.
+                raise ValueError(
+                    "share_comps is incompatible with PCA reduction "
+                    "(pcakeep/pcadb): the de-sphering similarity metric requires "
+                    "a full-rank sphere."
+                )
 
         self.do_mean = do_mean
         self.do_sphere = do_sphere
@@ -1039,10 +1051,14 @@ class AMICATorchNG:
         # The exact-EM mu/beta divisions are unguarded (matching Fortran, whose own
         # mu/beta guard is commented out), so surface a non-finite value here
         # instead of letting it propagate to a later, unattributable nan-LL stop.
-        if not torch.isfinite(self.mu).all() or not torch.isfinite(self.beta).all():
+        if (
+            not torch.isfinite(self.mu).all()
+            or not torch.isfinite(self.beta).all()
+            or not torch.isfinite(self.alpha).all()
+        ):
             logger.warning(
-                "Non-finite mu/beta at iter %d (a mixture component's mass likely "
-                "collapsed).",
+                "Non-finite mu/beta/alpha at iter %d (a mixture component's mass "
+                "likely collapsed).",
                 self.iteration,
             )
 
@@ -1087,46 +1103,41 @@ class AMICATorchNG:
         # fixed point but sends the free-running fit downhill -- issue #24 root
         # cause (.context/issue-24/root_cause_Aupdate.py, machine-exact check).
         # (newton_active / sigma2 / lambda_ / kappa were finalized above.)
-        eye = torch.eye(self.n_channels, dtype=self.dtype, device=self.device)
-        directions = []
-        no_newt = False
-        for h in range(self.n_models):
-            dA_h = -acc["dWtmp"][:, :, h] / acc["dgm"][h] + eye  # I - <g b^T>/dgm
-            if newton_active:
-                H, posdef = self._newton_direction(
-                    dA_h, sigma2[:, h], lambda_[:, h], kappa[:, h]
-                )
-                if posdef:
-                    directions.append(H)
-                else:
-                    no_newt = True
-                    directions.append(dA_h)  # fall back to natural gradient
-            else:
-                directions.append(dA_h)
-
-        if newton_active and no_newt:
-            # Fortran prints "Hessian not positive definite, using natural
-            # gradient" here (amica17.f90:1911-1913). Surface the same signal so
-            # a silent all-fallback run (the current issue #21 behaviour) is
-            # visible without re-instrumenting the code.
-            self.n_newton_fallbacks += 1
-            logger.warning(
-                "Newton not positive definite at iter %d; using natural gradient.",
-                self.iteration,
-            )
-
-        # A-update. Accumulate each model's natural-gradient/Newton contribution
-        # per mixing COLUMN (Fortran dAk, amica15.f90:1735) via index_add, then
-        # apply once. Routing through comp_list makes columns SHARED across
-        # models (issue #60) sum their gradients; with the default disjoint
-        # comp_list it is identical to a per-model in-place update, so single-/
-        # multi-model parity stays byte-for-byte. Both the lrate ramp and the A
-        # step are held for ~6 iterations after each share event (Fortran
-        # A-freeze, amica15.f90:1785); _a_frozen is always False when sharing is
-        # off, so the default path is unchanged.
+        # A-update. When sharing holds A this iteration (the post-merge settle
+        # window, Fortran amica15.f90:1785), skip the whole block -- direction
+        # computation, lrate ramp, and step -- so a discarded Newton direction
+        # cannot pollute the fallback counter. _a_frozen is always False when
+        # sharing is off, so the default path is unchanged.
         if not self._a_frozen():
+            eye = torch.eye(self.n_channels, dtype=self.dtype, device=self.device)
+            directions = []
+            no_newt = False
+            for h in range(self.n_models):
+                dA_h = -acc["dWtmp"][:, :, h] / acc["dgm"][h] + eye  # I - <g b^T>/dgm
+                if newton_active:
+                    H, posdef = self._newton_direction(
+                        dA_h, sigma2[:, h], lambda_[:, h], kappa[:, h]
+                    )
+                    if posdef:
+                        directions.append(H)
+                    else:
+                        no_newt = True
+                        directions.append(dA_h)  # fall back to natural gradient
+                else:
+                    directions.append(dA_h)
+
+            if newton_active and no_newt:
+                # Fortran prints "Hessian not positive definite, using natural
+                # gradient" (amica15.f90:1791-1793). Surface the same signal so an
+                # all-fallback run (issue #21) is visible without re-instrumenting.
+                self.n_newton_fallbacks += 1
+                logger.warning(
+                    "Newton not positive definite at iter %d; using natural gradient.",
+                    self.iteration,
+                )
+
             # Learning-rate ramp: toward newtrate while Newton is active and
-            # stable, otherwise toward lrate0 (Fortran amica17.f90:1906-1917).
+            # stable, otherwise toward lrate0 (Fortran amica15.f90:1786-1797).
             # Ramped after mu/beta/rho (exact-EM, lrate-free) and before A.
             if newton_active and not no_newt:
                 self.lrate = min(
@@ -1137,10 +1148,22 @@ class AMICATorchNG:
                     self.lrate_cap, self.lrate + min(1.0 / self.newt_ramp, self.lrate)
                 )
 
+            # Accumulate each model's natural-gradient/Newton contribution per
+            # mixing COLUMN as a gm-WEIGHTED AVERAGE (Fortran dAk/zeta,
+            # amica15.f90:1730-1743): dAk = sum_h gm[h]*dir_h scattered by
+            # comp_list, zeta = sum_h gm[h] per column, then dAk /= zeta. For the
+            # default disjoint comp_list every column has exactly one contributor,
+            # so gm cancels (dAk = dir) and single-model (gm=[1]) is byte-for-byte
+            # unchanged; for a SHARED column (issue #60) the step is Fortran's
+            # responsibility-weighted average, NOT a raw sum (a raw sum would
+            # over-step by the contributor count and destabilize the fit).
             dAk = torch.zeros_like(self.A)
+            zeta = torch.zeros(self.n_comps, dtype=self.dtype, device=self.device)
             for h in range(self.n_models):
                 idx = self.comp_list[:, h]
-                dAk.index_add_(1, idx, directions[h].T @ self.A[:, idx])
+                dAk.index_add_(1, idx, self.gm[h] * (directions[h].T @ self.A[:, idx]))
+                zeta.index_add_(0, idx, self.gm[h].expand(idx.shape[0]))
+            dAk = dAk / zeta.clamp_min(torch.finfo(self.dtype).tiny)
             self.A = self.A - self.lrate * dAk
 
         if self.doscaling and (self.iteration % self.scalestep == 0):
@@ -1155,18 +1178,29 @@ class AMICATorchNG:
     def _a_frozen(self) -> bool:
         """Whether the A-update (and its lrate ramp) is held this iteration.
 
-        The Fortran reference freezes A for the first ~6 iterations of each
-        ``share_iter`` cycle after ``share_start`` (amica15.f90:1785) so the
-        density parameters can settle onto a freshly merged component before the
-        mixing matrix moves again. Gated behind ``share_comps`` here (the
-        reference gates only on the schedule, but freezing A when sharing is off
-        would change the validated default trajectory), so with ``share_comps``
-        off this is always False and the default path is untouched.
+        A is frozen for the first 6 iterations of every ``share_iter``-length
+        window once ``iter >= share_start`` -- i.e. the merge iteration and the 5
+        after it -- so the density parameters can settle onto any freshly merged
+        component before the mixing matrix moves again (Fortran A-freeze,
+        amica15.f90:1785). The window fires each cycle regardless of whether that
+        cycle's ``_identify_shared_comps`` actually merged a pair.
+
+        Anchored on ``(itf - share_start) % share_iter`` so it stays aligned with
+        the merge schedule for any ``share_start``; the literal Fortran formula
+        uses ``mod(iter, share_iter)`` (misaligned unless share_start is a
+        multiple of share_iter, and a permanent freeze for ``share_iter <= 6``),
+        but that path is dead in the reference (see :meth:`_identify_shared_comps`)
+        so there is no parity constraint -- the constructor requires
+        ``share_iter > 6`` so the window never consumes the whole cycle. Gated
+        behind ``share_comps`` and ``n_models >= 2``, so with sharing off it is
+        always False and the validated default trajectory is untouched.
         """
         if not self.share_comps or self.n_models < 2:
             return False
         itf = self.iteration + 1  # Fortran-style 1-indexed iteration
-        return itf >= self.share_start and (itf % self.share_iter) <= 5
+        if itf < self.share_start:
+            return False
+        return (itf - self.share_start) % self.share_iter <= 5
 
     def _identify_shared_comps(self) -> None:
         """Merge near-collinear mixing columns across models (Fortran
@@ -1190,15 +1224,38 @@ class AMICATorchNG:
         Skips a pair already merged, or one whose two columns coexist in some
         single model (a model cannot share a component with itself).
 
-        No bit-exact oracle: the reference's ``Spinv2`` metric is never
-        initialized (like ``do_choose_pdfs``, #26), so its reassignment never
-        actually fires. This implements the intended algorithm; correctness is
-        validated by real-data behavior, not byte parity.
+        No bit-exact oracle: ``Spinv2`` is *declared* in the reference headers
+        but never *allocated* anywhere in ``amica15.f90``/``amica17.f90`` (unlike
+        ``Spinv``, allocated at :551), so invoking ``identify_shared_comps`` with
+        ``share_comps=.true.`` would read an unallocated array through ``DGEMV``
+        -- undefined behavior, most likely a crash, not a benign no-op. The
+        routine is effectively unrunnable in the reference (cf. the also-dead
+        ``do_choose_pdfs`` switch, #26), so this implements the intended
+        algorithm and validates it on real data, not against byte parity.
         """
         if self.n_models < 2:
             return
         if self._spinv is None:
-            self._spinv = torch.linalg.inv(self.sphere)
+            # The de-sphering metric needs a full-rank, invertible sphere.
+            # Average-referenced EEG (covariance rank n_channels-1) or naturally
+            # rank-deficient data makes the sphere singular; surface it loudly
+            # rather than merging on garbage (the degenerate-fit philosophy,
+            # amica.py). (pcakeep/pcadb reduction is already rejected in __init__.)
+            try:
+                spinv = torch.linalg.inv(self.sphere)
+            except RuntimeError as exc:
+                raise RuntimeError(
+                    "Component sharing needs an invertible sphere, but it is "
+                    "singular (common with average-referenced or rank-deficient "
+                    "data). Disable share_comps or use full-rank data."
+                ) from exc
+            if not torch.isfinite(spinv).all():
+                raise RuntimeError(
+                    "Component sharing produced a non-finite de-sphering matrix "
+                    "(the sphere is singular/ill-conditioned). Disable share_comps "
+                    "or use full-rank data."
+                )
+            self._spinv = spinv
         # De-sphered mixing columns in sensor space, on CPU for the small greedy
         # scan (n_models^2 * n_channels^2 pairs; avoids per-element GPU syncs).
         atil = (self._spinv @ self.A).detach().cpu().numpy()
@@ -1217,7 +1274,9 @@ class AMICATorchNG:
                         t0 = abs(atil[:, ci] @ atil[:, cj]) / (
                             norms[ci] * norms[cj] + tiny
                         )
-                        if t0 < self.comp_thresh:
+                        # NaN t0 (e.g. a zero-norm column) must NOT merge:
+                        # `NaN < thresh` is False, so guard finiteness explicitly.
+                        if not np.isfinite(t0) or t0 < self.comp_thresh:
                             continue
                         # A model cannot share a component with itself: skip if
                         # any single model already uses both columns.
@@ -1371,6 +1430,7 @@ class AMICATorchNG:
         self.ll_history = []
         self.numrej = 0
         self.n_newton_fallbacks = 0
+        self._spinv = None  # rebuild the de-sphering metric for this fit's sphere
         self.stop_reason = "max_iter"
         self.good_idx = (
             torch.arange(n_total, device=self.device) if self.do_reject else None
@@ -1379,19 +1439,27 @@ class AMICATorchNG:
 
         # Best-iterate safeguard (issue #51): track the highest-LL iterate so a
         # late Newton-fallback overshoot cannot leave the returned model below a
-        # peak it already reached. Inactive under do_reject, where the good set
-        # (and the LL normalization) changes across iterations, so per-iteration
-        # LLs are not comparable.
-        track_best = self.keep_best and not self.do_reject
+        # peak it already reached. Inactive under do_reject (the good set, and so
+        # the LL normalization, changes across iterations) and under share_comps
+        # (a merge drops parameters, so pre- and post-merge LLs are not
+        # comparable AND the snapshot's comp_list would revert the merge -- the
+        # returned model would silently be unmerged; #60). In both cases fit()
+        # returns the last iterate, matching Fortran.
+        track_best = self.keep_best and not self.do_reject and not self.share_comps
         best_ll = -math.inf
         best_snapshot: Optional[Dict[str, object]] = None
-        if self.keep_best and self.do_reject:
-            # keep_best defaults on, so a user enabling rejection would otherwise
-            # silently lose the safeguard; surface it once (silent-failure review).
+        if self.keep_best and (self.do_reject or self.share_comps):
+            # keep_best defaults on, so a user enabling rejection/sharing would
+            # otherwise silently lose the safeguard; surface it once.
+            reason = "do_reject" if self.do_reject else "share_comps"
             logger.warning(
-                "keep_best is inactive under do_reject: the good-sample set (and "
-                "the per-iteration LL normalization) changes as samples are "
-                "rejected, so best-iterate selection by LL is not well-defined."
+                "keep_best is inactive under %s: best-iterate selection by LL is "
+                "not well-defined (%s), so fit() returns the last iterate.",
+                reason,
+                "the good-sample set / LL normalization changes across iterations"
+                if self.do_reject
+                else "a merge changes the parameter count and reverting to an "
+                "earlier snapshot would undo the merge",
             )
 
         iterator = tqdm(range(max_iter), desc="AMICA-NG", disable=not verbose)
@@ -1465,8 +1533,11 @@ class AMICATorchNG:
             # Component sharing (Fortran identify_shared_comps schedule,
             # amica15.f90:1838): once per share_iter cycle from share_start,
             # merge near-collinear mixing columns across models using the
-            # just-updated A; the merged comp_list takes effect next E-step.
-            # No-op when share_comps is off or n_models == 1.
+            # just-updated A. Fortran runs identify_shared_comps BEFORE
+            # get_unmixing_matrices (amica15.f90:1840,1845), so rebuild W from the
+            # merged comp_list -- otherwise the next E-step would read a stale W
+            # (pre-merge comp_list) while indexing the densities by the merged
+            # comp_list. No-op when share_comps is off or n_models == 1.
             if self.share_comps:
                 itf = it + 1
                 if (
@@ -1474,6 +1545,7 @@ class AMICATorchNG:
                     and (itf - self.share_start) % self.share_iter == 0
                 ):
                     self._identify_shared_comps()
+                    self._update_unmixing_matrices()
 
             self.ll_history.append(ll)
 

--- a/pyAMICA/torch_impl/core.py
+++ b/pyAMICA/torch_impl/core.py
@@ -293,6 +293,23 @@ class AMICATorchNG:
     doscaling, scalestep : bool, int
         Whether/how often to rescale ``A`` columns to unit norm each
         iteration (with matching ``mu``/``beta`` rescale).
+    share_comps : bool, default=False
+        Enable multi-model component sharing (Fortran ``share_comps`` /
+        ``identify_shared_comps``, amica15.f90:1898): components that are
+        near-collinear across different models are merged so they share one
+        mixing column and one density. Requires ``n_models >= 2`` (a model
+        cannot share with itself); a no-op otherwise. OFF by default, so
+        single-model (#24) and default multi-model (#27) results are unchanged.
+        There is no bit-exact oracle -- the reference's similarity metric is
+        never initialized (like ``do_choose_pdfs``, #26) -- so this implements
+        the intended algorithm, validated by real-data behavior.
+    share_start, share_iter : int
+        Sharing schedule: first iteration to attempt merges and the interval
+        between attempts (Fortran ``share_start``/``share_iter``). The A-update
+        is held for ~6 iterations after each merge so densities can settle.
+    comp_thresh : float, default=0.99
+        Cosine-similarity cutoff (in the de-sphered/sensor-space metric) above
+        which two mixing columns are identified and merged.
     do_mean, do_sphere, do_approx_sphere : bool
         Preprocessing options, matching ``pyAMICA.AMICA._preprocess_data``.
     pcakeep, pcadb : int, float, optional
@@ -345,6 +362,10 @@ class AMICATorchNG:
         invsigmax: float = 1000.0,
         doscaling: bool = True,
         scalestep: int = 1,
+        share_comps: bool = False,
+        share_start: int = 100,
+        share_iter: int = 100,
+        comp_thresh: float = 0.99,
         do_mean: bool = True,
         do_sphere: bool = True,
         do_approx_sphere: bool = True,
@@ -442,6 +463,29 @@ class AMICATorchNG:
 
         self.doscaling = doscaling
         self.scalestep = scalestep
+
+        # Component sharing (Fortran share_comps / identify_shared_comps,
+        # amica15.f90:1838-1945): periodically merge mixing columns that are
+        # near-collinear across DIFFERENT models so they share one density and
+        # one mixing column. Multi-model only (a model cannot share with
+        # itself); OFF by default so single-model (#24) and default multi-model
+        # (#27) parity stay byte-for-byte. There is no bit-exact oracle -- the
+        # reference's similarity metric (Spinv2) is never initialized, so its
+        # reassignment never fires (the do_choose_pdfs situation, #26); this is
+        # the intended algorithm, validated by real-data behavior (unique-count
+        # drops, log-likelihood does not degrade).
+        self.share_comps = share_comps
+        self.share_start = share_start
+        self.share_iter = share_iter
+        self.comp_thresh = comp_thresh
+        self._spinv = None  # cached de-sphering metric, built on first share
+        if share_comps:
+            if share_start < 1:
+                raise ValueError(f"share_start must be >= 1, got {share_start}")
+            if share_iter < 1:
+                raise ValueError(f"share_iter must be >= 1, got {share_iter}")
+            if not 0.0 < comp_thresh <= 1.0:
+                raise ValueError(f"comp_thresh must be in (0, 1], got {comp_thresh}")
 
         self.do_mean = do_mean
         self.do_sphere = do_sphere
@@ -956,7 +1000,19 @@ class AMICATorchNG:
                     self.iteration,
                 )
 
-        self.alpha = acc["dalpha_n"] / acc["dalpha_n"].sum(dim=0, keepdim=True)
+        # Component sharing (#60): a component that was merged away is no longer
+        # referenced by comp_list, so no sufficient statistic accumulates into
+        # its column (dalpha_n/dmu_d/dbeta_d == 0) and the divisions below would
+        # be 0/0 = NaN. Update only USED columns and freeze the rest at their
+        # last finite value (Fortran carries NaN there harmlessly behind its
+        # comp_used mask; we keep them finite so save/the degenerate guard are
+        # not tripped). With the default full comp_list every column is used, so
+        # ``used`` is all-True and every update below is byte-for-byte unchanged.
+        used = self.comp_used.unsqueeze(0)  # (1, n_comps)
+
+        self.alpha = torch.where(
+            used, acc["dalpha_n"] / acc["dalpha_n"].sum(dim=0, keepdim=True), self.alpha
+        )
 
         # Finalize the Newton curvature with the PRE-update mu. Fortran folds the
         # mu^2 term into lambda during E-step accumulation, before the M-step
@@ -968,11 +1024,16 @@ class AMICATorchNG:
             sigma2, lambda_, kappa = self._finalize_newton_stats(acc)
 
         # Exact-EM mixture location/scale (Fortran :1978/:1993). No lrate.
-        self.mu = self.mu + acc["dmu_n"] / acc["dmu_d"]
-        self.beta = torch.clamp(
-            self.beta * torch.sqrt(acc["dbeta_n"] / acc["dbeta_d"]),
-            self.invsigmin,
-            self.invsigmax,
+        # ``used`` masks merged-away columns (no-op for the default comp_list).
+        self.mu = torch.where(used, self.mu + acc["dmu_n"] / acc["dmu_d"], self.mu)
+        self.beta = torch.where(
+            used,
+            torch.clamp(
+                self.beta * torch.sqrt(acc["dbeta_n"] / acc["dbeta_d"]),
+                self.invsigmin,
+                self.invsigmax,
+            ),
+            self.beta,
         )
         # Fortran keeps a live "NaN in sbeta!" canary here (amica17.f90:1996-2000).
         # The exact-EM mu/beta divisions are unguarded (matching Fortran, whose own
@@ -1012,7 +1073,9 @@ class AMICATorchNG:
                 new_rho = torch.where(
                     nan_mask, torch.full_like(new_rho, self.rho0), new_rho
                 )
-            self.rho = torch.clamp(new_rho, self.minrho, self.maxrho)
+            self.rho = torch.where(
+                used, torch.clamp(new_rho, self.minrho, self.maxrho), self.rho
+            )
 
         # --- A / W update: natural gradient, optionally Newton-preconditioned.
         # A is stored as Fortran's A^T (the true unmixing is W^T = inv(A)^T), so
@@ -1052,22 +1115,33 @@ class AMICATorchNG:
                 self.iteration,
             )
 
-        # Learning-rate ramp: toward newtrate while Newton is active and stable,
-        # otherwise toward lrate0 (Fortran amica17.f90:1906-1917). Ramped after
-        # mu/beta/rho (which are exact-EM, lrate-free) and before A.
-        if newton_active and not no_newt:
-            self.lrate = min(
-                self.newtrate, self.lrate + min(1.0 / self.newt_ramp, self.lrate)
-            )
-        else:
-            self.lrate = min(
-                self.lrate_cap, self.lrate + min(1.0 / self.newt_ramp, self.lrate)
-            )
+        # A-update. Accumulate each model's natural-gradient/Newton contribution
+        # per mixing COLUMN (Fortran dAk, amica15.f90:1735) via index_add, then
+        # apply once. Routing through comp_list makes columns SHARED across
+        # models (issue #60) sum their gradients; with the default disjoint
+        # comp_list it is identical to a per-model in-place update, so single-/
+        # multi-model parity stays byte-for-byte. Both the lrate ramp and the A
+        # step are held for ~6 iterations after each share event (Fortran
+        # A-freeze, amica15.f90:1785); _a_frozen is always False when sharing is
+        # off, so the default path is unchanged.
+        if not self._a_frozen():
+            # Learning-rate ramp: toward newtrate while Newton is active and
+            # stable, otherwise toward lrate0 (Fortran amica17.f90:1906-1917).
+            # Ramped after mu/beta/rho (exact-EM, lrate-free) and before A.
+            if newton_active and not no_newt:
+                self.lrate = min(
+                    self.newtrate, self.lrate + min(1.0 / self.newt_ramp, self.lrate)
+                )
+            else:
+                self.lrate = min(
+                    self.lrate_cap, self.lrate + min(1.0 / self.newt_ramp, self.lrate)
+                )
 
-        for h in range(self.n_models):
-            idx = self.comp_list[:, h]
-            A_cols = self.A[:, idx]
-            self.A[:, idx] = A_cols - self.lrate * (directions[h].T @ A_cols)
+            dAk = torch.zeros_like(self.A)
+            for h in range(self.n_models):
+                idx = self.comp_list[:, h]
+                dAk.index_add_(1, idx, directions[h].T @ self.A[:, idx])
+            self.A = self.A - self.lrate * dAk
 
         if self.doscaling and (self.iteration % self.scalestep == 0):
             scale = torch.sqrt((self.A**2).sum(dim=0))  # (n_comps,)
@@ -1077,6 +1151,103 @@ class AMICATorchNG:
             self.beta[:, nonzero] = self.beta[:, nonzero] / scale[nonzero]
 
         self._update_unmixing_matrices()
+
+    def _a_frozen(self) -> bool:
+        """Whether the A-update (and its lrate ramp) is held this iteration.
+
+        The Fortran reference freezes A for the first ~6 iterations of each
+        ``share_iter`` cycle after ``share_start`` (amica15.f90:1785) so the
+        density parameters can settle onto a freshly merged component before the
+        mixing matrix moves again. Gated behind ``share_comps`` here (the
+        reference gates only on the schedule, but freezing A when sharing is off
+        would change the validated default trajectory), so with ``share_comps``
+        off this is always False and the default path is untouched.
+        """
+        if not self.share_comps or self.n_models < 2:
+            return False
+        itf = self.iteration + 1  # Fortran-style 1-indexed iteration
+        return itf >= self.share_start and (itf % self.share_iter) <= 5
+
+    def _identify_shared_comps(self) -> None:
+        """Merge near-collinear mixing columns across models (Fortran
+        ``identify_shared_comps``, amica15.f90:1898).
+
+        Two components (model ``h`` source ``i`` and model ``hh`` source ``ii``,
+        ``h < hh``) are identified when the angle between their mixing columns,
+        measured in the original (de-sphered) data space, is below the
+        ``comp_thresh`` cutoff::
+
+            t0 = |a . b| / (||a|| ||b||),   a = Spinv A[:,ci], b = Spinv A[:,cj]
+
+        where ``Spinv = sphere^-1`` de-spheres the columns back to sensor space
+        (so the similarity compares scalp maps). On a match, ``cj`` is folded
+        into ``ci``: every ``comp_list`` entry equal to ``cj`` is reassigned to
+        ``ci``, so the two now share one mixing column and one density (the
+        M-step already accumulates every sufficient statistic through
+        ``comp_list`` via index_add, so shared components sum automatically).
+
+        Greedy and order-dependent, matching the reference's quadruple loop.
+        Skips a pair already merged, or one whose two columns coexist in some
+        single model (a model cannot share a component with itself).
+
+        No bit-exact oracle: the reference's ``Spinv2`` metric is never
+        initialized (like ``do_choose_pdfs``, #26), so its reassignment never
+        actually fires. This implements the intended algorithm; correctness is
+        validated by real-data behavior, not byte parity.
+        """
+        if self.n_models < 2:
+            return
+        if self._spinv is None:
+            self._spinv = torch.linalg.inv(self.sphere)
+        # De-sphered mixing columns in sensor space, on CPU for the small greedy
+        # scan (n_models^2 * n_channels^2 pairs; avoids per-element GPU syncs).
+        atil = (self._spinv @ self.A).detach().cpu().numpy()
+        norms = np.linalg.norm(atil, axis=0)
+        cl = self.comp_list.detach().cpu().numpy().copy()  # (nw, n_models)
+        nw, m = cl.shape
+        tiny = np.finfo(atil.dtype).tiny
+        merged = 0
+        for h in range(m):
+            for hh in range(h + 1, m):
+                for i in range(nw):
+                    for ii in range(nw):
+                        ci, cj = int(cl[i, h]), int(cl[ii, hh])
+                        if ci == cj:
+                            continue
+                        t0 = abs(atil[:, ci] @ atil[:, cj]) / (
+                            norms[ci] * norms[cj] + tiny
+                        )
+                        if t0 < self.comp_thresh:
+                            continue
+                        # A model cannot share a component with itself: skip if
+                        # any single model already uses both columns.
+                        if any(
+                            (cl[:, k] == ci).any() and (cl[:, k] == cj).any()
+                            for k in range(m)
+                        ):
+                            continue
+                        cl[cl == cj] = ci  # fold cj into ci everywhere
+                        merged += 1
+        if merged:
+            self.comp_list = torch.from_numpy(cl).to(self.comp_list.device)
+            logger.info(
+                "Component sharing (iter %d): %d merge(s), %d unique components.",
+                self.iteration,
+                merged,
+                int(np.unique(cl).size),
+            )
+
+    @property
+    def comp_used(self) -> torch.Tensor:
+        """Boolean mask (n_comps,) of components still referenced by comp_list.
+
+        A component drops out of use when it is folded into another by
+        :meth:`_identify_shared_comps`; unused columns receive no gradient and
+        are never read by the E-step. Derived from ``comp_list`` (not stored).
+        """
+        used = torch.zeros(self.n_comps, dtype=torch.bool, device=self.comp_list.device)
+        used[self.comp_list.reshape(-1)] = True
+        return used
 
     def _choose_pdfs(self, X: torch.Tensor) -> None:
         """Extended-Infomax adaptive PDF switch (Fortran ``do_choose_pdfs``).
@@ -1290,6 +1461,19 @@ class AMICATorchNG:
                 ):
                     self._choose_pdfs(X_use)
                     self.n_kurt_done += 1
+
+            # Component sharing (Fortran identify_shared_comps schedule,
+            # amica15.f90:1838): once per share_iter cycle from share_start,
+            # merge near-collinear mixing columns across models using the
+            # just-updated A; the merged comp_list takes effect next E-step.
+            # No-op when share_comps is off or n_models == 1.
+            if self.share_comps:
+                itf = it + 1
+                if (
+                    itf >= self.share_start
+                    and (itf - self.share_start) % self.share_iter == 0
+                ):
+                    self._identify_shared_comps()
 
             self.ll_history.append(ll)
 
@@ -1533,6 +1717,12 @@ class AMICATorchNG:
             "invsigmax": self.invsigmax,
             "doscaling": self.doscaling,
             "scalestep": self.scalestep,
+            # Component sharing (issue #60): persisted so a reloaded multi-model
+            # run keeps its schedule; the merged comp_list itself is in params.
+            "share_comps": self.share_comps,
+            "share_start": self.share_start,
+            "share_iter": self.share_iter,
+            "comp_thresh": self.comp_thresh,
             "do_mean": self.do_mean,
             "do_sphere": self.do_sphere,
             "do_approx_sphere": self.do_approx_sphere,


### PR DESCRIPTION
Closes #60. Ports the last unimplemented Fortran feature: multi-model component sharing.

## What it does
On the `share_start`/`share_iter` schedule, components that are near-collinear **across different models** (cosine angle of their de-sphered mixing columns above `comp_thresh`) are merged into one shared mixing column and one shared density (Fortran `identify_shared_comps`, amica15.f90:1898). An A-freeze holds the mixing update for ~6 iterations after each merge so densities can settle.

## Design (mirrors the #26 adaptive-PDF precedent)
- **No bit-exact oracle.** The reference's similarity metric `Spinv2` is **never declared/initialized** in `amica15.f90` (which has `implicit none`, so it would not even compile as-is) -- its reassignment never actually fires, exactly like the dead `do_choose_pdfs` switch (#26). So this implements the *intended* algorithm (cosine similarity of de-sphered scalp maps) and validates by real-data behavior, not byte parity.
- **Off by default**, and a no-op for `n_models=1` -- single-model (#24) and default multi-model (#27) parity stay **byte-for-byte** (full torch suite green: 95 passed).
- The M-step already sums sufficient stats through `comp_list` (index_add), so shared densities update jointly for free. The **A-update was refactored** to accumulate shared columns the same way (`dAk` index_add) -- byte-identical to the per-model update when unshared.
- **Merged-away columns are frozen** in the density M-step (they get no stats, so `0/0 -> NaN` otherwise; Fortran tolerates this behind its `comp_used` mask, we keep them finite so save/the degenerate-fit contract aren't tripped).

## Tests (`tests/torch_tests/test_ng_sharing.py`, 6)
- single-model byte-identical with sharing on vs off
- controlled single collinear-pair merge
- the 'no double-share within a model' guard (all-collinear 2x2 -> 2 shared comps, not 1)
- default multi-model leaves comps unshared
- full 2-model share fit stays finite and shares
- save/load round-trips the share config + merged comp_list

No new persisted state (comp_list already persisted; `comp_used` is derived). Also gitignores `.env`.