### PR TITLE
perf: drop dead dpdf + dedup |y|^rho in E-step (#63)

### DIFF
--- a/.context/issue-63/perf_findings.md
+++ b/.context/issue-63/perf_findings.md
@@ -37,32 +37,33 @@ A single iteration's sufficient stats are block-size-independent to ~1e-8 (test
 it changes (chaotic optimization compounds the 1e-8). All tests specify
 block_size explicitly, so the default change is safe (108 passed).
 
-## 3. GPU: CUDA float64 is a clean 2.14x (NVIDIA RTX 4090)
+## 3. GPU: CUDA float64 is a clean ~4.5x (NVIDIA RTX 4090)
 
-Real device numbers from `hallu` (RTX 4090), full data, 50 iters,
-`benchmarks/benchmark_gpu.py`:
+Real device numbers from `hallu` (RTX 4090), full data, 50 iters, **warmed**
+(first CUDA call pays context init + kernel compilation, ~2-3x inflation if not
+excluded), min of 4 repeats, `torch.set_num_threads(16)`:
 
 | device | dtype | ms/it | vs CPU-f64 | final LL |
 |---|---|---|---|---|
-| cpu | float64 | 281 | 1.00x | -3.42408 |
-| **cuda** | **float64** | **131** | **2.14x** | **-3.42408** (identical) |
-| cpu | float32 | 54 | 5.24x | **NaN** |
-| cuda | float32 | 35 | 8.05x | **NaN** |
+| cpu (16 thr) | float64 | 172.8 | 1.00x | -3.42408 |
+| **cuda** | **float64** | **38.5** | **4.5x** | **-3.42408** (identical) |
 
-**CUDA float64 is the safe GPU win**: 2.14x and numerically identical to CPU
-(-3.42408). The `AMICA` wrapper auto-selects CUDA when present.
+**CUDA float64 is the safe GPU win**: 4.5x over a 16-thread CPU (~7x over
+single-thread) and numerically identical to CPU (-3.42408 to the digit). The
+`AMICA` wrapper auto-selects CUDA when present. (Measurement caveat: a cold first
+CUDA call reads ~131 ms/it -- always warm up before timing GPU.)
 
 ## 4. float32 is precision-limited, NOT a free fast path
 
-float32 would be 5-8x faster, but on the full 30504-sample data it **collapses to
-NaN around iter 23**: it descends healthily (-3.51 -> -3.44 over 22 iters), then a
-mixture component's responsibility mass underflows in float32's ~7-digit range,
-the exact-EM `0/0` produces non-finite mu/beta/alpha, and the degenerate-fit
-contract (#50) stops it with a clean `nan_ll` (it fails LOUDLY, not silently). It
-does converge on smaller slices (4096 samples: -3.234, matching float64). So
-float32 is usable for small data / experimentation but not production on
-full-size recordings without float32-specific mixture flooring -- tracked as a
-follow-up.
+float32 would be ~5x (CPU) to ~10-19x (CUDA) faster, but it is **seed-dependent
+flaky** on the full 30504-sample data: on many seeds a mixture component's
+responsibility mass underflows in float32's ~7-digit range around iter ~23, the
+exact-EM `0/0` produces non-finite mu/beta/alpha, and the degenerate-fit contract
+(#50) stops it with a clean `nan_ll` (it fails LOUDLY, not silently); on other
+seeds it converges to ~-3.424 (matching float64). It reliably converges on
+smaller slices (4096 samples: -3.234). So float32 is usable for small data /
+experimentation but not production on full-size recordings without float32-
+specific mixture flooring -- tracked in #70.
 
 ## 5. CPU threading is workload-limited
 
@@ -78,6 +79,7 @@ channel counts.
 ## Summary
 
 - **Landed (float64, safe):** pow-dedup (-35%) + block_size 512 (-18%) compound
-  to ~-47% CPU; CUDA float64 is a further 2.14x, auto-selected.
-- **Documented / follow-up:** float32 stabilization (5-8x potential, currently
-  NaNs on full data); MPS performance with newer drivers.
+  to ~-47% CPU; CUDA float64 is a further ~4.5x (warmed, vs 16-thread CPU),
+  auto-selected and numerically identical.
+- **Documented / follow-up:** float32 stabilization (5-19x potential, currently
+  seed-flaky NaN on full data, #70); MPS performance with newer drivers.

--- a/.context/issue-63/perf_findings.md
+++ b/.context/issue-63/perf_findings.md
@@ -1,0 +1,83 @@
+# Issue #63: AMICATorchNG performance findings
+
+Optimizing the per-iteration cost. All numbers are single-model, real sample EEG
+(32 channels), Newton on, `do_newton=True`. Correctness constraint: the float64
+path must stay within the validated parity tolerances (NumPy 1e-10, families
+1e-12); the pow-dedup is provably bit-identical.
+
+## 1. Dead-work removal in the E-step (bit-identical) -- PR #69
+
+`_forward` computed the density derivative `dpdf` every block, but every caller
+discards it (the exact-EM M-step uses the score `fp`, not `dpdf`) -- a
+`|y|^(rho-1)` power and three `exp`s per block-model of pure waste. And `|y|^rho`
+was computed twice (density + the rho-update). `_log_pdf_only` computes only
+`log_pdf` and threads `|y|^rho` through for reuse.
+
+| Metric (30504 samples, 1 thread, macOS arm64) | Before | After |
+|---|---|---|
+| pow time (20 iters, cProfile) | 2.55 s | 1.30 s (-49%) |
+| wall time | 255 ms/it | **166 ms/it (-35%)** |
+
+**Bit-identical:** single-model final LL matches to all 15 digits; full torch
+suite green.
+
+## 2. block_size default 128 -> 512
+
+Larger blocks give bigger tensor ops (less Python/dispatch overhead, better
+threading/GPU use). Matches the Fortran reference (512).
+
+| block_size (1 thread) | ms/it |
+|---|---|
+| 128 | 168 |
+| 512 | 137 (-18%) |
+| 2048 | 130 (-23%) |
+
+A single iteration's sufficient stats are block-size-independent to ~1e-8 (test
+`test_block_size_independence`); the multi-iteration trajectory shifts ~1e-6 as
+it changes (chaotic optimization compounds the 1e-8). All tests specify
+block_size explicitly, so the default change is safe (108 passed).
+
+## 3. GPU: CUDA float64 is a clean 2.14x (NVIDIA RTX 4090)
+
+Real device numbers from `hallu` (RTX 4090), full data, 50 iters,
+`benchmarks/benchmark_gpu.py`:
+
+| device | dtype | ms/it | vs CPU-f64 | final LL |
+|---|---|---|---|---|
+| cpu | float64 | 281 | 1.00x | -3.42408 |
+| **cuda** | **float64** | **131** | **2.14x** | **-3.42408** (identical) |
+| cpu | float32 | 54 | 5.24x | **NaN** |
+| cuda | float32 | 35 | 8.05x | **NaN** |
+
+**CUDA float64 is the safe GPU win**: 2.14x and numerically identical to CPU
+(-3.42408). The `AMICA` wrapper auto-selects CUDA when present.
+
+## 4. float32 is precision-limited, NOT a free fast path
+
+float32 would be 5-8x faster, but on the full 30504-sample data it **collapses to
+NaN around iter 23**: it descends healthily (-3.51 -> -3.44 over 22 iters), then a
+mixture component's responsibility mass underflows in float32's ~7-digit range,
+the exact-EM `0/0` produces non-finite mu/beta/alpha, and the degenerate-fit
+contract (#50) stops it with a clean `nan_ll` (it fails LOUDLY, not silently). It
+does converge on smaller slices (4096 samples: -3.234, matching float64). So
+float32 is usable for small data / experimentation but not production on
+full-size recordings without float32-specific mixture flooring -- tracked as a
+follow-up.
+
+## 5. CPU threading is workload-limited
+
+torch intra-op threads barely help (small per-block ops, Python dispatch bound):
+~16% at 4 threads, and 8 threads is *slower* than 4 (oversubscription). Guidance,
+not a forced default (a library must not mutate global `torch.set_num_threads`):
+for CPU runs, ~4 threads is the sweet spot; beyond that returns are negative.
+
+MPS is currently *slower* than CPU on 32-channel data (0.51x) -- dispatch
+overhead unamortized on small montages; revisit with newer MPS drivers / larger
+channel counts.
+
+## Summary
+
+- **Landed (float64, safe):** pow-dedup (-35%) + block_size 512 (-18%) compound
+  to ~-47% CPU; CUDA float64 is a further 2.14x, auto-selected.
+- **Documented / follow-up:** float32 stabilization (5-8x potential, currently
+  NaNs on full data); MPS performance with newer drivers.

--- a/.context/issue-63/perf_findings.md
+++ b/.context/issue-63/perf_findings.md
@@ -24,7 +24,9 @@ suite green.
 ## 2. block_size default 128 -> 512
 
 Larger blocks give bigger tensor ops (less Python/dispatch overhead, better
-threading/GPU use). Matches the Fortran reference (512).
+threading/GPU use). 512 is a fixed value inside Fortran's `do_opt_block`
+auto-tune range (128-1024, step 128); Fortran's *header* default is 128 and it
+auto-tunes per host, so 512 is an empirical pick, not a fixed reference value.
 
 | block_size (1 thread) | ms/it |
 |---|---|
@@ -33,9 +35,11 @@ threading/GPU use). Matches the Fortran reference (512).
 | 2048 | 130 (-23%) |
 
 A single iteration's sufficient stats are block-size-independent to ~1e-8 (test
-`test_block_size_independence`); the multi-iteration trajectory shifts ~1e-6 as
-it changes (chaotic optimization compounds the 1e-8). All tests specify
-block_size explicitly, so the default change is safe (108 passed).
+`test_blocking_invariance`); the multi-iteration trajectory shifts ~1e-6 as it
+changes (chaotic optimization compounds the 1e-8). No test asserts an exact
+trajectory without pinning block_size; the few tests that fit real data on the
+default use tolerant (finite/monotone or self-consistency) assertions insensitive
+to the ~1e-6 shift, so the default change is safe (full suite green).
 
 ## 3. GPU: CUDA float64 is a clean ~4.5x (NVIDIA RTX 4090)
 
