### PR TITLE
docs: MPS/Apple-GPU acceleration pathways (#72)

### DIFF
--- a/.context/mps_pathways.md
+++ b/.context/mps_pathways.md
@@ -1,0 +1,99 @@
+# MPS / Apple-Silicon GPU acceleration: pathways analysis
+
+Research into whether and how the natural-gradient EM backend (`AMICATorchNG`)
+can be accelerated on Apple-Silicon GPUs. Motivated by MPS's growing traction,
+and by the #63/#70 findings that MPS was *slower* than CPU on the 32-channel
+sample data and that float32 diverges on full-size data.
+
+## The one fact that governs everything: no FP64 on Apple GPUs
+
+Apple-Silicon GPUs have **no native double-precision (FP64) hardware** ([Apple
+GPU microarchitecture](https://github.com/philipturner/metal-benchmarks);
+[real-world tech](https://www.realworldtech.com/forum/?threadid=217891&curpostid=218072)).
+Consequently:
+
+- **PyTorch MPS does not support float64** and still does not as of mid-2026 --
+  `Cannot convert a MPS Tensor to float64 dtype ... the MPS framework doesn't
+  support float64` ([PyTorch forums](https://discuss.pytorch.org/t/typeerror-cannot-convert-a-mps-tensor-to-float64-dtype-as-the-mps-framework-doesnt-support-float64-please-use-float32-instead/180852),
+  [Apple Developer forum, 2026](https://developer.apple.com/forums/thread/797778)).
+- **MLX** (Apple's own array framework) supports float64 **only on CPU**; GPU
+  arrays must be float32 ([MLX data types](https://ml-explore.github.io/mlx/build/html/python/data_types.html),
+  [MLX issue #799](https://github.com/ml-explore/mlx/issues/799)).
+
+`AMICATorchNG` computes in **float64 for Fortran parity**. So the parity path can
+never run on an Apple GPU. **Every MPS pathway therefore requires a numerically
+stable float32 (or mixed-precision) AMICA** -- exactly the wall #70 hit.
+
+## Pathway A (enabler): stabilize float32 with compensated / mixed precision
+
+This is the prerequisite for all Apple-GPU acceleration. #70 established float32
+diverges (precision-driven, not a divide-by-zero) and that float64
+responsibilities alone don't fix it. The research surfaces a stronger tool than
+the reductions-only approach tried there:
+
+- **Kahan / compensated summation** gives float32 sums *near float64 accuracy*
+  with an error bound independent of the term count N -- at ~2-3x the cost of a
+  naive sum ([optimi](https://optimi.benjaminwarner.dev/kahan_summation/),
+  [Dmitruk 2023](https://onlinelibrary.wiley.com/doi/abs/10.1002/cpe.7763)). The
+  AMICA sufficient-stat accumulation sums ~30504 samples per block/component --
+  a classic float32 precision sink and a prime suspect for the divergence.
+- Combined with a **mixed-precision** split (float64 for the density `|y|^rho`,
+  the LL, and the accumulation; float32 for the matmuls), this is the credible
+  route to a stable float32 fit. Kahan training reportedly lets pure low-precision
+  match full mixed-precision ([optimi](https://optimi.benjaminwarner.dev/kahan_summation/)).
+
+Effort: moderate. Payoff on *CUDA* is limited (float64-CUDA already gives 4.5x),
+but on Apple GPUs it is the *only* door. Reopen the #70 technical work under this
+angle if MPS is pursued.
+
+## Pathway B: exploit the large-workload regime (measure the crossover)
+
+MPS's problem on our data is **dispatch overhead**, not raw throughput: for small
+tensors, per-operator Metal kernel launches (limited fusion, generic kernels)
+dominate, and CPU with Accelerate/oneDNN wins ([elanapearl blog](https://elanapearl.github.io/blog/2025/the-bug-that-taught-me-pytorch/),
+[runebook MPS](https://runebook.dev/en/docs/pytorch/mps)). Our 32-channel /
+512-block ops are firmly in the small regime (MPS 0.51x).
+
+That overhead is **fixed per op**, so it amortizes as tensors grow. High-channel
+montages (128-256 ch), many-model runs, and larger blocks produce much bigger
+per-op tensors where MPS can plausibly overtake CPU. **Actionable:** once float32
+is stable (Pathway A), benchmark MPS-float32 vs CPU across channel count / block
+size / n_models to find the crossover, rather than concluding from 32 channels.
+`benchmarks/benchmark_gpu.py` already sweeps devices; add a dimension sweep.
+
+## Pathway C: MLX port (longer-term, higher ceiling)
+
+MLX consistently beats PyTorch MPS on the same hardware (2-3x for LLM inference)
+and is Apple-native with a real compiler / lazy graph ([WWDC25](https://developer.apple.com/videos/play/wwdc2025/315/),
+[MLX](https://github.com/ml-explore/mlx)); PyTorch MPS remains eager, largely
+unfused, and sometimes falls back to CPU ([State of PyTorch HW 2025](https://tunguz.github.io/PyTorch_Hardware_2025/)).
+An MLX backend could both cut dispatch overhead and fuse the per-block work.
+
+Cost: a full backend rewrite, still float32-only on GPU (so Pathway A is still
+required first), and a new dependency. High effort, uncertain until A lands. Best
+seen as a v2 acceleration option, not a near-term step.
+
+## Pathway D: software FP64 emulation -- DEAD END
+
+`metal-float64` emulates FP64 on Apple GPUs, but: it is **custom-Metal-only (not
+usable from PyTorch)**, runs at **1/32-1/64 of FP32 throughput** (~18-32x
+penalty), and implements **only add/multiply/FMA -- no transcendentals** (AMICA
+needs `exp`/`log`/`pow`), and the project is archived/incomplete
+([metal-float64](https://github.com/philipturner/metal-float64)). It cannot run
+AMICA and would be slower than the CPU even if it could. Ruled out.
+
+## Recommendation
+
+1. **Apple-GPU acceleration is gated on a stable float32 AMICA (Pathway A)** --
+   there is no float64 GPU path on Apple hardware, now or on the visible horizon.
+2. The right first step, if pursued, is **compensated (Kahan) + mixed-precision
+   float32** targeting the sufficient-stat accumulation and the density/LL, then
+   a **dimension-sweep MPS benchmark (Pathway B)** to see where MPS actually wins
+   (likely high channel counts, not 32).
+3. **MLX (Pathway C)** is the higher-ceiling but higher-cost option for later.
+4. Until then, **float64-CUDA (4.5x, bit-safe) remains the production GPU path**;
+   MPS/float32 stay experimental (documented in `issue-63/perf_findings.md`).
+
+Cost/benefit note: on CUDA the float32 work buys little (float64 already works);
+its real value is unlocking Apple GPUs *at all*. Prioritize it by how much the
+user base runs on Apple Silicon with large montages.


### PR DESCRIPTION
Closes #72. Research deliverable: `.context/mps_pathways.md`.

## Governing finding
Apple-Silicon GPUs have **no FP64 hardware**; PyTorch MPS and MLX both support float64 **only on CPU** (confirmed mid-2026 via PyTorch/Apple-Developer/MLX sources). AMICATorchNG runs float64 for parity, so **the parity path can never run on an Apple GPU** -- every MPS pathway is gated on a numerically stable float32 AMICA.

## Pathways (cited)
- **A (enabler):** float32 stabilization via **Kahan/compensated summation + mixed precision** -- targets the ~30504-sample sufficient-stat accumulation (a float32 precision sink the #70 attempt didn't address). Kahan gives near-float64 accuracy independent of N.
- **B:** exploit the **large-tensor regime** -- MPS lost on 32 channels due to fixed per-op dispatch overhead, which amortizes on big tensors; sweep channel count/block/n_models for the crossover.
- **C:** **MLX port** (2-3x over PyTorch MPS, Apple-native fusion) -- higher ceiling, full rewrite, v2.
- **D:** FP64 emulation (metal-float64) -- **dead end** (custom-Metal-only, no transcendentals, 18-32x penalty).

## Recommendation
Gated on A. Sequence A -> B -> C. Until then float64-CUDA (4.5x, bit-safe) is the production GPU path. Docs-only.