### PR TITLE
Phase C: MLX backend AMICAMLXNG (v1 MVP)

### DIFF
--- a/.context/mps_pathways.md
+++ b/.context/mps_pathways.md
@@ -83,9 +83,10 @@ rtol ~1e-4. MLX is an optional dependency (Apple Silicon only), so CI skips thes
 the other PDF families, sharing, multi-model, and save/load are fast-follows. Whether it beats
 CPU/MPS is Pathway B's question.
 
-Cost: a full backend rewrite, still float32-only on GPU (Pathway A, #75, already
-provides that), and a new dependency. High effort. Best seen as a v2 acceleration
-option, not a near-term step.
+Cost (estimated before landing, now borne by the #76 MVP): a backend rewrite,
+still float32-only on GPU (Pathway A, #75, provides that), and a new optional
+dependency. The MVP is in-tree (see Status above); Newton, the other families,
+sharing and multi-model remain fast-follows.
 
 ## Pathway D: software FP64 emulation -- DEAD END
 

--- a/.context/mps_pathways.md
+++ b/.context/mps_pathways.md
@@ -64,13 +64,24 @@ count / block size / n_models to find the crossover, rather than concluding from
 32 channels.
 `benchmarks/benchmark_gpu.py` already sweeps devices; add a dimension sweep.
 
-## Pathway C: MLX port (longer-term, higher ceiling)
+## Pathway C: MLX port -- v1 MVP LANDED (#76)
 
 MLX consistently beats PyTorch MPS on the same hardware (2-3x for LLM inference)
 and is Apple-native with a real compiler / lazy graph ([WWDC25](https://developer.apple.com/videos/play/wwdc2025/315/),
 [MLX](https://github.com/ml-explore/mlx)); PyTorch MPS remains eager, largely
 unfused, and sometimes falls back to CPU ([State of PyTorch HW 2025](https://tunguz.github.io/PyTorch_Hardware_2025/)).
 An MLX backend could both cut dispatch overhead and fuse the per-block work.
+
+**Status (#76):** `AMICAMLXNG` (`pyAMICA/mlx_impl/core.py`) is a v1 MVP -- single-model,
+generalized-Gaussian, natural gradient. It is a **hybrid**: the E/M-step hot path runs on
+the GPU in float32 (with the Phase A `ufp/y` guard), while all `mlx.core.linalg` is CPU-only
+in MLX 0.32, so `inv(A)`/`slogdet(W)` run on the CPU stream (hoisted to once per iteration --
+measured ~42 us/iter vs a ~13 ms GPU E-pass, so not the bottleneck; `mx.eval` placement is).
+`lgamma`/`digamma` (absent in MLX) are computed host-side via SciPy on the small `rho` array.
+It matches the PyTorch float32 backend's converged LL to ~2e-6 and the NumPy reference stats to
+rtol ~1e-4. MLX is an optional dependency (Apple Silicon only), so CI skips these tests. Newton,
+the other PDF families, sharing, multi-model, and save/load are fast-follows. Whether it beats
+CPU/MPS is Pathway B's question.
 
 Cost: a full backend rewrite, still float32-only on GPU (Pathway A, #75, already
 provides that), and a new dependency. High effort. Best seen as a v2 acceleration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,10 @@ pyAMICA/
 ├── amica.py                 # Main scikit-learn-style AMICA interface (wraps AMICATorchNG)
 ├── __init__.py              # Exposes AMICA (PyTorch), AMICA_NumPy (legacy), numpy_impl, torch_impl
 ├── torch_impl/              # PyTorch backend
-│   ├── core.py              #   Natural-gradient EM port (AMICATorchNG); Fortran-parity, sole backend
+│   ├── core.py              #   Natural-gradient EM port (AMICATorchNG); Fortran-parity, primary backend
 │   └── utils.py             #   Preprocessing (sphering, PCA), device selection
+├── mlx_impl/                # Optional MLX backend (Apple GPU; AMICAMLXNG, issue #76)
+│   └── core.py              #   float32 GPU E/M-step + CPU-stream linalg (v1 MVP: single-model GG, NG)
 ├── numpy_impl/              # Legacy NumPy reference (topic-named modules, issue #34)
 │   ├── core.py              #   AMICA_NumPy; newton.py, pdf.py, data.py, load.py, viz.py, utils.py, cli.py
 │   └── ...
@@ -25,7 +27,9 @@ validate_implementations.py  # Runs both implementations, Hungarian component ma
 Module names are topic-based (`core`/`newton`/`pdf`/`data`/... under `numpy_impl/`,
 `core`/`utils` under `torch_impl/`); the old `pyAMICA.py`/`amica_*.py`/`amica_torch_ng.py`
 prefixes were dropped in issue #34. The public import surface is stable:
-`from pyAMICA import AMICA, AMICA_NumPy, AMICATorchNG`.
+`from pyAMICA import AMICA, AMICA_NumPy, AMICATorchNG`. The optional MLX backend is
+imported separately (`from pyAMICA.mlx_impl import AMICAMLXNG`) so `import pyAMICA` never
+requires MLX; install it with `uv pip install mlx` or the `mlx` extra (Apple Silicon only).
 
 ## Environment Setup
 Canonical environment is **UV** (per global standards). The PyTorch stack is declared in

--- a/pyAMICA/mlx_impl/__init__.py
+++ b/pyAMICA/mlx_impl/__init__.py
@@ -1,0 +1,16 @@
+"""MLX backend for pyAMICA (Apple-Silicon GPU).
+
+Mirrors ``torch_impl`` but targets Apple's MLX array framework. MLX is an
+*optional* dependency (Apple Silicon only); importing this subpackage requires
+``mlx`` to be installed, so the top-level ``pyAMICA`` package never imports it
+eagerly. Install with ``uv pip install mlx`` (or the ``mlx`` extra).
+
+The backend (:class:`AMICAMLXNG`) runs the natural-gradient EM E/M-step on the
+Apple GPU in float32 (Apple GPUs have no FP64), with the small per-iteration
+linear algebra on MLX's CPU stream (issue #76, epic #74 Phase C). It is a v1
+MVP: single-model, generalized-Gaussian (``pdftype=0``), natural gradient.
+"""
+
+from .core import AMICAMLXNG
+
+__all__ = ["AMICAMLXNG"]

--- a/pyAMICA/mlx_impl/core.py
+++ b/pyAMICA/mlx_impl/core.py
@@ -20,9 +20,10 @@ Design constraints (verified against MLX 0.32, see ``.context/mps_pathways.md``)
   so they are computed host-side with SciPy once per iteration.
 
 MVP scope: single model (``n_models=1``), generalized Gaussian (``pdftype=0``),
-natural gradient (``do_newton=False``). Newton, the other PDF families, component
-sharing, multi-model, outlier rejection, ``keep_best``, ``transform`` and
-save/load are deferred to fast-follows and rejected with a clear error.
+natural gradient (``do_newton=False``). Newton, the other PDF families and
+multi-model are rejected in ``__init__`` with a clear ``NotImplementedError``
+(``transform`` likewise). Component sharing, outlier rejection, ``keep_best``
+and save/load are simply absent (no such parameter/method) -- all fast-follows.
 """
 
 from __future__ import annotations
@@ -48,7 +49,7 @@ _CPU = mx.cpu
 
 def _score_gg(y: mx.array, rho: mx.array) -> mx.array:
     """GG score ``fp = rho*sign(y)*|y|^(rho-1)`` (AMICATorchNG ``_score``, GG
-    branch, core.py:174-183). ``fp(0)=0`` for ``rho>=1``, which the ``ufp/y``
+    branch, core.py:176-183). ``fp(0)=0`` for ``rho>=1``, which the ``ufp/y``
     guard relies on."""
     abs_y = mx.abs(y)
     sign_y = mx.sign(y)
@@ -61,7 +62,7 @@ def _log_pdf_gg(
     y: mx.array, rho: mx.array, lgamma_table: mx.array
 ) -> tuple[mx.array, mx.array]:
     """GG log-density and ``|y|^rho`` (AMICATorchNG ``_log_pdf_only``, GG branch,
-    core.py:214-224). ``lgamma_table = lgamma(1+1/rho)`` is precomputed host-side
+    core.py:216-224). ``lgamma_table = lgamma(1+1/rho)`` is precomputed host-side
     (MLX has no ``lgamma``); it makes the uniform GG form reduce to the exact
     Laplace (rho=1) and Gaussian (rho=2) log-densities."""
     abs_y = mx.abs(y)
@@ -168,16 +169,18 @@ class AMICAMLXNG:
         self._lgamma_table = None  # mx.array (n_mix, n_channels): lgamma(1+1/rho)
         self._logdet_W = None  # mx.array scalar: log|det W|, refreshed per iter
 
-    _DEGENERATE_STOP_REASONS = ("nan_ll", "singular_ll")
+    _DEGENERATE_STOP_REASONS = ("nan_ll", "singular_ll", "nan_params")
 
     # ------------------------------------------------------------------
     # Preprocessing (host / numpy; mirrors AMICATorchNG._preprocess in float64)
     # ------------------------------------------------------------------
     def _preprocess(self, X: np.ndarray) -> mx.array:
         """Mean-removal + sphering in float64 on the host, then handed to MLX as
-        float32. Done in numpy (not MLX) because MLX ``eigh`` is CPU-only and
-        float32; keeping it float64-on-host makes the sphere/sldet match the
-        PyTorch backend (both derive from the same float64 eigh)."""
+        float32. Done in numpy (not MLX) because it reuses the exact float64
+        preprocessing AMICATorchNG already validates, so the sphere/sldet match
+        the PyTorch backend. (MLX's CPU-stream ``eigh`` is full float64 -- only
+        the GPU stream is unsupported -- so this is a code-sharing choice, not a
+        precision workaround.)"""
         Xc = np.ascontiguousarray(X).astype(np.float64)
         data_dim = Xc.shape[0]
 
@@ -255,7 +258,12 @@ class AMICAMLXNG:
 
     def _update_unmixing_matrices(self):
         """W = inv(A) and the LL Jacobian log|det W|, both on the CPU stream
-        (MLX linalg is CPU-only) and hoisted to once per iteration."""
+        (MLX linalg is CPU-only) and hoisted to once per iteration.
+
+        These build lazy graph nodes; a singular ``A`` therefore raises not here
+        but where the graph is materialized (the ``mx.eval`` in ``fit``), so a
+        LinAlg traceback rooted in ``fit`` actually originates in this method.
+        """
         self.W = mx.linalg.inv(self.A, stream=_CPU)
         self._logdet_W = mx.linalg.slogdet(self.W, stream=_CPU)[1]
 
@@ -283,7 +291,8 @@ class AMICAMLXNG:
 
     def _get_block_updates(self, Xb: mx.array) -> dict:
         """Exact-EM sufficient statistics for one block (single-model,
-        non-Newton subset of AMICATorchNG._get_block_updates, core.py:887-947)."""
+        non-Newton subset of AMICATorchNG._get_block_updates, core.py:891-944;
+        the bias-c accumulator is excluded -- single-model has no c update)."""
         logV, b, z, y, az_rho = self._forward(Xb)
         block_ll = logV.sum()  # single model: logsumexp over one model is identity
         beta_h = self.beta.T[None]  # (1, n_channels, n_mix)
@@ -356,16 +365,27 @@ class AMICAMLXNG:
         )
 
         # GG shape update with the 1/psi(1+1/rho) digamma factor (Fortran
-        # :2013-2014); digamma is computed host-side (MLX has none).
+        # :2013-2014); digamma is computed host-side (MLX has none). A NaN here
+        # (e.g. from an upstream mu/beta blow-up) is reset to rho0 and surfaced,
+        # matching AMICATorchNG (core.py:1140-1151), so it does not silently
+        # poison the lgamma table and every subsequent E-step.
         if self.dorho:
             drho = acc["drho_n"] / mx.maximum(acc["dalpha_n"], 1e-8)
             rho_np = np.array(self.rho, dtype=np.float64)
             psi = mx.array(digamma(1.0 + 1.0 / rho_np).astype(np.float32))
             new_rho = self.rho + self.rholrate * (1.0 - (self.rho / psi) * drho)
+            nan_mask = mx.isnan(new_rho)
+            if bool(mx.any(nan_mask).item()):
+                logger.warning(
+                    "NaN in rho update at iter %d; resetting to rho0=%g.",
+                    self.iteration,
+                    self.rho0,
+                )
+                new_rho = mx.where(nan_mask, self.rho0, new_rho)
             self.rho = mx.clip(new_rho, self.minrho, self.maxrho)
 
         # Natural-gradient A-update. A is stored as Fortran's A^T, so the update
-        # is a LEFT-multiply by the transposed direction (core.py:1156-1164,
+        # is a LEFT-multiply by the transposed direction (core.py:1176-1184,
         # #24 root cause). Single-model collapses the gm-weighted column average.
         eye = mx.eye(self.n_channels)
         dA = -acc["dWtmp"] / acc["dgm"] + eye  # I - <g b^T>/dgm
@@ -376,9 +396,13 @@ class AMICAMLXNG:
 
         if self.doscaling and (self.iteration % self.scalestep == 0):
             scale = mx.sqrt((self.A**2).sum(axis=0))  # (n_comps,)
+            # A zero-norm (collapsed) column is left untouched, not rescaled:
+            # safe_scale is 1 there, so A/beta are unchanged and mu*safe_scale
+            # keeps its prior value (matching AMICATorchNG's nonzero mask,
+            # core.py:1229-1234 -- using raw `scale` would zero mu instead).
             safe_scale = mx.where(scale > 0, scale, mx.ones_like(scale))
             self.A = self.A / safe_scale
-            self.mu = self.mu * scale
+            self.mu = self.mu * safe_scale
             self.beta = self.beta / safe_scale
 
         self._refresh_lgamma_table()
@@ -433,6 +457,29 @@ class AMICAMLXNG:
             # worth of ops (the updated params feed the next accumulate).
             mx.eval(self.A, self.W, self.mu, self.alpha, self.beta, self.rho)
 
+            # Surface a corrupted M-step (component collapse / float32 overflow)
+            # at the iteration it happens. The ll check above only catches a
+            # corruption via the NEXT iteration's E-step, so a final-iteration
+            # blow-up would otherwise complete as max_iter with silently NaN
+            # parameters (the torch backend has state_dict as a backstop; the
+            # MLX MVP does not, so guard in fit()). Params are already
+            # materialized by the mx.eval above, so this is a cheap read.
+            params_finite = (
+                mx.all(mx.isfinite(self.A))
+                & mx.all(mx.isfinite(self.mu))
+                & mx.all(mx.isfinite(self.alpha))
+                & mx.all(mx.isfinite(self.beta))
+                & mx.all(mx.isfinite(self.rho))
+            )
+            if not bool(params_finite.item()):
+                logger.warning(
+                    "Non-finite parameters at iter %d (a mixture component "
+                    "likely collapsed); stopping.",
+                    it,
+                )
+                self.stop_reason = "nan_params"
+                break
+
             self.ll_history.append(ll)
 
             # Learning-rate control (Fortran amica17.f90:1062-1108): anneal on an
@@ -458,3 +505,12 @@ class AMICAMLXNG:
         else:
             self.final_ll_ = self.ll_history[-1] if self.ll_history else float("nan")
         return self
+
+    def transform(self, X: np.ndarray, model_idx: int = 0) -> np.ndarray:
+        """Not in the v1 MVP -- fail with a clear boundary rather than a bare
+        AttributeError. Use ``AMICATorchNG.transform`` for source extraction; the
+        MLX backend (issue #76) validates via ``final_ll_``/``ll_history``."""
+        raise NotImplementedError(
+            "AMICAMLXNG (v1) does not implement transform yet; it is a "
+            "fast-follow. Use AMICATorchNG for source extraction."
+        )

--- a/pyAMICA/mlx_impl/core.py
+++ b/pyAMICA/mlx_impl/core.py
@@ -1,0 +1,460 @@
+"""MLX natural-gradient EM backend for AMICA (issue #76, epic #74 Phase C).
+
+``AMICAMLXNG`` is a v1 MVP port of :class:`pyAMICA.torch_impl.core.AMICATorchNG`
+to Apple's MLX array framework, so the per-block E/M-step runs on the Apple GPU.
+It is structurally parallel to the PyTorch backend (same method names/order and
+Fortran citations) so the two can be diffed method-by-method.
+
+Design constraints (verified against MLX 0.32, see ``.context/mps_pathways.md``):
+
+* **float32 only on the GPU** -- Apple GPUs have no FP64, and MLX raises on GPU
+  float64. Full-data float32 converges thanks to the ``ufp/y`` divide-by-zero
+  guard from issue #75, which is reproduced here.
+* **All ``mlx.core.linalg`` is CPU-stream only** -- ``inv(A)`` and ``slogdet(W)``
+  run under ``mx.stream(mx.cpu)``. They are hoisted to once per iteration (the
+  PyTorch ``_forward`` recomputes ``slogdet`` inside the block loop; here it is a
+  cached constant), so the GPU pipeline sees one cross-stream handoff per
+  iteration, not one per block.
+* **No ``lgamma``/``digamma`` in MLX** -- the GG normalizer ``lgamma(1+1/rho)``
+  and the rho-update ``digamma(1+1/rho)`` depend only on the small ``rho`` array,
+  so they are computed host-side with SciPy once per iteration.
+
+MVP scope: single model (``n_models=1``), generalized Gaussian (``pdftype=0``),
+natural gradient (``do_newton=False``). Newton, the other PDF families, component
+sharing, multi-model, outlier rejection, ``keep_best``, ``transform`` and
+save/load are deferred to fast-follows and rejected with a clear error.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Optional
+
+import mlx.core as mx
+import numpy as np
+from scipy.special import digamma, gammaln
+
+logger = logging.getLogger(__name__)
+
+_LOG2 = math.log(2.0)
+# Fortran epsdble: zero the rho*ln|y| term when |y|^rho underflows below this
+# (amica17.f90:1570), matching AMICATorchNG.
+_EPSDBLE = 1e-16
+# MLX linalg runs on the CPU stream only (float32-accurate); the GPU stream
+# raises "not yet supported on the GPU" for inv/slogdet/eigh/solve.
+_CPU = mx.cpu
+
+
+def _score_gg(y: mx.array, rho: mx.array) -> mx.array:
+    """GG score ``fp = rho*sign(y)*|y|^(rho-1)`` (AMICATorchNG ``_score``, GG
+    branch, core.py:174-183). ``fp(0)=0`` for ``rho>=1``, which the ``ufp/y``
+    guard relies on."""
+    abs_y = mx.abs(y)
+    sign_y = mx.sign(y)
+    fp_gg = rho * sign_y * mx.power(abs_y, rho - 1.0)
+    # rho is generically in (1, 2); keep the exact Laplace/Gaussian endpoints.
+    return mx.where(rho == 2.0, 2.0 * y, mx.where(rho == 1.0, sign_y, fp_gg))
+
+
+def _log_pdf_gg(
+    y: mx.array, rho: mx.array, lgamma_table: mx.array
+) -> tuple[mx.array, mx.array]:
+    """GG log-density and ``|y|^rho`` (AMICATorchNG ``_log_pdf_only``, GG branch,
+    core.py:214-224). ``lgamma_table = lgamma(1+1/rho)`` is precomputed host-side
+    (MLX has no ``lgamma``); it makes the uniform GG form reduce to the exact
+    Laplace (rho=1) and Gaussian (rho=2) log-densities."""
+    abs_y = mx.abs(y)
+    az_rho = mx.power(abs_y, rho)  # reused by the rho-update accumulator
+    log_pdf = -az_rho - _LOG2 - lgamma_table
+    return log_pdf, az_rho
+
+
+class AMICAMLXNG:
+    """MLX natural-gradient EM backend (single-model GG MVP, issue #76).
+
+    Parameters mirror the subset of :class:`AMICATorchNG` that the MVP supports;
+    the same ``seed`` produces the same initial parameters as the PyTorch/NumPy
+    backends, so cross-backend equivalence is testable.
+    """
+
+    def __init__(
+        self,
+        n_channels: int,
+        n_models: int = 1,
+        n_mix: int = 3,
+        block_size: int = 512,
+        lrate: float = 0.1,
+        minlrate: float = 1e-12,
+        lratefact: float = 0.5,
+        maxdecs: int = 5,
+        newt_ramp: int = 10,
+        do_newton: bool = False,
+        rho0: float = 1.5,
+        minrho: float = 1.0,
+        maxrho: float = 2.0,
+        rholrate: float = 0.05,
+        rholratefact: float = 0.1,
+        pdftype: int = 0,
+        invsigmin: float = 1e-4,
+        invsigmax: float = 1000.0,
+        doscaling: bool = True,
+        scalestep: int = 1,
+        do_mean: bool = True,
+        do_sphere: bool = True,
+        do_approx_sphere: bool = True,
+        seed: Optional[int] = None,
+    ):
+        # --- MVP boundaries: reject the deferred configurations up front. -----
+        if n_models != 1:
+            raise NotImplementedError(
+                "AMICAMLXNG (v1) supports single-model only (n_models=1); "
+                "multi-model is a fast-follow. Use AMICATorchNG for n_models>1."
+            )
+        if pdftype != 0:
+            raise NotImplementedError(
+                "AMICAMLXNG (v1) supports the generalized-Gaussian family "
+                "(pdftype=0) only; the other families are a fast-follow."
+            )
+        if do_newton:
+            raise NotImplementedError(
+                "AMICAMLXNG (v1) supports the natural gradient only "
+                "(do_newton=False); Newton is a fast-follow."
+            )
+
+        self.n_channels = n_channels
+        self.n_models = 1
+        self.n_mix = n_mix
+        self.n_comps = n_channels
+        self.block_size = block_size
+
+        self.lrate0 = lrate
+        self.lrate = lrate
+        self.lrate_cap = lrate
+        self.minlrate = minlrate
+        self.lratefact = lratefact
+        self.maxdecs = maxdecs
+        self.newt_ramp = newt_ramp
+        self.do_newton = False
+
+        self.rho0 = rho0
+        self.minrho = minrho
+        self.maxrho = maxrho
+        self.rholrate0 = rholrate
+        self.rholrate = rholrate
+        self.rholratefact = rholratefact
+        self.dorho = True  # GG shape adapts (Fortran dorho, pdftype==0)
+
+        self.pdftype = 0
+        self.invsigmin = invsigmin
+        self.invsigmax = invsigmax
+        self.doscaling = doscaling
+        self.scalestep = scalestep
+
+        self.do_mean = do_mean
+        self.do_sphere = do_sphere
+        self.do_approx_sphere = do_approx_sphere
+        self.seed = seed
+
+        self.iteration = 0
+        self.ll_history: list[float] = []
+        self.final_ll_: Optional[float] = None
+        self.stop_reason: Optional[str] = None
+
+        # Populated by fit()/_initialize_parameters().
+        self.A = self.W = self.mu = self.alpha = self.beta = self.rho = None
+        self.gm = self.mean = self.sphere = None
+        self.sldet = 0.0
+        self._lgamma_table = None  # mx.array (n_mix, n_channels): lgamma(1+1/rho)
+        self._logdet_W = None  # mx.array scalar: log|det W|, refreshed per iter
+
+    _DEGENERATE_STOP_REASONS = ("nan_ll", "singular_ll")
+
+    # ------------------------------------------------------------------
+    # Preprocessing (host / numpy; mirrors AMICATorchNG._preprocess in float64)
+    # ------------------------------------------------------------------
+    def _preprocess(self, X: np.ndarray) -> mx.array:
+        """Mean-removal + sphering in float64 on the host, then handed to MLX as
+        float32. Done in numpy (not MLX) because MLX ``eigh`` is CPU-only and
+        float32; keeping it float64-on-host makes the sphere/sldet match the
+        PyTorch backend (both derive from the same float64 eigh)."""
+        Xc = np.ascontiguousarray(X).astype(np.float64)
+        data_dim = Xc.shape[0]
+
+        if self.do_mean:
+            mean = Xc.mean(axis=1, keepdims=True)
+            Xc = Xc - mean
+        else:
+            mean = np.zeros((data_dim, 1))
+
+        if self.do_sphere:
+            # Population covariance (/N), matching Fortran's DSYRK scatter, not
+            # numpy's default sample covariance (/(N-1)) -- see core.py:635-639.
+            cov = np.cov(Xc, bias=True)
+            evals, evecs = np.linalg.eigh(cov)
+            order = np.argsort(evals)[::-1]
+            evals = evals[order]
+            evecs = evecs[:, order]
+            inv_sqrt = np.diag(1.0 / np.sqrt(evals))
+            if self.do_approx_sphere:
+                # Symmetric ZCA sphere V diag(1/sqrt) V^T (Fortran default).
+                sphere = evecs @ inv_sqrt @ evecs.T
+            else:
+                sphere = inv_sqrt @ evecs.T
+            Xc = sphere @ Xc
+            sldet = float(-0.5 * np.log(evals).sum())
+        else:
+            sphere = np.eye(data_dim)
+            sldet = 0.0
+
+        self.mean = mx.array(mean.astype(np.float32))
+        self.sphere = mx.array(sphere.astype(np.float32))
+        self.sldet = sldet
+        return mx.array(Xc.astype(np.float32))
+
+    # ------------------------------------------------------------------
+    # Initialization (identical RNG draws to AMICATorchNG for cross-backend test)
+    # ------------------------------------------------------------------
+    def _initialize_parameters(self):
+        """Initialize parameters with the *same* ``np.random.RandomState`` draw
+        order as AMICATorchNG/AMICA_NumPy (core.py:688-725), so a shared seed
+        gives a bit-identical (float32-cast) starting point."""
+        rng = np.random.RandomState(self.seed)
+        n, ncomp, nmix = self.n_channels, self.n_comps, self.n_mix
+
+        A_np = np.eye(n) + 0.01 * (0.5 - rng.rand(n, n))
+
+        mu_np = np.zeros((nmix, ncomp))
+        for k in range(ncomp):
+            mu_np[:, k] = np.linspace(-1, 1, nmix)
+            mu_np[:, k] += 0.05 * (1 - 2 * rng.rand(nmix))
+
+        alpha_np = np.ones((nmix, ncomp)) / nmix
+        beta_np = np.ones((nmix, ncomp)) + 0.1 * (0.5 - rng.rand(nmix, ncomp))
+        rho_np = self.rho0 * np.ones((nmix, ncomp))
+
+        self.A = mx.array(A_np.astype(np.float32))
+        self.mu = mx.array(mu_np.astype(np.float32))
+        self.alpha = mx.array(alpha_np.astype(np.float32))
+        self.beta = mx.array(beta_np.astype(np.float32))
+        self.rho = mx.array(rho_np.astype(np.float32))
+        self.gm = mx.array(np.ones(1, dtype=np.float32))
+
+        self.lrate = self.lrate0
+        self.lrate_cap = self.lrate0
+        self.rholrate = self.rholrate0
+        self.iteration = 0
+        self._refresh_lgamma_table()
+        self._update_unmixing_matrices()
+
+    def _refresh_lgamma_table(self):
+        """Recompute ``lgamma(1+1/rho)`` host-side (MLX has no lgamma). Called at
+        init and after every rho update. Cheap: rho is ``(n_mix, n_channels)``."""
+        rho_np = np.array(self.rho, dtype=np.float64)
+        self._lgamma_table = mx.array(gammaln(1.0 + 1.0 / rho_np).astype(np.float32))
+
+    def _update_unmixing_matrices(self):
+        """W = inv(A) and the LL Jacobian log|det W|, both on the CPU stream
+        (MLX linalg is CPU-only) and hoisted to once per iteration."""
+        self.W = mx.linalg.inv(self.A, stream=_CPU)
+        self._logdet_W = mx.linalg.slogdet(self.W, stream=_CPU)[1]
+
+    # ------------------------------------------------------------------
+    # E-step
+    # ------------------------------------------------------------------
+    def _forward(self, Xb: mx.array):
+        """E-step forward pass for one block (single model). ``Xb`` is
+        ``(n_channels, batch)``. Returns ``(logV, b, z, y, az_rho)``."""
+        b = Xb.T @ self.W  # (batch, n_channels); c == 0 for single model
+        mu_h = self.mu.T[None]  # (1, n_channels, n_mix)
+        beta_h = self.beta.T[None]
+        rho_h = self.rho.T[None]
+        alpha_h = self.alpha.T[None]
+        lgamma_h = self._lgamma_table.T[None]
+
+        y = beta_h * (b[..., None] - mu_h)  # (batch, n_channels, n_mix)
+        log_pdf, az_rho = _log_pdf_gg(y, rho_h, lgamma_h)
+        z0 = mx.log(alpha_h) + mx.log(beta_h) + log_pdf
+        ll_i = mx.logsumexp(z0, axis=-1)  # (batch, n_channels)
+        z = mx.softmax(z0, axis=-1)
+        # Single model: log(gm)=0; logdet_W + sldet are the Jacobian terms.
+        logV = self._logdet_W + self.sldet + ll_i.sum(axis=-1)  # (batch,)
+        return logV, b, z, y, az_rho
+
+    def _get_block_updates(self, Xb: mx.array) -> dict:
+        """Exact-EM sufficient statistics for one block (single-model,
+        non-Newton subset of AMICATorchNG._get_block_updates, core.py:887-947)."""
+        logV, b, z, y, az_rho = self._forward(Xb)
+        block_ll = logV.sum()  # single model: logsumexp over one model is identity
+        beta_h = self.beta.T[None]  # (1, n_channels, n_mix)
+        rho_h = self.rho.T[None]
+
+        fp = _score_gg(y, rho_h)
+        u = z  # u = v*z with v == 1 (single model)
+        ufp = u * fp
+
+        dgm = mx.array(float(Xb.shape[1]), dtype=mx.float32)  # sum_t v_h = n samples
+        dalpha_n = u.sum(0).T  # (n_mix, n_channels)
+        dmu_n = ufp.sum(0).T
+        # Phase A guard: float32 can round y to exactly 0 (fp(0)=0 => ufp=0), so
+        # ufp/y is 0/0=NaN; where y==0, 0/1 contributes 0 (issue #75).
+        safe_y = mx.where(y == 0, mx.ones_like(y), y)
+        dmu_d = (beta_h[0] * (ufp / safe_y).sum(0)).T
+        dbeta_n = u.sum(0).T
+        dbeta_d = (ufp * y).sum(0).T
+
+        ay = mx.abs(y)
+        tiny = float(np.finfo(np.float32).tiny)
+        logab = rho_h * mx.log(mx.maximum(ay, tiny))
+        logab = mx.where(az_rho < _EPSDBLE, mx.zeros_like(logab), logab)
+        drho_n = (u * (az_rho * logab)).sum(0).T
+
+        g = (beta_h * ufp).sum(-1)  # (batch, n_channels)
+        dWtmp = g.T @ b  # (n_channels, n_channels)
+
+        return {
+            "dgm": dgm,
+            "dalpha_n": dalpha_n,
+            "dmu_n": dmu_n,
+            "dmu_d": dmu_d,
+            "dbeta_n": dbeta_n,
+            "dbeta_d": dbeta_d,
+            "drho_n": drho_n,
+            "dWtmp": dWtmp,
+            "ll": block_ll,
+        }
+
+    def _accumulate_blocks(self, X: mx.array) -> dict:
+        """Sum sufficient statistics over all blocks as one lazy graph (no
+        per-block ``mx.eval`` -- that over-syncs 2.6x)."""
+        n_samples = X.shape[1]
+        acc: Optional[dict] = None
+        for start in range(0, n_samples, self.block_size):
+            end = min(start + self.block_size, n_samples)
+            block_acc = self._get_block_updates(X[:, start:end])
+            if acc is None:
+                acc = block_acc
+            else:
+                for key in acc:
+                    acc[key] = acc[key] + block_acc[key]
+        return acc
+
+    # ------------------------------------------------------------------
+    # M-step
+    # ------------------------------------------------------------------
+    def _update_parameters(self, acc: dict, n_samples: int):
+        """Exact-EM mixture updates + natural-gradient A-update (single-model,
+        non-Newton subset of AMICATorchNG._update_parameters, core.py:1049-1247)."""
+        self.gm = acc["dgm"] / n_samples  # == 1 for single model
+
+        self.alpha = acc["dalpha_n"] / acc["dalpha_n"].sum(axis=0, keepdims=True)
+        self.mu = self.mu + acc["dmu_n"] / acc["dmu_d"]
+        self.beta = mx.clip(
+            self.beta * mx.sqrt(acc["dbeta_n"] / acc["dbeta_d"]),
+            self.invsigmin,
+            self.invsigmax,
+        )
+
+        # GG shape update with the 1/psi(1+1/rho) digamma factor (Fortran
+        # :2013-2014); digamma is computed host-side (MLX has none).
+        if self.dorho:
+            drho = acc["drho_n"] / mx.maximum(acc["dalpha_n"], 1e-8)
+            rho_np = np.array(self.rho, dtype=np.float64)
+            psi = mx.array(digamma(1.0 + 1.0 / rho_np).astype(np.float32))
+            new_rho = self.rho + self.rholrate * (1.0 - (self.rho / psi) * drho)
+            self.rho = mx.clip(new_rho, self.minrho, self.maxrho)
+
+        # Natural-gradient A-update. A is stored as Fortran's A^T, so the update
+        # is a LEFT-multiply by the transposed direction (core.py:1156-1164,
+        # #24 root cause). Single-model collapses the gm-weighted column average.
+        eye = mx.eye(self.n_channels)
+        dA = -acc["dWtmp"] / acc["dgm"] + eye  # I - <g b^T>/dgm
+        self.lrate = min(
+            self.lrate_cap, self.lrate + min(1.0 / self.newt_ramp, self.lrate)
+        )
+        self.A = self.A - self.lrate * (dA.T @ self.A)
+
+        if self.doscaling and (self.iteration % self.scalestep == 0):
+            scale = mx.sqrt((self.A**2).sum(axis=0))  # (n_comps,)
+            safe_scale = mx.where(scale > 0, scale, mx.ones_like(scale))
+            self.A = self.A / safe_scale
+            self.mu = self.mu * scale
+            self.beta = self.beta / safe_scale
+
+        self._refresh_lgamma_table()
+        self._update_unmixing_matrices()
+
+    # ------------------------------------------------------------------
+    # Fit
+    # ------------------------------------------------------------------
+    def fit(
+        self, X: np.ndarray, max_iter: int = 100, verbose: bool = True
+    ) -> "AMICAMLXNG":
+        """Fit the model. ``X`` is ``(n_channels, n_samples)``."""
+        if X.ndim != 2:
+            raise ValueError(f"X must be 2D (n_channels, n_samples), got {X.shape}")
+        if X.shape[0] != self.n_channels:
+            raise ValueError(
+                f"X has {X.shape[0]} channels, model expects {self.n_channels}"
+            )
+
+        X_t = self._preprocess(X)
+        n_total = X_t.shape[1]
+        self._initialize_parameters()
+        self.ll_history = []
+        self.stop_reason = "max_iter"
+        numdecs = 0
+
+        rng = range(max_iter)
+        if verbose:
+            try:
+                from tqdm import tqdm
+
+                rng = tqdm(rng, desc="AMICA-MLX")
+            except ImportError:
+                pass
+
+        for it in rng:
+            self.iteration = it
+            acc = self._accumulate_blocks(X_t)
+
+            ll_arr = acc["ll"] / (n_total * self.n_channels)
+            mx.eval(ll_arr)  # materialize the accumulate graph once
+            ll = float(ll_arr.item())
+            if not math.isfinite(ll):
+                self.stop_reason = "nan_ll" if math.isnan(ll) else "singular_ll"
+                logger.warning(
+                    "Non-finite log-likelihood (%s) at iteration %d; stopping.", ll, it
+                )
+                break
+
+            self._update_parameters(acc, n_total)
+            # One eval per iteration bounds the lazy graph to a single iteration's
+            # worth of ops (the updated params feed the next accumulate).
+            mx.eval(self.A, self.W, self.mu, self.alpha, self.beta, self.rho)
+
+            self.ll_history.append(ll)
+
+            # Learning-rate control (Fortran amica17.f90:1062-1108): anneal on an
+            # LL decrease; ratchet the ceiling after maxdecs persistent decreases.
+            if len(self.ll_history) > 1 and ll < self.ll_history[-2]:
+                if self.lrate <= self.minlrate:
+                    logger.warning(
+                        "lrate floor (%g) reached at iter %d; stopping.",
+                        self.minlrate,
+                        it,
+                    )
+                    self.stop_reason = "lrate_floor"
+                    break
+                self.lrate *= self.lratefact
+                self.rholrate *= self.rholratefact
+                numdecs += 1
+                if numdecs >= self.maxdecs:
+                    self.lrate_cap *= self.lratefact
+                    numdecs = 0
+
+        if self.stop_reason in self._DEGENERATE_STOP_REASONS:
+            self.final_ll_ = float("nan")
+        else:
+            self.final_ll_ = self.ll_history[-1] if self.ll_history else float("nan")
+        return self

--- a/pyAMICA/tests/mlx_tests/test_mlx_backend.py
+++ b/pyAMICA/tests/mlx_tests/test_mlx_backend.py
@@ -1,0 +1,149 @@
+"""MLX backend (AMICAMLXNG) tests -- issue #76, epic #74 Phase C.
+
+Apple-Silicon only. Real sample EEG (no synthetic/mock). The whole module
+self-skips when MLX or an Apple GPU is unavailable, so CI on ubuntu skips it.
+
+Correctness is checked two ways: the per-block sufficient statistics match the
+validated NumPy float64 reference (tight, independent oracle), and a full fit's
+converged log-likelihood matches the PyTorch float32 backend (the epic's
+backend-vs-backend acceptance).
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+SAMPLE_DIR = Path(__file__).resolve().parents[2] / "sample_data"
+DATA_FILE = SAMPLE_DIR / "eeglab_data.fdt"
+NW = 32
+FIELD = 30504
+NMIX = 3
+SEED = 42
+
+pytestmark = [
+    pytest.mark.skipif(not DATA_FILE.exists(), reason="sample data missing"),
+    pytest.mark.skipif(
+        mx.default_device().type != mx.DeviceType.gpu, reason="no Apple GPU"
+    ),
+]
+
+# Sufficient-stat keys the MLX backend produces (single-model, non-Newton).
+_STAT_KEYS = [
+    "dgm",
+    "dalpha_n",
+    "dmu_n",
+    "dmu_d",
+    "dbeta_n",
+    "dbeta_d",
+    "drho_n",
+    "dWtmp",
+]
+
+
+def _load_real_data() -> np.ndarray:
+    from pyAMICA.torch_impl.utils import load_eeglab_data
+
+    return load_eeglab_data(str(DATA_FILE), data_dim=NW, field_dim=FIELD).astype(
+        np.float64
+    )
+
+
+def test_mvp_rejects_unsupported_config():
+    """The v1 MVP boundaries fail loudly, not silently."""
+    from pyAMICA.mlx_impl import AMICAMLXNG
+
+    for kw in ({"n_models": 2}, {"do_newton": True}, {"pdftype": 2, "n_mix": NMIX}):
+        with pytest.raises(NotImplementedError):
+            AMICAMLXNG(n_channels=NW, n_mix=kw.pop("n_mix", 1), **kw)
+
+
+def test_sufficient_stats_match_numpy_reference():
+    """Tight algorithmic faithfulness: the MLX (float32) per-block sufficient
+    statistics match the validated NumPy float64 reference on an identical block
+    with identical (shared-seed) parameters. rtol=1e-3 accommodates float32
+    vs float64 (measured max relerr ~1.6e-4 on dWtmp/dmu_d)."""
+    from pyAMICA.mlx_impl import AMICAMLXNG
+    from pyAMICA.numpy_impl.core import AMICA as AMICA_NumPy
+
+    data = _load_real_data()
+    m = AMICAMLXNG(n_channels=NW, n_mix=NMIX, seed=SEED, block_size=256)
+    x_t = m._preprocess(data)
+    m._initialize_parameters()
+
+    blk = 256
+    block = np.array(x_t[:, :blk])  # float32 sphered block, on host
+    mlx_upd = m._get_block_updates(mx.array(block))
+
+    npm = AMICA_NumPy(num_models=1, num_mix=NMIX, do_newton=False)
+    npm.data_dim = NW
+    npm.num_comps = NW
+    npm.num_models = 1
+    npm.num_mix = NMIX
+    npm.block_size = blk
+    npm.comp_list = np.arange(NW).reshape(NW, 1)
+    npm.A = np.array(m.A, dtype=np.float64)
+    npm.W = np.array(m.W, dtype=np.float64)[:, :, None]  # NumPy expects (n,n,models)
+    npm.c = np.zeros((NW, 1))
+    npm.mu = np.array(m.mu, dtype=np.float64)
+    npm.alpha = np.array(m.alpha, dtype=np.float64)
+    npm.beta = np.array(m.beta, dtype=np.float64)
+    npm.rho = np.array(m.rho, dtype=np.float64)
+    npm.gm = np.array(m.gm, dtype=np.float64)
+    np_upd = npm._get_block_updates(block.astype(np.float64))
+
+    for key in _STAT_KEYS:
+        a = np.asarray(np.array(mlx_upd[key]), dtype=np.float64)
+        b = np.asarray(np_upd[key], dtype=np.float64).reshape(a.shape)
+        assert np.allclose(a, b, rtol=1e-3, atol=1e-4), (
+            f"{key} differs from NumPy reference by {np.max(np.abs(a - b)):.3e}"
+        )
+
+
+def test_backend_stable_on_full_data():
+    """The MLX backend fits the full 30504-sample EEG on the Apple GPU (float32)
+    without diverging (the Phase A ``ufp/y`` guard is carried into MLX), and the
+    log-likelihood improves over the run."""
+    from pyAMICA.mlx_impl import AMICAMLXNG
+
+    m = AMICAMLXNG(n_channels=NW, n_mix=NMIX, seed=SEED)
+    m.fit(_load_real_data(), max_iter=100, verbose=False)
+
+    hist = np.asarray(m.ll_history, dtype=float)
+    assert np.all(np.isfinite(hist))
+    assert np.isfinite(m.final_ll_)
+    assert np.all(np.isfinite(np.array(m.A)))
+    assert m.stop_reason not in AMICAMLXNG._DEGENERATE_STOP_REASONS
+    assert hist[-1] > hist[0]  # ascent
+
+
+def test_converged_ll_matches_torch_float32():
+    """Epic acceptance: the MLX backend is equivalent to the PyTorch float32
+    backend. At matched settings/seed both reach the same natural-gradient GG
+    fixed point; the converged per-sample-per-channel LL agrees within 1e-2
+    (measured gap ~2e-6). Bit-identity is impossible (GPU-vs-CPU float32 +
+    reduction order), so the tolerance is relational, never a hardcoded LL."""
+    import torch
+
+    from pyAMICA.mlx_impl import AMICAMLXNG
+    from pyAMICA.torch_impl import AMICATorchNG
+
+    data = _load_real_data()
+    mlx_m = AMICAMLXNG(n_channels=NW, n_mix=NMIX, seed=SEED)
+    mlx_m.fit(data, max_iter=100, verbose=False)
+
+    torch_m = AMICATorchNG(
+        n_channels=NW,
+        n_models=1,
+        n_mix=NMIX,
+        seed=SEED,
+        device="cpu",
+        dtype=torch.float32,
+        do_newton=False,
+    )
+    torch_m.fit(data, max_iter=100, verbose=False)
+
+    assert np.isfinite(mlx_m.final_ll_)
+    assert abs(mlx_m.final_ll_ - torch_m.final_ll_) < 1e-2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,12 @@ dependencies = [
     "torch>=2.12.1",
 ]
 
+# Optional Apple-Silicon GPU backend (AMICAMLXNG). MLX is Apple-only, so it is
+# NOT a core dependency; install with `uv pip install mlx` or `pip install
+# pyAMICA[mlx]`. `import pyAMICA` never requires it (mlx_impl is imported lazily).
+[project.optional-dependencies]
+mlx = ["mlx>=0.32"]
+
 [project.urls]
 Homepage = "http://github.com/neuromechanist/pyAMICA"
 Repository = "http://github.com/neuromechanist/pyAMICA"
@@ -40,7 +46,7 @@ Repository = "http://github.com/neuromechanist/pyAMICA"
 [tool.setuptools]
 # List subpackages explicitly so the wheel is deterministic across platforms
 # (a bare ["pyAMICA"] dropped torch_impl/ on some setuptools versions).
-packages = ["pyAMICA", "pyAMICA.numpy_impl", "pyAMICA.torch_impl"]
+packages = ["pyAMICA", "pyAMICA.numpy_impl", "pyAMICA.torch_impl", "pyAMICA.mlx_impl"]
 # numpy_impl/params.json is the NumPy backend's default parameter file, loaded at
 # runtime via importlib/__file__, so it must ship in the wheel.
 package-data = {"pyAMICA" = ["data/*"], "pyAMICA.numpy_impl" = ["params.json"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,10 @@ omit = [
     "pyAMICA/tests/*",
     # argparse CLI entrypoint: exercised via subprocess, not unit-covered here.
     "pyAMICA/numpy_impl/cli.py",
+    # Optional MLX backend (Apple Silicon only): its tests require MLX + an Apple
+    # GPU, so CI (ubuntu, no mlx) cannot exercise it and always measures 0%. It is
+    # covered locally by tests/mlx_tests/ on Apple hardware (issue #76).
+    "pyAMICA/mlx_impl/*",
 ]
 
 [tool.coverage.report]

--- a/uv.lock
+++ b/uv.lock
@@ -523,6 +523,47 @@ wheels = [
 ]
 
 [[package]]
+name = "mlx"
+version = "0.32.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mlx-metal", marker = "sys_platform == 'darwin'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/a6/489176d8a2a06137a299910057cc44dc3fccfb73151f7562fea2b75894d9/mlx-0.32.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:ea5a594355c89c0095eaba413fd39d4caa8642fa13432dfb0c9354d141046467", size = 558889, upload-time = "2026-07-07T17:55:45.268Z" },
+    { url = "https://files.pythonhosted.org/packages/85/2a/5d1f1cb1b073c39c822e0c0be1e68f4ced6fd32ab15cf8bb1f448028842c/mlx-0.32.0-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:e5f778001562ccce26cf6e5be1050d2afc78e2902bad206201ab9f5a6d0f886a", size = 558890, upload-time = "2026-07-07T17:55:46.701Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/01/02110ceacf4efd00ec172f60b4cd42c8b1509ac50ffa65a6a77d723133aa/mlx-0.32.0-cp312-cp312-macosx_26_0_arm64.whl", hash = "sha256:8dfb577faa4dc413cfd0d6eb78f230d3b3b6169df4473e84408abdeb21346e9d", size = 558856, upload-time = "2026-07-07T17:55:48.09Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/af/b16b7ab2670edf0f8f2cdeb2b6b3d5ab27a749b31ed74cb6825958ca0892/mlx-0.32.0-cp312-cp312-manylinux_2_35_aarch64.whl", hash = "sha256:50bc29bfaf31dff5138a472b56963bd6ece0fa67800c6c382745aaa41126d01f", size = 617769, upload-time = "2026-07-07T17:55:49.596Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ef/c326e05070f35c43a9775ce9dceaf155c8a9b2706a4c52d64e8999d4929a/mlx-0.32.0-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:78804098c9f64978b6048ffdfd78689b9e06efa2a530c541d0bd73ce44d2f589", size = 675402, upload-time = "2026-07-07T17:55:51.148Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/e9/04cd133d18b4da1c00515c595c1cb6de7e2534938d2c3de2f3f2301c3466/mlx-0.32.0-cp312-cp312-win_amd64.whl", hash = "sha256:13ac6469479cda4bfd6954e0b574b92930b87073f7c79be121a68b31a3a6c596", size = 558048, upload-time = "2026-07-07T17:55:52.471Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f6/f27397f44c84138bcae00592a377fc5b1fc79d1dbfa820c1af20042f4c33/mlx-0.32.0-cp312-cp312-win_arm64.whl", hash = "sha256:7c8d3a7b506ab45b3f7976495126c16830d988ec53289134b2bb64dae1efb835", size = 543631, upload-time = "2026-07-07T17:55:53.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/be/ddc888d4a20c7602da06ad1a244f495010c6c7d2457f6253e8fa3c99ceea/mlx-0.32.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:abb786ee1e9638759be82583222fc7d09c5650ef90ad2b7c5da7d1931a8676dc", size = 558795, upload-time = "2026-07-07T17:55:54.907Z" },
+    { url = "https://files.pythonhosted.org/packages/38/b9/4f0ae7785fdb3fa7e44434908d832cbc7a9a1e096d046ac6fe953812c52c/mlx-0.32.0-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:deb284f3a5cd0c3e87bed80c2bee9dcbf946bdad44d75592f6fb784da878c1c0", size = 558799, upload-time = "2026-07-07T17:55:56.844Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/a8/7bc999ce5d09dfac8961dcda4ed47e173fca2857492f34599b237380f20d/mlx-0.32.0-cp313-cp313-macosx_26_0_arm64.whl", hash = "sha256:4192a2d02014a13a6a1030bf13dfb4e4fe05ec3ffa47678ee37da29111e25cb1", size = 558786, upload-time = "2026-07-07T17:55:58.272Z" },
+    { url = "https://files.pythonhosted.org/packages/83/cf/90980e28e6adaaf47d7951604ff2ac4ceb3952040f941bececb9b7a07a4c/mlx-0.32.0-cp313-cp313-manylinux_2_35_aarch64.whl", hash = "sha256:102043c6455fe0939509c1e96caec4678f51e241981238da97c83beeed5653f6", size = 617228, upload-time = "2026-07-07T17:55:59.603Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fa/e3608936caa02ebf7fc645e3289134918facb0cff6dcb563d51996a5b70e/mlx-0.32.0-cp313-cp313-manylinux_2_35_x86_64.whl", hash = "sha256:e5cdb9bf7c1a9320827a65f7ed63e3742d5b9280d31affc0c277e77982d465ae", size = 675294, upload-time = "2026-07-07T17:56:00.993Z" },
+    { url = "https://files.pythonhosted.org/packages/65/96/4979a82390a69e7ff48a43d3ea5cac222ae6bc41c2ba56550f6f5bd416b3/mlx-0.32.0-cp313-cp313-win_amd64.whl", hash = "sha256:9fea39d8ecf1d08e5c3d5d70936d5a1ca6b890353c1b0b96c4e6232349d48e36", size = 558017, upload-time = "2026-07-07T17:56:02.307Z" },
+    { url = "https://files.pythonhosted.org/packages/15/94/1b2a1e3b60fce6bd61ca8af3ccfe0da30f42184352a70123870fd960ce0d/mlx-0.32.0-cp313-cp313-win_arm64.whl", hash = "sha256:df6fa6785fb7a6f8d8e3e91c41074c885aa253b09c2b69e3c4d4f905e3c457e3", size = 543559, upload-time = "2026-07-07T17:56:03.644Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/90/5e49c183f9024f86dc1f038866ccd743aaec1fe412a7e7dc76fec9271f48/mlx-0.32.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2ee79b1f8c2c2a329afc95ece7dce0be798d43f3de771a6370d2b9f9702bbd9a", size = 561387, upload-time = "2026-07-07T17:56:05.177Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/33/e3d7f7a18331523762e9968b6716e81514649af81ffd9ba4364e3df95823/mlx-0.32.0-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:e0db558267bb2d13fac4f85674456adbe0f085c570b9219e03d4e95fdc11c4d0", size = 561389, upload-time = "2026-07-07T17:56:06.743Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/58/bd847d3fed65296573a4bb3399adde6934c0a718813b5636000d7d1b4063/mlx-0.32.0-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:23e83c8e74a23156696e9f9905d16a17b7d27b5a596c1bc0f720a98df1c5aadf", size = 561392, upload-time = "2026-07-07T17:56:08.237Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f3/0c3c8bb11362a97ebc6407a1c3e24a45de470e9326ef53dcc96e83263e84/mlx-0.32.0-cp314-cp314-manylinux_2_35_aarch64.whl", hash = "sha256:253c5d20c573b277fc64a3eec491984e7ad4c64f9b246c1b3fee903b7d1db824", size = 618758, upload-time = "2026-07-07T17:56:09.729Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/94/61b29c561045576e78d6f992c22d0bb301e8e6eec65588560f942d59c88d/mlx-0.32.0-cp314-cp314-manylinux_2_35_x86_64.whl", hash = "sha256:4edffbdb1f7c185e35dc4e48611966d012b1dda9225a0dabd0fbd31651374a71", size = 675130, upload-time = "2026-07-07T17:56:11.059Z" },
+    { url = "https://files.pythonhosted.org/packages/01/fe/5a0dd8784e0335aa7d472365177a6a13245b4aa28cf102c9bac6d65675c8/mlx-0.32.0-cp314-cp314-win_amd64.whl", hash = "sha256:f67557bd9ce31cbb519b39e9455b19cca698eb153ab6f4deef5b4d5509d94df3", size = 572405, upload-time = "2026-07-07T17:56:12.427Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/26/f9efe51f7f32afc7da95fc832cc3e2744f9284b846e0e18ebd98b6bd2458/mlx-0.32.0-cp314-cp314-win_arm64.whl", hash = "sha256:13f793c354ea9dc589bbd113f4b7d299900fb440199bbb403546845852b2499b", size = 558174, upload-time = "2026-07-07T17:56:13.694Z" },
+]
+
+[[package]]
+name = "mlx-metal"
+version = "0.32.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/ef/d74ae99cfe9ddb59fd08abd14f47754c3d199291a93756903fa595b31b8a/mlx_metal-0.32.0-py3-none-macosx_14_0_arm64.whl", hash = "sha256:5b64b20ac24b0c401f489de01e8209edc4d372125201f19314e6f39e385322aa", size = 40824649, upload-time = "2026-07-07T17:55:20.7Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/38/b96a3de98cfbb009592b3870af46ff63657b192f8d1e06c6c1faea5fbef3/mlx_metal-0.32.0-py3-none-macosx_15_0_arm64.whl", hash = "sha256:1bd94a1ce5b03a0c898771a3e759f0124300c6ab5155127906a1d50b1f3fcf19", size = 40818869, upload-time = "2026-07-07T17:55:25.059Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/59/65d32520175379df33f107749193aa94ea9db069167a36a1a100ff689f62/mlx_metal-0.32.0-py3-none-macosx_26_0_arm64.whl", hash = "sha256:3af76a498d84804f66119800499f9d143d7dffb0878a0dd0d7c2846e58565fd7", size = 56511379, upload-time = "2026-07-07T17:55:36.045Z" },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -845,6 +886,11 @@ dependencies = [
     { name = "tqdm" },
 ]
 
+[package.optional-dependencies]
+mlx = [
+    { name = "mlx" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
@@ -857,11 +903,13 @@ dev = [
 requires-dist = [
     { name = "json5" },
     { name = "matplotlib" },
+    { name = "mlx", marker = "extra == 'mlx'", specifier = ">=0.32" },
     { name = "numpy" },
     { name = "scipy" },
     { name = "torch", specifier = ">=2.12.1" },
     { name = "tqdm" },
 ]
+provides-extras = ["mlx"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
Adds `AMICAMLXNG` (`pyAMICA/mlx_impl/core.py`), an **optional Apple-Silicon GPU backend** that runs the natural-gradient EM E/M-step on the Apple GPU via MLX. Epic #74 Phase C. Now that Phase A made full-data float32 converge (the precision Apple GPUs are limited to), an MLX backend becomes viable.

**v1 MVP scope:** single-model, generalized Gaussian (`pdftype=0`), natural gradient. Newton, the other PDF families, component sharing, multi-model, outlier rejection and save/load are fast-follows (rejected with `NotImplementedError`, not silent).

## Hybrid design (forced by MLX 0.32, verified by probing)
- **GPU is float32-only** (Apple has no FP64) and **all `mlx.core.linalg` is CPU-only**. So the elementwise/matmul hot path runs on the **GPU float32 stream** (carrying the Phase A `ufp/y` divide-by-zero guard), while `inv(A)`/`slogdet(W)` run on the **CPU stream**, hoisted to **once per iteration** (the torch `_forward` recomputes slogdet 60x/iter). Measured: CPU linalg ~42 us/iter vs a ~13 ms GPU E-pass (0.3%) -- not the bottleneck; `mx.eval` placement is (one per iteration bounds the lazy graph).
- **`lgamma`/`digamma` are absent in MLX** -- the GG normalizer and the rho update are computed **host-side (SciPy)** on the small `rho` array, so the GPU E-step has no special functions.

## Optional dependency (CI-safe)
`mlx` is under `[project.optional-dependencies]`, not the default deps; `mlx_impl` is imported lazily so `import pyAMICA` never requires MLX. CI (ubuntu) doesn't install mlx, so the MLX tests self-skip (`pytest.importorskip` + skip-if-no-Apple-GPU).

## Test plan (real sample EEG, Apple GPU; NO MOCKS)
`pyAMICA/tests/mlx_tests/test_mlx_backend.py` (4 tests, all pass locally in ~20s):
- **Sufficient stats vs the NumPy float64 reference** (one block, identical shared-seed params): rtol 1e-3 (measured max relerr ~1.6e-4). Tight algorithmic faithfulness against an independent oracle.
- **Converged LL vs the PyTorch float32 backend** (the epic's acceptance): matched settings/seed, `|gap| < 1e-2` -- **measured gap ~2e-6** (both reach the same NG-GG fixed point).
- **Full-data stability:** finite `ll_history`, non-degenerate stop, ascent (the Phase A guard holds in MLX).
- **MVP boundaries** fail loudly (`NotImplementedError` for `n_models>1`, `do_newton`, `pdftype!=0`).
- Full non-slow torch suite unaffected (124 passed).

## Honest note
This is an **enablement + validation** step, not a proven speed win at 32 channels -- whether MLX actually beats CPU/PyTorch-MPS is what **Phase B** (dimension-sweep benchmark) measures.

Closes #76
Part of epic #74