### PR TITLE
Phase D: Multi-model support for AMICAMLXNG

### DIFF
--- a/.context/issue-77/benchmark_findings.md
+++ b/.context/issue-77/benchmark_findings.md
@@ -31,14 +31,22 @@ strong NVIDIA GPU", not a same-box comparison.
 | 48 | -3.20951 | -3.20952 | -3.20953 | -3.20951 | -3.21019 |
 | 70 | -3.21579 | -3.21562 | -3.21560 | -3.21570 | -3.21315 |
 
-## Multi-model -- ms/it and LL (Mac; MLX excluded = single-model MVP; CUDA pending)
+## Multi-model (n_models=2) -- ms/it (Mac; CUDA pending)
 
-m2 (no share), 70ch: torch-cpu-f32 **224** / cpu-f64 253 / mps-f32 270 / numpy 928 ms.
-m2+share, 70ch: cpu-f32 **224** / cpu-f64 253 / mps-f32 262 / numpy 934 ms.
-Sharing activates in torch (70ch LL -2.943 -> -3.049); numpy's sharing diverges
-(-2.919 -> -2.917) -- multi-model is not partition-identifiable and has no
-bit-exact oracle (#27/#60), so cross-backend LL differs by intrinsic estimator
-spread, not a defect.
+MLX now supports multi-model (issue #81), so it is measured here too:
+
+| channels | **mlx-f32** | torch-cpu-f32 | torch-mps-f32 | numpy-cpu-f64 |
+|---:|---:|---:|---:|---:|
+| 32 | **38** | 187 | 291 | 869 |
+| 70 | **45** | 224 | 270 | 928 |
+
+**The Apple-GPU win extends to multi-model: MLX ~38-45 ms/it, ~5x over torch-CPU**
+(and MPS still loses). Converged LL matches torch-float32 (32ch -3.0883 both; the
+one-iteration sufficient stats agree to float32 precision, `tests/mlx_tests`).
+Component sharing stays a fast-follow for MLX; in torch, sharing activates (70ch
+LL -2.943 -> -3.049) while numpy's sharing diverges -- multi-model is not
+partition-identifiable and has no bit-exact oracle (#27/#60), so cross-backend LL
+differs by intrinsic estimator spread, not a defect.
 
 ## Findings
 
@@ -60,19 +68,20 @@ spread, not a defect.
    implementation, not a production path. (numpy is benchmarked with the same
    fixed block_size=512 and `do_opt_block=False`; leaving its default on ran an
    in-fit block-size auto-tune that ~doubled its time -- fixed in the harness.)
-6. **Multi-model has no GPU acceleration today**: MLX (the only Apple-GPU win) is
-   single-model-only (v1 MVP), and MPS loses. **Extending `AMICAMLXNG` to
-   multi-model is the highest-value fast-follow** -- it would carry the ~7x MLX
-   win to multi-model AMICA.
+6. **Multi-model MLX now carries the win (issue #81)**: ~38-45 ms/it, ~5x over
+   torch-CPU (MPS still loses), LL matching torch-float32. The remaining MLX
+   fast-follow is component sharing; a 128-256 ch / many-model sweep would find
+   the eventual MLX/CUDA crossover.
 
 ## Recommendation
 
-- **Apple Silicon: use the MLX backend** for single-model AMICA (~7x over CPU);
-  avoid `device="mps"` (no gain). **NVIDIA: float64-CUDA** stays the bit-safe
-  production GPU path.
-- **Fast-follow: multi-model MLX** (issue TBD) to extend the win beyond
-  single-model; and a high-dimensional (128-256 ch, many-model) sweep to find the
-  MLX/CUDA crossover.
+- **Apple Silicon: use the MLX backend** for single- and multi-model AMICA (~5-7x
+  over CPU); avoid `device="mps"` (no gain). **NVIDIA: float64-CUDA** stays the
+  bit-safe production GPU path.
+- **Fast-follows:** MLX component sharing; a high-dimensional (128-256 ch,
+  many-model) sweep to find the MLX/CUDA crossover; and a native-Fortran /
+  CPU-core-scaling cross-platform benchmark (its own effort, on a native-x86
+  Linux + CUDA host, since Apple's Fortran binary is x86-under-Rosetta).
 
 ## Caveats / pending
 

--- a/benchmarks/benchmark_dimsweep.py
+++ b/benchmarks/benchmark_dimsweep.py
@@ -111,13 +111,13 @@ def _run_torch(data, device, dtype_str, iters, repeats, n_models=1, share=False)
     return min(times) / iters * 1000.0, ll
 
 
-def _run_mlx(data, iters, repeats):
+def _run_mlx(data, iters, repeats, n_models=1):
     from pyAMICA.mlx_impl import AMICAMLXNG
 
     def one(n_iter):
         m = AMICAMLXNG(
             n_channels=data.shape[0],
-            n_models=1,
+            n_models=n_models,
             n_mix=N_MIX,
             do_newton=False,
             block_size=BLOCK_SIZE,
@@ -193,8 +193,8 @@ def _available(name: str, n_models: int = 1, share: bool = False) -> bool:
     if kind == "torch":
         return _torch_available(kw["device"])
     if kind == "mlx":
-        # AMICAMLXNG (v1 MVP) is single-model only, no sharing.
-        if n_models != 1 or share:
+        # AMICAMLXNG supports single- and multi-model (#81); sharing not yet.
+        if share:
             return False
         try:
             import mlx.core as mx
@@ -214,7 +214,7 @@ def _run_backend(name, data, iters, repeats, n_models=1, share=False):
             data, iters=iters, repeats=repeats, n_models=n_models, share=share, **kw
         )
     if kind == "mlx":
-        return _run_mlx(data, iters=iters, repeats=repeats)
+        return _run_mlx(data, iters=iters, repeats=repeats, n_models=n_models)
     return _run_numpy(
         data, iters=iters, repeats=repeats, n_models=n_models, share=share
     )

--- a/pyAMICA/mlx_impl/core.py
+++ b/pyAMICA/mlx_impl/core.py
@@ -1,6 +1,6 @@
-"""MLX natural-gradient EM backend for AMICA (issue #76, epic #74 Phase C).
+"""MLX natural-gradient EM backend for AMICA (issue #76/#81, epic #74 Phase C/D).
 
-``AMICAMLXNG`` is a v1 MVP port of :class:`pyAMICA.torch_impl.core.AMICATorchNG`
+``AMICAMLXNG`` is a port of :class:`pyAMICA.torch_impl.core.AMICATorchNG`
 to Apple's MLX array framework, so the per-block E/M-step runs on the Apple GPU.
 It is structurally parallel to the PyTorch backend (same method names/order and
 Fortran citations) so the two can be diffed method-by-method.
@@ -75,7 +75,7 @@ def _log_pdf_gg(
 class AMICAMLXNG:
     """MLX natural-gradient EM backend (GG, single- and multi-model; #76/#81).
 
-    Parameters mirror the subset of :class:`AMICATorchNG` that the MVP supports;
+    Parameters mirror the subset of :class:`AMICATorchNG` that is supported;
     the same ``seed`` produces the same initial parameters as the PyTorch/NumPy
     backends, so cross-backend equivalence is testable.
     """
@@ -257,7 +257,7 @@ class AMICAMLXNG:
 
     def _refresh_lgamma_table(self):
         """Recompute ``lgamma(1+1/rho)`` host-side (MLX has no lgamma). Called at
-        init and after every rho update. Cheap: rho is ``(n_mix, n_channels)``."""
+        init and after every rho update. Cheap: rho is ``(n_mix, n_comps)``."""
         rho_np = np.array(self.rho, dtype=np.float64)
         self._lgamma_table = mx.array(gammaln(1.0 + 1.0 / rho_np).astype(np.float32))
 
@@ -399,15 +399,21 @@ class AMICAMLXNG:
         tiny = float(np.finfo(np.float32).tiny)
 
         # Per-model data-space bias c[i,h] = sum_t v_h*x / sum_t v_h (Fortran
-        # update_c, core.py:1063-1073). Skipped for n_models=1 (v==1 => c is the
+        # update_c, core.py:1083-1092). Skipped for n_models=1 (v==1 => c is the
         # zero data mean; the update would add a float-sum residual and break the
         # #24 bit-exact single-model path). A dead model (dgm[h]==0) keeps its
-        # prior c rather than writing 0/0.
+        # prior c rather than writing 0/0, and is surfaced (matching AMICATorchNG).
         if self.n_models > 1:
             dgm = acc["dgm"]
-            live = (dgm > 0.0)[None, :]
+            live = dgm > 0.0
             new_c = acc["dc_numer"] / mx.maximum(dgm, tiny)[None, :]
-            self.c = mx.where(live, new_c, self.c)
+            self.c = mx.where(live[None, :], new_c, self.c)
+            if not bool(mx.all(live).item()):
+                logger.warning(
+                    "Zero-responsibility model(s) at iter %d; kept their prior "
+                    "bias c (dead-model guard).",
+                    self.iteration,
+                )
 
         self.alpha = acc["dalpha_n"] / acc["dalpha_n"].sum(axis=0, keepdims=True)
         self.mu = self.mu + acc["dmu_n"] / acc["dmu_d"]
@@ -440,7 +446,7 @@ class AMICAMLXNG:
         # Natural-gradient A-update. A is stored as Fortran's A^T, so the update
         # is a LEFT-multiply by the transposed direction (core.py:1176-1184,
         # #24 root cause). Each model's direction is scattered into its mixing
-        # columns as a gm-weighted average (Fortran dAk/zeta, core.py:1220-1227):
+        # columns as a gm-weighted average (Fortran dAk/zeta, core.py:1231-1247):
         # for the default disjoint comp_list every column has one contributor, so
         # gm cancels and n_models=1 is byte-for-byte the old `A - lrate*(dA.T@A)`.
         eye = mx.eye(self.n_channels)
@@ -519,15 +525,26 @@ class AMICAMLXNG:
 
             self._update_parameters(acc, n_total)
             # One eval per iteration bounds the lazy graph to a single iteration's
-            # worth of ops (the updated params feed the next accumulate).
-            mx.eval(self.A, self.W, self.mu, self.alpha, self.beta, self.rho)
+            # worth of ops (the updated params feed the next accumulate). gm/c are
+            # included so their dependency chain is materialized each iteration too
+            # (c depends on the prior iteration's c), not left to grow unbounded.
+            mx.eval(
+                self.A,
+                self.W,
+                self.mu,
+                self.alpha,
+                self.beta,
+                self.rho,
+                self.gm,
+                self.c,
+            )
 
             # Surface a corrupted M-step (component collapse / float32 overflow)
             # at the iteration it happens. The ll check above only catches a
             # corruption via the NEXT iteration's E-step, so a final-iteration
             # blow-up would otherwise complete as max_iter with silently NaN
             # parameters (the torch backend has state_dict as a backstop; the
-            # MLX MVP does not, so guard in fit()). Params are already
+            # MLX backend does not, so guard in fit()). Params are already
             # materialized by the mx.eval above, so this is a cheap read.
             params_finite = (
                 mx.all(mx.isfinite(self.A))
@@ -535,6 +552,8 @@ class AMICAMLXNG:
                 & mx.all(mx.isfinite(self.alpha))
                 & mx.all(mx.isfinite(self.beta))
                 & mx.all(mx.isfinite(self.rho))
+                & mx.all(mx.isfinite(self.gm))
+                & mx.all(mx.isfinite(self.c))
             )
             if not bool(params_finite.item()):
                 logger.warning(
@@ -572,10 +591,10 @@ class AMICAMLXNG:
         return self
 
     def transform(self, X: np.ndarray, model_idx: int = 0) -> np.ndarray:
-        """Not in the v1 MVP -- fail with a clear boundary rather than a bare
+        """Not yet implemented -- fail with a clear boundary rather than a bare
         AttributeError. Use ``AMICATorchNG.transform`` for source extraction; the
-        MLX backend (issue #76) validates via ``final_ll_``/``ll_history``."""
+        MLX backend validates via ``final_ll_``/``ll_history``."""
         raise NotImplementedError(
-            "AMICAMLXNG (v1) does not implement transform yet; it is a "
-            "fast-follow. Use AMICATorchNG for source extraction."
+            "AMICAMLXNG does not implement transform yet; it is a fast-follow. "
+            "Use AMICATorchNG for source extraction."
         )

--- a/pyAMICA/mlx_impl/core.py
+++ b/pyAMICA/mlx_impl/core.py
@@ -19,11 +19,12 @@ Design constraints (verified against MLX 0.32, see ``.context/mps_pathways.md``)
   and the rho-update ``digamma(1+1/rho)`` depend only on the small ``rho`` array,
   so they are computed host-side with SciPy once per iteration.
 
-MVP scope: single model (``n_models=1``), generalized Gaussian (``pdftype=0``),
-natural gradient (``do_newton=False``). Newton, the other PDF families and
-multi-model are rejected in ``__init__`` with a clear ``NotImplementedError``
-(``transform`` likewise). Component sharing, outlier rejection, ``keep_best``
-and save/load are simply absent (no such parameter/method) -- all fast-follows.
+Scope: single- and multi-model (``n_models >= 1``, issue #81), generalized
+Gaussian (``pdftype=0``), natural gradient (``do_newton=False``). Newton and the
+other PDF families are rejected in ``__init__`` with a clear
+``NotImplementedError`` (``transform`` likewise). Component sharing, outlier
+rejection, ``keep_best`` and save/load are simply absent (no such
+parameter/method) -- all fast-follows.
 """
 
 from __future__ import annotations
@@ -72,7 +73,7 @@ def _log_pdf_gg(
 
 
 class AMICAMLXNG:
-    """MLX natural-gradient EM backend (single-model GG MVP, issue #76).
+    """MLX natural-gradient EM backend (GG, single- and multi-model; #76/#81).
 
     Parameters mirror the subset of :class:`AMICATorchNG` that the MVP supports;
     the same ``seed`` produces the same initial parameters as the PyTorch/NumPy
@@ -106,27 +107,22 @@ class AMICAMLXNG:
         do_approx_sphere: bool = True,
         seed: Optional[int] = None,
     ):
-        # --- MVP boundaries: reject the deferred configurations up front. -----
-        if n_models != 1:
-            raise NotImplementedError(
-                "AMICAMLXNG (v1) supports single-model only (n_models=1); "
-                "multi-model is a fast-follow. Use AMICATorchNG for n_models>1."
-            )
+        # --- Boundaries: reject the still-deferred configurations up front. ---
         if pdftype != 0:
             raise NotImplementedError(
-                "AMICAMLXNG (v1) supports the generalized-Gaussian family "
+                "AMICAMLXNG supports the generalized-Gaussian family "
                 "(pdftype=0) only; the other families are a fast-follow."
             )
         if do_newton:
             raise NotImplementedError(
-                "AMICAMLXNG (v1) supports the natural gradient only "
+                "AMICAMLXNG supports the natural gradient only "
                 "(do_newton=False); Newton is a fast-follow."
             )
 
         self.n_channels = n_channels
-        self.n_models = 1
+        self.n_models = n_models  # multi-model supported (issue #81); no sharing yet
         self.n_mix = n_mix
-        self.n_comps = n_channels
+        self.n_comps = n_channels * n_models
         self.block_size = block_size
 
         self.lrate0 = lrate
@@ -164,9 +160,9 @@ class AMICAMLXNG:
 
         # Populated by fit()/_initialize_parameters().
         self.A = self.W = self.mu = self.alpha = self.beta = self.rho = None
-        self.gm = self.mean = self.sphere = None
+        self.gm = self.c = self.comp_list = self.mean = self.sphere = None
         self.sldet = 0.0
-        self._lgamma_table = None  # mx.array (n_mix, n_channels): lgamma(1+1/rho)
+        self._lgamma_table = None  # mx.array (n_mix, n_comps): lgamma(1+1/rho)
         self._logdet_W = None  # mx.array scalar: log|det W|, refreshed per iter
 
     _DEGENERATE_STOP_REASONS = ("nan_ll", "singular_ll", "nan_params")
@@ -223,9 +219,16 @@ class AMICAMLXNG:
         order as AMICATorchNG/AMICA_NumPy (core.py:688-725), so a shared seed
         gives a bit-identical (float32-cast) starting point."""
         rng = np.random.RandomState(self.seed)
-        n, ncomp, nmix = self.n_channels, self.n_comps, self.n_mix
+        n, m, ncomp, nmix = self.n_channels, self.n_models, self.n_comps, self.n_mix
 
-        A_np = np.eye(n) + 0.01 * (0.5 - rng.rand(n, n))
+        # Per-model mixing blocks + comp_list mapping each (channel, model) to its
+        # column in A (identical RNG draw order to AMICATorchNG; for m=1 the loop
+        # runs once, so single-model init stays byte-for-byte).
+        A_np = np.zeros((n, ncomp))
+        comp_list_np = np.zeros((n, m), dtype=np.int64)
+        for h in range(m):
+            A_np[:, h * n : (h + 1) * n] = np.eye(n) + 0.01 * (0.5 - rng.rand(n, n))
+            comp_list_np[:, h] = np.arange(h * n, (h + 1) * n)
 
         mu_np = np.zeros((nmix, ncomp))
         for k in range(ncomp):
@@ -237,11 +240,13 @@ class AMICAMLXNG:
         rho_np = self.rho0 * np.ones((nmix, ncomp))
 
         self.A = mx.array(A_np.astype(np.float32))
+        self.comp_list = mx.array(comp_list_np)  # (n_channels, n_models) int
         self.mu = mx.array(mu_np.astype(np.float32))
         self.alpha = mx.array(alpha_np.astype(np.float32))
         self.beta = mx.array(beta_np.astype(np.float32))
         self.rho = mx.array(rho_np.astype(np.float32))
-        self.gm = mx.array(np.ones(1, dtype=np.float32))
+        self.gm = mx.array((np.ones(m) / m).astype(np.float32))
+        self.c = mx.array(np.zeros((n, m), dtype=np.float32))
 
         self.lrate = self.lrate0
         self.lrate_cap = self.lrate0
@@ -257,79 +262,115 @@ class AMICAMLXNG:
         self._lgamma_table = mx.array(gammaln(1.0 + 1.0 / rho_np).astype(np.float32))
 
     def _update_unmixing_matrices(self):
-        """W = inv(A) and the LL Jacobian log|det W|, both on the CPU stream
-        (MLX linalg is CPU-only) and hoisted to once per iteration.
+        """Per-model ``W_h = inv(A[:, comp_list[:, h]])`` and the LL Jacobian
+        ``log|det W_h|``, on the CPU stream (MLX linalg is CPU-only), hoisted to
+        once per iteration. ``W`` is ``(n_models, n, n)`` and ``_logdet_W`` is
+        ``(n_models,)``. For n_models=1 this is ``inv(A)`` unchanged.
 
         These build lazy graph nodes; a singular ``A`` therefore raises not here
         but where the graph is materialized (the ``mx.eval`` in ``fit``), so a
         LinAlg traceback rooted in ``fit`` actually originates in this method.
         """
-        self.W = mx.linalg.inv(self.A, stream=_CPU)
-        self._logdet_W = mx.linalg.slogdet(self.W, stream=_CPU)[1]
+        ws, logdets = [], []
+        for h in range(self.n_models):
+            wh = mx.linalg.inv(self.A[:, self.comp_list[:, h]], stream=_CPU)
+            ws.append(wh)
+            logdets.append(mx.linalg.slogdet(wh, stream=_CPU)[1])
+        self.W = mx.stack(ws, axis=0)  # (n_models, n, n)
+        self._logdet_W = mx.stack(logdets)  # (n_models,)
 
     # ------------------------------------------------------------------
     # E-step
     # ------------------------------------------------------------------
     def _forward(self, Xb: mx.array):
-        """E-step forward pass for one block (single model). ``Xb`` is
-        ``(n_channels, batch)``. Returns ``(logV, b, z, y, az_rho)``."""
-        b = Xb.T @ self.W  # (batch, n_channels); c == 0 for single model
-        mu_h = self.mu.T[None]  # (1, n_channels, n_mix)
-        beta_h = self.beta.T[None]
-        rho_h = self.rho.T[None]
-        alpha_h = self.alpha.T[None]
-        lgamma_h = self._lgamma_table.T[None]
+        """E-step forward pass for one block, per model (AMICATorchNG._forward,
+        core.py:762-825). ``Xb`` is ``(n_channels, batch)``. Returns ``logV``
+        ``(batch, n_models)`` and per-model lists ``(b, z, y, az_rho)``. For
+        n_models=1 (c=0, gm=1, comp_list=identity) this is numerically identical
+        to the single-model path."""
+        b_list, z_list, y_list, azrho_list, logv_cols = [], [], [], [], []
+        for h in range(self.n_models):
+            idx = self.comp_list[:, h]
+            b = (Xb - self.c[:, h][:, None]).T @ self.W[h]  # (batch, n_channels)
+            mu_h = self.mu[:, idx].T[None]  # (1, n_channels, n_mix)
+            beta_h = self.beta[:, idx].T[None]
+            rho_h = self.rho[:, idx].T[None]
+            alpha_h = self.alpha[:, idx].T[None]
+            lgamma_h = self._lgamma_table[:, idx].T[None]
 
-        y = beta_h * (b[..., None] - mu_h)  # (batch, n_channels, n_mix)
-        log_pdf, az_rho = _log_pdf_gg(y, rho_h, lgamma_h)
-        z0 = mx.log(alpha_h) + mx.log(beta_h) + log_pdf
-        ll_i = mx.logsumexp(z0, axis=-1)  # (batch, n_channels)
-        z = mx.softmax(z0, axis=-1)
-        # Single model: log(gm)=0; logdet_W + sldet are the Jacobian terms.
-        logV = self._logdet_W + self.sldet + ll_i.sum(axis=-1)  # (batch,)
-        return logV, b, z, y, az_rho
+            y = beta_h * (b[..., None] - mu_h)  # (batch, n_channels, n_mix)
+            log_pdf, az_rho = _log_pdf_gg(y, rho_h, lgamma_h)
+            z0 = mx.log(alpha_h) + mx.log(beta_h) + log_pdf
+            ll_i = mx.logsumexp(z0, axis=-1)  # (batch, n_channels)
+            z = mx.softmax(z0, axis=-1)
+            logv_cols.append(
+                mx.log(self.gm[h]) + self._logdet_W[h] + self.sldet + ll_i.sum(axis=-1)
+            )
+            b_list.append(b)
+            z_list.append(z)
+            y_list.append(y)
+            azrho_list.append(az_rho)
+        logV = mx.stack(logv_cols, axis=1)  # (batch, n_models)
+        return logV, b_list, z_list, y_list, azrho_list
 
     def _get_block_updates(self, Xb: mx.array) -> dict:
-        """Exact-EM sufficient statistics for one block (single-model,
-        non-Newton subset of AMICATorchNG._get_block_updates, core.py:891-944;
-        the bias-c accumulator is excluded -- single-model has no c update)."""
-        logV, b, z, y, az_rho = self._forward(Xb)
-        block_ll = logV.sum()  # single model: logsumexp over one model is identity
-        beta_h = self.beta.T[None]  # (1, n_channels, n_mix)
-        rho_h = self.rho.T[None]
-
-        fp = _score_gg(y, rho_h)
-        u = z  # u = v*z with v == 1 (single model)
-        ufp = u * fp
-
-        dgm = mx.array(float(Xb.shape[1]), dtype=mx.float32)  # sum_t v_h = n samples
-        dalpha_n = u.sum(0).T  # (n_mix, n_channels)
-        dmu_n = ufp.sum(0).T
-        # Phase A guard: float32 can round y to exactly 0 (fp(0)=0 => ufp=0), so
-        # ufp/y is 0/0=NaN; where y==0, 0/1 contributes 0 (issue #75).
-        safe_y = mx.where(y == 0, mx.ones_like(y), y)
-        dmu_d = (beta_h[0] * (ufp / safe_y).sum(0)).T
-        dbeta_n = u.sum(0).T
-        dbeta_d = (ufp * y).sum(0).T
-
-        ay = mx.abs(y)
+        """Exact-EM sufficient statistics for one block (non-Newton subset of
+        AMICATorchNG._get_block_updates, core.py:833-953). Mixture stats are
+        scattered into their ``comp_list`` columns; ``dWtmp``/``dgm``/``dc_numer``
+        are per-model. For n_models=1 (v==1, identity comp_list) this reproduces
+        the single-model accumulators exactly."""
+        logV, b_list, z_list, y_list, azrho_list = self._forward(Xb)
+        block_ll = mx.logsumexp(logV, axis=1).sum()
+        v = mx.softmax(logV, axis=1)  # (batch, n_models) model responsibilities
+        nmix, ncomp = self.n_mix, self.n_comps
         tiny = float(np.finfo(np.float32).tiny)
-        logab = rho_h * mx.log(mx.maximum(ay, tiny))
-        logab = mx.where(az_rho < _EPSDBLE, mx.zeros_like(logab), logab)
-        drho_n = (u * (az_rho * logab)).sum(0).T
 
-        g = (beta_h * ufp).sum(-1)  # (batch, n_channels)
-        dWtmp = g.T @ b  # (n_channels, n_channels)
+        def zeros():
+            return mx.zeros((nmix, ncomp), dtype=mx.float32)
+
+        dalpha_n, dmu_n, dmu_d = zeros(), zeros(), zeros()
+        dbeta_n, dbeta_d, drho_n = zeros(), zeros(), zeros()
+        dgm_cols, dwtmp_mods, dc_cols = [], [], []
+
+        for h in range(self.n_models):
+            idx = self.comp_list[:, h]
+            b, zr, y, az_rho = b_list[h], z_list[h], y_list[h], azrho_list[h]
+            v_h = v[:, h]
+            beta_h = self.beta[:, idx].T[None]  # (1, n_channels, n_mix)
+            rho_h = self.rho[:, idx].T[None]
+
+            fp = _score_gg(y, rho_h)
+            u = v_h[:, None, None] * zr  # u = v*z, (batch, n_channels, n_mix)
+            ufp = u * fp
+
+            dgm_cols.append(v_h.sum())
+            dalpha_n = dalpha_n.at[:, idx].add(u.sum(0).T)
+            dmu_n = dmu_n.at[:, idx].add(ufp.sum(0).T)
+            # Phase A guard: float32 can round y to exactly 0 (fp(0)=0 => ufp=0),
+            # so ufp/y is 0/0=NaN; where y==0, 0/1 contributes 0 (issue #75).
+            safe_y = mx.where(y == 0, mx.ones_like(y), y)
+            dmu_d = dmu_d.at[:, idx].add((beta_h[0] * (ufp / safe_y).sum(0)).T)
+            dbeta_n = dbeta_n.at[:, idx].add(u.sum(0).T)
+            dbeta_d = dbeta_d.at[:, idx].add((ufp * y).sum(0).T)
+
+            logab = rho_h * mx.log(mx.maximum(mx.abs(y), tiny))
+            logab = mx.where(az_rho < _EPSDBLE, mx.zeros_like(logab), logab)
+            drho_n = drho_n.at[:, idx].add((u * (az_rho * logab)).sum(0).T)
+
+            g = (beta_h * ufp).sum(-1)  # (batch, n_channels)
+            dwtmp_mods.append(g.T @ b)  # (n_channels, n_channels)
+            dc_cols.append(Xb @ v_h)  # data-space bias numerator sum_t v_h*x
 
         return {
-            "dgm": dgm,
+            "dgm": mx.stack(dgm_cols),  # (n_models,)
             "dalpha_n": dalpha_n,
             "dmu_n": dmu_n,
             "dmu_d": dmu_d,
             "dbeta_n": dbeta_n,
             "dbeta_d": dbeta_d,
             "drho_n": drho_n,
-            "dWtmp": dWtmp,
+            "dWtmp": mx.stack(dwtmp_mods, axis=0),  # (n_models, n_ch, n_ch)
+            "dc_numer": mx.stack(dc_cols, axis=1),  # (n_channels, n_models)
             "ll": block_ll,
         }
 
@@ -352,9 +393,21 @@ class AMICAMLXNG:
     # M-step
     # ------------------------------------------------------------------
     def _update_parameters(self, acc: dict, n_samples: int):
-        """Exact-EM mixture updates + natural-gradient A-update (single-model,
-        non-Newton subset of AMICATorchNG._update_parameters, core.py:1049-1247)."""
-        self.gm = acc["dgm"] / n_samples  # == 1 for single model
+        """Exact-EM mixture updates + natural-gradient A-update (non-Newton subset
+        of AMICATorchNG._update_parameters, core.py:1049-1247)."""
+        self.gm = acc["dgm"] / n_samples  # (n_models,); == 1 for single model
+        tiny = float(np.finfo(np.float32).tiny)
+
+        # Per-model data-space bias c[i,h] = sum_t v_h*x / sum_t v_h (Fortran
+        # update_c, core.py:1063-1073). Skipped for n_models=1 (v==1 => c is the
+        # zero data mean; the update would add a float-sum residual and break the
+        # #24 bit-exact single-model path). A dead model (dgm[h]==0) keeps its
+        # prior c rather than writing 0/0.
+        if self.n_models > 1:
+            dgm = acc["dgm"]
+            live = (dgm > 0.0)[None, :]
+            new_c = acc["dc_numer"] / mx.maximum(dgm, tiny)[None, :]
+            self.c = mx.where(live, new_c, self.c)
 
         self.alpha = acc["dalpha_n"] / acc["dalpha_n"].sum(axis=0, keepdims=True)
         self.mu = self.mu + acc["dmu_n"] / acc["dmu_d"]
@@ -386,13 +439,25 @@ class AMICAMLXNG:
 
         # Natural-gradient A-update. A is stored as Fortran's A^T, so the update
         # is a LEFT-multiply by the transposed direction (core.py:1176-1184,
-        # #24 root cause). Single-model collapses the gm-weighted column average.
+        # #24 root cause). Each model's direction is scattered into its mixing
+        # columns as a gm-weighted average (Fortran dAk/zeta, core.py:1220-1227):
+        # for the default disjoint comp_list every column has one contributor, so
+        # gm cancels and n_models=1 is byte-for-byte the old `A - lrate*(dA.T@A)`.
         eye = mx.eye(self.n_channels)
-        dA = -acc["dWtmp"] / acc["dgm"] + eye  # I - <g b^T>/dgm
+        directions = [
+            -acc["dWtmp"][h] / acc["dgm"][h] + eye for h in range(self.n_models)
+        ]
         self.lrate = min(
             self.lrate_cap, self.lrate + min(1.0 / self.newt_ramp, self.lrate)
         )
-        self.A = self.A - self.lrate * (dA.T @ self.A)
+        dAk = mx.zeros_like(self.A)
+        zeta = mx.zeros((self.n_comps,), dtype=mx.float32)
+        for h in range(self.n_models):
+            idx = self.comp_list[:, h]
+            dAk = dAk.at[:, idx].add(self.gm[h] * (directions[h].T @ self.A[:, idx]))
+            zeta = zeta.at[idx].add(self.gm[h] + mx.zeros((self.n_channels,)))
+        dAk = dAk / mx.maximum(zeta, tiny)
+        self.A = self.A - self.lrate * dAk
 
         if self.doscaling and (self.iteration % self.scalestep == 0):
             scale = mx.sqrt((self.A**2).sum(axis=0))  # (n_comps,)

--- a/pyAMICA/tests/mlx_tests/test_mlx_backend.py
+++ b/pyAMICA/tests/mlx_tests/test_mlx_backend.py
@@ -119,6 +119,9 @@ def test_backend_stable_on_full_data():
     assert np.all(np.isfinite(np.array(m.A)))
     assert m.stop_reason not in AMICAMLXNG._DEGENERATE_STOP_REASONS
     assert hist[-1] > hist[0]  # ascent
+    # Single-model must never touch the bias c (the n_models>1-only update); a
+    # nonzero c would signal the #24 bit-exact single-model path was perturbed.
+    assert np.all(np.array(m.c) == 0.0)
 
 
 def test_converged_ll_matches_torch_float32():
@@ -183,12 +186,36 @@ def test_multimodel_matches_torch_float32():
     xt2 = ng._preprocess(data)
     ng._initialize_parameters()
     na = ng._accumulate_blocks(xt2)
-    for key in ("dgm", "dmu_n", "dbeta_d", "dc_numer"):
+    # Every accumulator, including dWtmp (input to the gm-weighted comp_list A
+    # scatter) and the scattered mixture stats. rtol=5e-3 (looser than the 1e-3
+    # single-model-vs-numpy check) because this compares two float32 backends on
+    # different devices, whose reduction orders diverge more than float32-vs-f64.
+    for key in (
+        "dgm",
+        "dalpha_n",
+        "dmu_n",
+        "dmu_d",
+        "dbeta_d",
+        "drho_n",
+        "dc_numer",
+        "dWtmp",
+    ):
         a = np.asarray(np.array(ma[key]), dtype=np.float64)
-        b = na[key].cpu().numpy().astype(np.float64).reshape(a.shape)
-        assert np.allclose(a, b, rtol=5e-3, atol=1e-4), (
-            f"{key}: {np.abs(a - b).max():.2e}"
+        b = na[key].cpu().numpy().astype(np.float64)
+        if key == "dWtmp":  # torch (n, n, n_models) -> MLX (n_models, n, n)
+            b = np.transpose(b, (2, 0, 1))
+        assert np.allclose(a, b.reshape(a.shape), rtol=5e-3, atol=1e-4), (
+            f"{key}: {np.abs(a - b.reshape(a.shape)).max():.2e}"
         )
+
+    # The per-model bias c update (the n_models>1-only formula) is the
+    # responsibility-weighted data mean c[:,h] = sum_t v_h*x / sum_t v_h, and the
+    # two models' c must differ (a would-be no-op would leave them equal at 0).
+    mlx_m._update_parameters(ma, xt.shape[1])
+    c = np.array(mlx_m.c)
+    dc = np.array(ma["dc_numer"]) / np.array(ma["dgm"])[None, :]
+    assert np.allclose(c, dc, rtol=1e-5, atol=1e-6)
+    assert not np.allclose(c[:, 0], c[:, 1])
 
     # Converged LL (multi-model is not partition-identifiable, but at matched
     # init/settings both backends track the same trajectory).

--- a/pyAMICA/tests/mlx_tests/test_mlx_backend.py
+++ b/pyAMICA/tests/mlx_tests/test_mlx_backend.py
@@ -51,11 +51,12 @@ def _load_real_data() -> np.ndarray:
     )
 
 
-def test_mvp_rejects_unsupported_config():
-    """The v1 MVP boundaries fail loudly, not silently."""
+def test_rejects_unsupported_config():
+    """The still-deferred configs (Newton, non-GG families) fail loudly, not
+    silently. Multi-model IS supported (issue #81), so it is not rejected."""
     from pyAMICA.mlx_impl import AMICAMLXNG
 
-    for kw in ({"n_models": 2}, {"do_newton": True}, {"pdftype": 2, "n_mix": NMIX}):
+    for kw in ({"do_newton": True}, {"pdftype": 2, "n_mix": NMIX}):
         with pytest.raises(NotImplementedError):
             AMICAMLXNG(n_channels=NW, n_mix=kw.pop("n_mix", 1), **kw)
 
@@ -85,7 +86,8 @@ def test_sufficient_stats_match_numpy_reference():
     npm.block_size = blk
     npm.comp_list = np.arange(NW).reshape(NW, 1)
     npm.A = np.array(m.A, dtype=np.float64)
-    npm.W = np.array(m.W, dtype=np.float64)[:, :, None]  # NumPy expects (n,n,models)
+    # MLX W is (n_models, n, n); NumPy expects (n, n, n_models).
+    npm.W = np.array(m.W, dtype=np.float64).transpose(1, 2, 0)
     npm.c = np.zeros((NW, 1))
     npm.mu = np.array(m.mu, dtype=np.float64)
     npm.alpha = np.array(m.alpha, dtype=np.float64)
@@ -147,3 +149,62 @@ def test_converged_ll_matches_torch_float32():
 
     assert np.isfinite(mlx_m.final_ll_)
     assert abs(mlx_m.final_ll_ - torch_m.final_ll_) < 1e-2
+
+
+def test_multimodel_matches_torch_float32():
+    """Multi-model (n_models=2) MLX matches the PyTorch float32 backend (issue
+    #81): the one-iteration sufficient stats agree to float32 precision, and the
+    converged LL matches (measured gap ~1e-5). Single-model stays byte-identical
+    (covered by the tests above)."""
+    import torch
+
+    from pyAMICA.mlx_impl import AMICAMLXNG
+    from pyAMICA.torch_impl import AMICATorchNG
+
+    data = _load_real_data()
+    m = 2
+
+    # One iteration of sufficient stats from identical (shared-seed) init.
+    mlx_m = AMICAMLXNG(n_channels=NW, n_models=m, n_mix=NMIX, seed=SEED, block_size=512)
+    xt = mlx_m._preprocess(data)
+    mlx_m._initialize_parameters()
+    ma = mlx_m._accumulate_blocks(xt)
+
+    ng = AMICATorchNG(
+        n_channels=NW,
+        n_models=m,
+        n_mix=NMIX,
+        seed=SEED,
+        device="cpu",
+        dtype=torch.float32,
+        do_newton=False,
+        block_size=512,
+    )
+    xt2 = ng._preprocess(data)
+    ng._initialize_parameters()
+    na = ng._accumulate_blocks(xt2)
+    for key in ("dgm", "dmu_n", "dbeta_d", "dc_numer"):
+        a = np.asarray(np.array(ma[key]), dtype=np.float64)
+        b = na[key].cpu().numpy().astype(np.float64).reshape(a.shape)
+        assert np.allclose(a, b, rtol=5e-3, atol=1e-4), (
+            f"{key}: {np.abs(a - b).max():.2e}"
+        )
+
+    # Converged LL (multi-model is not partition-identifiable, but at matched
+    # init/settings both backends track the same trajectory).
+    mlx_c = AMICAMLXNG(n_channels=NW, n_models=m, n_mix=NMIX, seed=SEED)
+    mlx_c.fit(data, max_iter=60, verbose=False)
+    ng_c = AMICATorchNG(
+        n_channels=NW,
+        n_models=m,
+        n_mix=NMIX,
+        seed=SEED,
+        device="cpu",
+        dtype=torch.float32,
+        do_newton=False,
+        keep_best=False,
+    )
+    ng_c.fit(data, max_iter=60, verbose=False)
+    assert np.isfinite(mlx_c.final_ll_)
+    assert mlx_c.stop_reason not in AMICAMLXNG._DEGENERATE_STOP_REASONS
+    assert abs(mlx_c.final_ll_ - ng_c.final_ll_) < 1e-2


### PR DESCRIPTION
## Summary
Epic #74 Phase D (final phase): extend the MLX Apple-GPU backend (`AMICAMLXNG`) to **`n_models > 1`**. The Phase B benchmark showed multi-model had no GPU path (MLX was single-model, MPS loses); this closes that gap so the ~7x single-model MLX win extends to multi-model AMICA.

Ports the multi-model machinery from `AMICATorchNG`:
- `comp_list` indirection (params go `(n_mix, n_channels)` -> `(n_mix, n_comps)`), per-model `W = inv(A[:, comp_list[:,h]])` + `slogdet` on the CPU stream (hoisted per iteration).
- E-step per-model loop -> `logV (batch, n_models)`, cross-model responsibilities `v = softmax(logV)`, `u = v_h * z`.
- M-step: `gm`, the per-model exact-EM bias `c` update, and the **gm-weighted A-update scattered through `comp_list`**.

**Single-model (#76) stays byte-for-byte unchanged** (the loop runs once, `gm=1`, identity `comp_list` -> the A-update collapses to the old `A - lrate*(dA.T@A)`). Component sharing remains a fast-follow.

## Validation (real sample EEG; Apple GPU)
- **Multi-model (n_models=2) matches PyTorch float32**: one-iteration sufficient stats agree to float32 precision (dWtmp 2.7e-3, dmu_d 6.2e-4, rest <=1e-4); converged LL gap **~1e-5** (MLX -3.38967 vs torch -3.38966). New `test_multimodel_matches_torch_float32`.
- Single-model byte-identity + torch-float32 tests still pass (5/5 mlx tests green).

## Benchmark
MLX now runs in the multi-model configs (dropped the single-model gate). **MLX wins multi-model too:** ~38 ms/it (32ch) / 45 ms/it (70ch) -- ~5x over torch-CPU, MPS still loses. Findings updated (`.context/issue-77/benchmark_findings.md`).

## Scope note
The comprehensive native-Fortran + CPU-core-scaling (4/6/8/12) + CUDA cross-platform benchmark is intentionally **NOT** in this PR -- it is being split into its own epic (native x86 Linux + CUDA host, since Apple's Fortran binary is x86-under-Rosetta and Mac CPU timing is unreliable).

## Test plan
`uv run pytest pyAMICA/tests/mlx_tests/` (Apple Silicon; self-skips in CI). Full torch suite unaffected (mlx_impl is isolated + optional). ruff clean; `mlx_impl` omitted from the coverage gate (Apple-only).

Closes #81
Part of epic #74