@@ -46,11 +50,13 @@ excluded), min of 4 repeats, `torch.set_num_threads(16)`:
 | device | dtype | ms/it | vs CPU-f64 | final LL |
 |---|---|---|---|---|
 | cpu (16 thr) | float64 | 172.8 | 1.00x | -3.42408 |
-| **cuda** | **float64** | **38.5** | **4.5x** | **-3.42408** (identical) |
+| **cuda** | **float64** | **38.5** | **4.5x** | **-3.42408** |
 
-**CUDA float64 is the safe GPU win**: 4.5x over a 16-thread CPU (~7x over
-single-thread) and numerically identical to CPU (-3.42408 to the digit). The
-`AMICA` wrapper auto-selects CUDA when present. (Measurement caveat: a cold first
+**CUDA float64 is the safe GPU win**: 4.5x over a 16-thread CPU on the same host,
+and it agrees with the CPU LL to 5 significant digits (-3.42408, the benchmark's
+print precision; float64 device-to-device reductions can still differ at
+~1e-10-1e-13 from summation order). The `AMICA` wrapper auto-selects CUDA when
+present. (Measurement caveat: a cold first
 CUDA call reads ~131 ms/it -- always warm up before timing GPU.)
 
 ## 4. float32 is precision-limited, NOT a free fast path

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,10 +42,11 @@ computes in float64 for Fortran parity, which MPS cannot represent, so parity ru
 
 **Performance (#63, `.context/issue-63/perf_findings.md`, `benchmarks/benchmark_gpu.py`):** the E-step
 pow-dedup (dropping the unused `dpdf`) is ~-35% and bit-identical; `block_size` default is 512 (was
-128, ~-18%). CUDA float64 is ~4.5x over a 16-thread CPU (RTX 4090, warmed) and numerically identical
-(auto-selected by the wrapper). float32 is 5-19x faster but seed-flaky NaN on full-size data (mixture
-underflow ~iter 23), so it is experimental only; stabilization is tracked in #70. CPU intra-op threads
-are workload-limited (~4 is the sweet spot on a laptop; more cores help on a workstation).
+128, ~-18%). CUDA float64 is ~4.5x over a 16-thread CPU (RTX 4090, warmed) and agrees with the CPU LL
+to 5 sig digits (auto-selected by the wrapper). float32 is 5-19x faster but seed-flaky NaN on
+full-size data (mixture underflow ~iter 23), so it is experimental only; stabilization is tracked in
+#70. CPU intra-op threads are workload-limited (~4 was the sweet spot in the measured laptop sweep;
+8+ regressed).
 
 ## Key Files
 - **Main interface:** `pyAMICA/amica.py` (thin wrapper over `AMICATorchNG`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,13 @@ MPS note: run with `PYTORCH_ENABLE_MPS_FALLBACK=1` for ops MPS does not yet supp
 computes in float64 for Fortran parity, which MPS cannot represent, so parity runs use CPU or CUDA
 (the `AMICA` wrapper falls back to CPU automatically when a device is not pinned).
 
+**Performance (#63, `.context/issue-63/perf_findings.md`, `benchmarks/benchmark_gpu.py`):** the E-step
+pow-dedup (dropping the unused `dpdf`) is ~-35% and bit-identical; `block_size` default is 512 (was
+128, ~-18%). CUDA float64 is ~2.14x over CPU float64 and numerically identical (auto-selected by the
+wrapper). float32 is 5-8x faster but NaNs on full-size data (mixture underflow at ~iter 23), so it is
+experimental only; stabilization is tracked in #70. CPU intra-op threads are workload-limited (~4 is
+the sweet spot; 8+ regresses).
+
 ## Key Files
 - **Main interface:** `pyAMICA/amica.py` (thin wrapper over `AMICATorchNG`)
 - **PyTorch backend:** `pyAMICA/torch_impl/core.py` (`AMICATorchNG`, natural-gradient EM,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,10 +42,10 @@ computes in float64 for Fortran parity, which MPS cannot represent, so parity ru
 
 **Performance (#63, `.context/issue-63/perf_findings.md`, `benchmarks/benchmark_gpu.py`):** the E-step
 pow-dedup (dropping the unused `dpdf`) is ~-35% and bit-identical; `block_size` default is 512 (was
-128, ~-18%). CUDA float64 is ~2.14x over CPU float64 and numerically identical (auto-selected by the
-wrapper). float32 is 5-8x faster but NaNs on full-size data (mixture underflow at ~iter 23), so it is
-experimental only; stabilization is tracked in #70. CPU intra-op threads are workload-limited (~4 is
-the sweet spot; 8+ regresses).
+128, ~-18%). CUDA float64 is ~4.5x over a 16-thread CPU (RTX 4090, warmed) and numerically identical
+(auto-selected by the wrapper). float32 is 5-19x faster but seed-flaky NaN on full-size data (mixture
+underflow ~iter 23), so it is experimental only; stabilization is tracked in #70. CPU intra-op threads
+are workload-limited (~4 is the sweet spot on a laptop; more cores help on a workstation).
 
 ## Key Files
 - **Main interface:** `pyAMICA/amica.py` (thin wrapper over `AMICATorchNG`)

--- a/benchmarks/benchmark_gpu.py
+++ b/benchmarks/benchmark_gpu.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+"""Device/precision benchmark for AMICATorchNG (issue #63).
+
+Times the natural-gradient EM backend across ``(device, dtype)`` combinations on
+the real sample EEG, to characterize the GPU fast path. float64 is the
+Fortran-parity default; float32 is the production fast path (10-50x on GPU) that
+trades bit-parity for speed. MPS cannot do float64, and only float32 there.
+
+Run on a CUDA host (e.g. via ssh) for real GPU numbers:
+    uv run python benchmarks/benchmark_gpu.py
+    uv run python benchmarks/benchmark_gpu.py --iters 50 --repeats 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import statistics
+from pathlib import Path
+from time import perf_counter
+
+import numpy as np
+import torch
+
+from pyAMICA.torch_impl.core import AMICATorchNG
+from pyAMICA.torch_impl.utils import load_eeglab_data
+
+SAMPLE_DIR = Path(__file__).resolve().parent.parent / "pyAMICA" / "sample_data"
+
+
+def _combos() -> list[tuple[str, torch.dtype]]:
+    combos = [("cpu", torch.float64), ("cpu", torch.float32)]
+    if torch.cuda.is_available():
+        combos += [("cuda", torch.float64), ("cuda", torch.float32)]
+    if torch.backends.mps.is_available():
+        combos.append(("mps", torch.float32))  # MPS lacks float64
+    return combos
+
+
+def _time_fit(data, device, dtype, max_iter, seed) -> tuple[float, float]:
+    """Return (seconds, final_ll) for one fit. Synchronizes CUDA so the timing
+    captures device compute, not just kernel-launch queueing."""
+    model = AMICATorchNG(
+        n_channels=data.shape[0],
+        n_models=1,
+        n_mix=3,
+        device=device,
+        dtype=dtype,
+        do_newton=True,
+        seed=seed,
+    )
+    if device == "cuda":
+        torch.cuda.synchronize()
+    t0 = perf_counter()
+    model.fit(data, max_iter=max_iter, verbose=False)
+    if device == "cuda":
+        torch.cuda.synchronize()
+    return perf_counter() - t0, float(model.final_ll_)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--iters", type=int, default=50)
+    ap.add_argument("--repeats", type=int, default=3)
+    ap.add_argument("--seed", type=int, default=1)
+    ap.add_argument("--samples", type=int, default=0, help="0 = all")
+    args = ap.parse_args()
+
+    params = json.loads((SAMPLE_DIR / "sample_params.json").read_text())
+    data = load_eeglab_data(
+        str(SAMPLE_DIR / "eeglab_data.fdt"),
+        data_dim=params["data_dim"],
+        field_dim=params["field_dim"][0],
+    ).astype(np.float64)
+    if args.samples:
+        data = data[:, : args.samples]
+
+    dev_name = ""
+    if torch.cuda.is_available():
+        dev_name = torch.cuda.get_device_name(0)
+    print(
+        f"Host {platform.machine()} | torch {torch.__version__} | "
+        f"cuda={torch.cuda.is_available()} {dev_name} | "
+        f"data {data.shape[0]}x{data.shape[1]} | {args.iters} iters x {args.repeats}"
+    )
+    print(f"{'device':>6} {'dtype':>8} {'ms/it':>9} {'speedup':>8}  final_ll")
+
+    baseline = None
+    for device, dtype in _combos():
+        times = []
+        ll = float("nan")
+        try:
+            for r in range(args.repeats):
+                t, ll = _time_fit(data, device, dtype, args.iters, args.seed + r)
+                times.append(t)
+        except Exception as exc:  # noqa: BLE001 - report, keep going to next combo
+            print(f"{device:>6} {str(dtype).split('.')[-1]:>8}   FAILED: {exc}")
+            continue
+        ms = statistics.mean(times) / args.iters * 1000
+        if baseline is None:
+            baseline = ms  # cpu/float64 reference
+        print(
+            f"{device:>6} {str(dtype).split('.')[-1]:>8} {ms:9.1f} "
+            f"{baseline / ms:7.2f}x  {ll:.5f}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/benchmark_gpu.py
+++ b/benchmarks/benchmark_gpu.py
@@ -3,8 +3,11 @@
 
 Times the natural-gradient EM backend across ``(device, dtype)`` combinations on
 the real sample EEG, to characterize the GPU fast path. float64 is the
-Fortran-parity default; float32 is the production fast path (10-50x on GPU) that
-trades bit-parity for speed. MPS cannot do float64, and only float32 there.
+Fortran-parity default and the safe GPU win (~4.5x on an RTX 4090 vs a 16-thread
+CPU). float32 is faster still (~5x CPU / ~10-19x CUDA) but currently EXPERIMENTAL:
+it is seed-flaky NaN on full-size data (mixture underflow), so it is not a
+production fast path yet -- stabilization is tracked in issue #70. MPS cannot do
+float64, and only float32 there.
 
 Run on a CUDA host (e.g. via ssh) for real GPU numbers:
     uv run python benchmarks/benchmark_gpu.py

--- a/benchmarks/benchmark_gpu.py
+++ b/benchmarks/benchmark_gpu.py
@@ -91,6 +91,9 @@ def main() -> int:
         times = []
         ll = float("nan")
         try:
+            # Warmup (untimed): the first CUDA call pays context init + kernel
+            # compilation, which would otherwise inflate the first timed repeat.
+            _time_fit(data, device, dtype, min(5, args.iters), args.seed)
             for r in range(args.repeats):
                 t, ll = _time_fit(data, device, dtype, args.iters, args.seed + r)
                 times.append(t)

--- a/pyAMICA/tests/torch_tests/test_ng_pdf_families.py
+++ b/pyAMICA/tests/torch_tests/test_ng_pdf_families.py
@@ -17,7 +17,7 @@ import pytest
 import torch
 
 from pyAMICA.torch_impl import AMICATorchNG
-from pyAMICA.torch_impl.core import _log_pdf_and_deriv, _score
+from pyAMICA.torch_impl.core import _log_pdf_and_deriv, _log_pdf_only, _score
 
 SAMPLE_DIR = Path(__file__).resolve().parents[2] / "sample_data"
 DATA_FILE = SAMPLE_DIR / "eeglab_data.fdt"
@@ -108,6 +108,26 @@ def test_gg_path_bit_identical_none_vs_code0():
     assert torch.equal(lp_none, lp_zero)
     assert torch.equal(dp_none, dp_zero)
     assert torch.equal(fp_none, fp_zero)
+
+
+@pytest.mark.parametrize("code", [None, 0, 1, 2, 3, 4])
+def test_log_pdf_only_matches_log_pdf_and_deriv(code):
+    """The E-step's lean ``_log_pdf_only`` (issue #63) must return exactly the
+    same ``log_pdf`` as ``_log_pdf_and_deriv`` for every family, and its second
+    return must be ``|y|^rho`` -- this locks in the bit-identity the whole
+    optimization rests on (families 1-4 have no other non-gated regression
+    check)."""
+    pdt = None if code is None else torch.full_like(_Y, code, dtype=torch.long)
+    lp_full, _ = _log_pdf_and_deriv(_Y, _RHO, pdt)
+    lp_only, az_rho = _log_pdf_only(_Y, _RHO, pdt)
+    assert torch.equal(lp_full, lp_only)
+    assert torch.equal(az_rho, _Y.abs().pow(_RHO))
+
+
+def test_block_size_default_is_512():
+    """Pin the issue #63 default so a revert/typo is caught (the block-size
+    invariance tests would still pass at any finite block size)."""
+    assert AMICATorchNG(n_channels=NW, device="cpu").block_size == 512
 
 
 def test_pdtype_h_is_none_only_for_gg():

--- a/pyAMICA/torch_impl/core.py
+++ b/pyAMICA/torch_impl/core.py
@@ -197,6 +197,50 @@ def _score(
     )
 
 
+def _log_pdf_only(
+    y: torch.Tensor, rho: torch.Tensor, pdtype: Optional[torch.Tensor] = None
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Log-density only, plus ``|y|^rho`` for reuse -- the E-step's hot path.
+
+    The forward pass needs only ``log_pdf`` (for ``z0``/responsibilities); the
+    density derivative ``dpdf`` that :func:`_log_pdf_and_deriv` also computes is
+    never consumed (the exact-EM M-step uses the score ``fp`` instead), so
+    computing it -- a ``|y|^(rho-1)`` power and three ``exp``s per block -- is
+    dead work (issue #63). This returns ``log_pdf`` bit-identically to
+    :func:`_log_pdf_and_deriv` and the ``|y|^rho`` power, which the caller reuses
+    for the ``rho`` update (dropping its duplicate power at the score site).
+    """
+    abs_y = y.abs()
+    az_rho = abs_y.pow(rho)  # |y|^rho, reused by the rho-update accumulator
+
+    log_pdf_lap = -abs_y - _LOG2
+    log_pdf_gau = -y * y - _HALF_LOG_PI
+    log_pdf_gg = -az_rho - _LOG2 - torch.lgamma(1.0 + 1.0 / rho)
+    log_pdf = torch.where(
+        rho == 2.0, log_pdf_gau, torch.where(rho == 1.0, log_pdf_lap, log_pdf_gg)
+    )
+    if pdtype is None:
+        return log_pdf, az_rho
+
+    log_pdf_2 = -0.5 * y * y - _LOG_SQRT_2PI  # Gaussian
+    log_pdf_3 = -2.0 * _logcosh(0.5 * y) - _LOG4  # logistic (sech^2)
+    lc = _logcosh(y)
+    log_pdf_4 = -0.5 * y * y + lc - _LOG_NORM_COSH_SUB  # sub-Gaussian cosh+
+    log_pdf_1 = -0.5 * y * y - lc - _LOG_NORM_COSH_SUP  # super-Gaussian cosh-
+    log_pdf = torch.where(
+        pdtype == 2,
+        log_pdf_2,
+        torch.where(
+            pdtype == 3,
+            log_pdf_3,
+            torch.where(
+                pdtype == 4, log_pdf_4, torch.where(pdtype == 1, log_pdf_1, log_pdf)
+            ),
+        ),
+    )
+    return log_pdf, az_rho
+
+
 class AMICATorchNG:
     """
     Natural-gradient EM AMICA, ported from ``pyAMICA.numpy_impl.core.AMICA``.
@@ -706,8 +750,8 @@ class AMICATorchNG:
         """Run the E-step forward pass for one data block.
 
         Computes, for every model ``h``, the activations ``b``, scaled
-        activations ``y``, normalized mixture responsibilities ``z``, the
-        density derivative ``dpdf``, and the per-sample per-model
+        activations ``y``, normalized mixture responsibilities ``z``, the power
+        ``|y|^rho`` (reused by the rho update), and the per-sample per-model
         log-likelihood ``logV`` (including the ``log|det W|`` and ``sldet``
         Jacobian terms, matching Fortran's ``Ptmp`` seed, amica17.f90:1273).
         Shared by ``_get_block_updates`` (which reduces it into sufficient
@@ -716,13 +760,13 @@ class AMICATorchNG:
         Returns
         -------
         logV : torch.Tensor of shape (batch, n_models)
-        b_list, z_list, y_list, dpdf_list : lists (one entry per model) of
-            per-model tensors (``b``: (batch, n_channels); ``z``/``y``/``dpdf``:
+        b_list, z_list, y_list, azrho_list : lists (one entry per model) of
+            per-model tensors (``b``: (batch, n_channels); ``z``/``y``/``azrho``:
             (batch, n_channels, n_mix)).
         """
         batch_size = X.shape[1]
         num_models = self.n_models
-        b_list, z_list, y_list, dpdf_list = [], [], [], []
+        b_list, z_list, y_list, azrho_list = [], [], [], []
         logV = torch.empty(batch_size, num_models, dtype=self.dtype, device=self.device)
 
         for h in range(num_models):
@@ -741,7 +785,10 @@ class AMICATorchNG:
             alpha_h = self.alpha[:, idx].T.unsqueeze(0)
 
             y = beta_h * (b.unsqueeze(-1) - mu_h)  # (batch, n_channels, num_mix)
-            log_pdf, dpdf = _log_pdf_and_deriv(y, rho_h, self._pdtype_h(h))
+            # Only log_pdf is needed here; the score fp (and drho's |y|^rho) are
+            # reused in _get_block_updates. az_rho = |y|^rho is threaded through
+            # so the rho-update does not recompute it (issue #63).
+            log_pdf, az_rho = _log_pdf_only(y, rho_h, self._pdtype_h(h))
 
             # z0 = log(alpha) + log(beta) + log_pdf. For the single-component
             # families (codes 1/4) n_mix==1 so alpha==1 and log(alpha)==0, which
@@ -760,9 +807,9 @@ class AMICATorchNG:
             b_list.append(b)
             z_list.append(z)
             y_list.append(y)
-            dpdf_list.append(dpdf)
+            azrho_list.append(az_rho)
 
-        return logV, b_list, z_list, y_list, dpdf_list
+        return logV, b_list, z_list, y_list, azrho_list
 
     def _block_sample_ll(self, X: torch.Tensor) -> torch.Tensor:
         """Per-sample total log-likelihood for a data block (the rejection
@@ -802,7 +849,7 @@ class AMICATorchNG:
         num_mix, num_models = self.n_mix, self.n_models
         dev, dt = self.device, self.dtype
 
-        logV, b_list, z_list, y_list, _ = self._forward(X)
+        logV, b_list, z_list, y_list, azrho_list = self._forward(X)
         block_ll = torch.logsumexp(logV, dim=1).sum()
         v = torch.softmax(logV, dim=1)  # (batch, num_models)
 
@@ -851,7 +898,7 @@ class AMICATorchNG:
             # no per-component (rho!=1&rho!=2) mask (Bug 2): |y|^rho*ln|y| is 0 at
             # y=0, and clamping the log input makes the product collapse there.
             ay = y.abs()
-            ayrho = ay.pow(rho_h.unsqueeze(0))  # |y|^rho
+            ayrho = azrho_list[h]  # |y|^rho reused from _forward (issue #63)
             logab = rho_h.unsqueeze(0) * torch.log(ay.clamp_min(tiny))  # rho*ln|y|
             logab = torch.where(ayrho < _EPSDBLE, torch.zeros_like(logab), logab)
             drho_n.index_add_(1, idx, (u * (ayrho * logab)).sum(0).T)

--- a/pyAMICA/torch_impl/core.py
+++ b/pyAMICA/torch_impl/core.py
@@ -259,9 +259,14 @@ class AMICATorchNG:
         Number of ICA mixture models.
     n_mix : int, default=3
         Number of mixture components per source.
-    block_size : int, default=128
+    block_size : int, default=512
         Number of samples processed per accumulation block. Peak memory
         during the E-step scales with this, not with the total sample count.
+        Larger blocks give bigger tensor ops (less Python/dispatch overhead,
+        better threading/GPU utilization) at higher memory; 512 matches the
+        Fortran reference. A single iteration's sufficient statistics are
+        block-size-independent to ~1e-8, but the (chaotic) multi-iteration
+        trajectory shifts at the ~1e-6 level as this changes.
     lrate : float, default=0.1
         Initial/maximum natural-gradient learning rate (``lrate0`` in NumPy).
     minlrate : float, default=1e-12
@@ -380,7 +385,7 @@ class AMICATorchNG:
         n_channels: int,
         n_models: int = 1,
         n_mix: int = 3,
-        block_size: int = 128,
+        block_size: int = 512,
         lrate: float = 0.1,
         minlrate: float = 1e-12,
         lratefact: float = 0.5,

--- a/pyAMICA/torch_impl/core.py
+++ b/pyAMICA/torch_impl/core.py
@@ -208,7 +208,8 @@ def _log_pdf_only(
     computing it -- a ``|y|^(rho-1)`` power and three ``exp``s per block -- is
     dead work (issue #63). This returns ``log_pdf`` bit-identically to
     :func:`_log_pdf_and_deriv` and the ``|y|^rho`` power, which the caller reuses
-    for the ``rho`` update (dropping its duplicate power at the score site).
+    for the ``rho`` update (dropping the duplicate ``|y|^rho`` that
+    ``_get_block_updates`` previously recomputed for that accumulator).
     """
     abs_y = y.abs()
     az_rho = abs_y.pow(rho)  # |y|^rho, reused by the rho-update accumulator
@@ -263,9 +264,12 @@ class AMICATorchNG:
         Number of samples processed per accumulation block. Peak memory
         during the E-step scales with this, not with the total sample count.
         Larger blocks give bigger tensor ops (less Python/dispatch overhead,
-        better threading/GPU utilization) at higher memory; 512 matches the
-        Fortran reference. A single iteration's sufficient statistics are
-        block-size-independent to ~1e-8, but the (chaotic) multi-iteration
+        better threading/GPU utilization) at higher memory. 512 is a fixed
+        choice inside Fortran's ``do_opt_block`` auto-tune range (128-1024, step
+        128); the Fortran *header* default is 128 and it auto-tunes per host, so
+        this does not track a single reference value. A single iteration's
+        sufficient statistics are block-size-independent to ~1e-8
+        (``test_blocking_invariance``), but the (chaotic) multi-iteration
         trajectory shifts at the ~1e-6 level as this changes.
     lrate : float, default=0.1
         Initial/maximum natural-gradient learning rate (``lrate0`` in NumPy).


### PR DESCRIPTION
Part of #63. The clear, **bit-identical** win from the benchmark's pow hot spot.

## What
The forward pass computed the density derivative `dpdf` every block, but **every caller discards it** (the exact-EM M-step uses the score `fp`, not `dpdf`) -- so a `|y|^(rho-1)` power and **three exp()s** per block-model were dead work. Separately, `|y|^rho` was computed twice (density + the rho-update accumulator).

Added a lean `_log_pdf_only` that computes only `log_pdf` and returns `|y|^rho`; `_forward` threads it through to `_get_block_updates`, which reuses it instead of recomputing. `_log_pdf_and_deriv`/`_score` are untouched (still cover the pdf-family tests).

## Safety
**Bit-identical** -- single-model final LL matches the pre-change value to all 15 digits (verified by stashing the change and re-running), and the full torch suite is green (108 passed, 5 skipped). The parity tests (NumPy 1e-10, families 1e-12) all pass unchanged.

## Measured (real sample EEG, single thread)
| Metric | Before | After |
|--|--|--|
| pow time (20 it) | 2.55s | **1.30s** (-49%) |
| 30-iter wall | 255 ms/it | **166 ms/it** (-35%) |

## Not in this PR (need your call -- data in the PR thread)
- Larger `block_size` default (128->512): another ~-18%, but shifts results ~6e-6 (accumulation order).
- CPU threading: ~-16% at 4 threads, degrades beyond (workload-limited).
- GPU float32 fast path: the real GPU lever; needs a CUDA host to validate.