### PR TITLE
Epic: Apple-Silicon GPU acceleration for AMICATorchNG

### DIFF
--- a/.context/issue-63/perf_findings.md
+++ b/.context/issue-63/perf_findings.md
@@ -59,31 +59,32 @@ print precision; float64 device-to-device reductions can still differ at
 present. (Measurement caveat: a cold first
 CUDA call reads ~131 ms/it -- always warm up before timing GPU.)
 
-## 4. float32 is precision-limited, NOT a free fast path (#70)
+## 4. float32 stabilized by a divide-by-zero guard (#75 -- supersedes #70)
 
-float32 would be ~5x (CPU) to ~10-19x (CUDA) faster, but it **diverges to NaN on
-the full 30504-sample data across every seed, with Newton on AND off** (crashing
-anywhere from iter 9 to 81). It reliably converges only on small slices (4096
-samples: -3.234, matching float64).
+**RESOLVED (issue #75).** float32 (~5x CPU / ~10-19x CUDA faster) previously
+**diverged to NaN on the full 30504-sample data across every seed, Newton on AND
+off** (crashing iter ~9-105), converging only on small slices. Epic #74 Phase A
+fixed it with a **one-line guard** (`_get_block_updates`); float32 now converges
+across seeds and matches the float64 LL to ~5 significant digits.
 
-**Root cause (investigated in #70):** it is NOT a divide-by-zero -- the M-step
-denominators (`dmu_d`/`dbeta_d`/`dalpha_n`) are healthy (O(1e3)) right up to the
-crash, then `dmu_d` becomes NaN because a *parameter has already diverged* the
-prior iteration and the next E-step overflows. It is precision-driven instability
-of the natural-gradient EM at ~7 significant digits, not a single guardable op.
+**Actual root cause -- it IS a divide-by-zero, per-element (#70 looked at the
+wrong granularity).** The mu denominator is `sbeta*sum(ufp/y)` (`ufp=u*fp`). At a
+sample sitting on a mixture mean, float32 rounds `y` to *exactly* 0, and the
+score `fp(0)=0` for every family, so that sample's `ufp/y` is `0/0 = NaN` -- and
+one NaN summand poisons the whole `dmu_d`. #70 watched the *summed* denominators
+(`dmu_d`/`dbeta_d`/`dalpha_n`), which read healthy O(1e3) right up to the crash,
+and so concluded "not a divide-by-zero" -- but the 0/0 is in the per-sample term
+*before* the sum. float64 never rounds `y` to exactly 0, hence float64-only.
 
-**Cheap targeted fix tried and REJECTED:** computing the responsibility
-`logsumexp`/`softmax` in float64 (keeping density + matmuls float32) did **not**
-stabilize it (still NaN, all seeds) -- so the instability is in the density
-and/or the 30504-sample sufficient-stat accumulation, not the responsibilities.
-
-**A real fix needs mixed precision** (float64 for the density `|y|^rho`, the LL,
-and the stat accumulation; float32 for the matmuls). But those sensitive parts
-are also runtime-dominant (~50%+, section 1), so the net speedup would shrink
-toward ~1.5-2x, not 10x -- low payoff for a moderate refactor. **Recommendation:
-use float64 (float64-CUDA is 4.5x and bit-safe) for production; float32 is
-experimental / small-data only.** Mixed precision remains open in #70 if the
-payoff is later judged worth it.
+**Why summation precision was NOT the sink (diagnostics, #75):** accumulating the
+float32 block partials in float64 (and Neumaier compensated summation) did **not**
+help -- both still diverged, at the same iterations. And computing the density
+`|y|^rho`/`log_pdf` in float64 did **not** help either (nor, per #70, the
+responsibility `logsumexp`/`softmax`). Only guarding the `ufp/y` division does.
+So the earlier "needs mixed precision (float64 density + accumulation), payoff
+shrinks to ~1.5-2x" conclusion is **superseded**: the fix needs no float64 at all,
+which is exactly why it also works on MPS (no FP64 on Apple GPUs). float32 stays
+non-parity with float64 (~7 sig digits); use float64 for Fortran-parity runs.
 
 ## 5. CPU threading is workload-limited
 
@@ -101,5 +102,10 @@ channel counts.
 - **Landed (float64, safe):** pow-dedup (-35%) + block_size 512 (-18%) compound
   to ~-47% CPU; CUDA float64 is a further ~4.5x (warmed, vs 16-thread CPU),
   auto-selected and numerically identical.
-- **Documented / follow-up:** float32 stabilization (5-19x potential, currently
-  seed-flaky NaN on full data, #70); MPS performance with newer drivers.
+- **Landed (float32):** the `ufp/y` divide-by-zero guard (#75) makes full-data
+  float32 converge across seeds (~5x CPU / ~10-19x CUDA potential; ~7 sig digits,
+  not float64-parity). Unblocks the Apple-GPU roadmap (epic #74): the fix needs no
+  float64, so it holds on MPS.
+- **Follow-up:** MPS dimension-sweep benchmark to find the CPU/GPU crossover
+  (epic #74 Phase B); float64-accumulation mixed precision remains an unneeded
+  CPU/CUDA-only option.

--- a/.context/issue-77/benchmark_findings.md
+++ b/.context/issue-77/benchmark_findings.md
@@ -31,14 +31,22 @@ strong NVIDIA GPU", not a same-box comparison.
 | 48 | -3.20951 | -3.20952 | -3.20953 | -3.20951 | -3.21019 |
 | 70 | -3.21579 | -3.21562 | -3.21560 | -3.21570 | -3.21315 |
 
-## Multi-model -- ms/it and LL (Mac; MLX excluded = single-model MVP; CUDA pending)
+## Multi-model (n_models=2) -- ms/it (Mac; CUDA pending)
 
-m2 (no share), 70ch: torch-cpu-f32 **224** / cpu-f64 253 / mps-f32 270 / numpy 928 ms.
-m2+share, 70ch: cpu-f32 **224** / cpu-f64 253 / mps-f32 262 / numpy 934 ms.
-Sharing activates in torch (70ch LL -2.943 -> -3.049); numpy's sharing diverges
-(-2.919 -> -2.917) -- multi-model is not partition-identifiable and has no
-bit-exact oracle (#27/#60), so cross-backend LL differs by intrinsic estimator
-spread, not a defect.
+MLX now supports multi-model (issue #81), so it is measured here too:
+
+| channels | **mlx-f32** | torch-cpu-f32 | torch-mps-f32 | numpy-cpu-f64 |
+|---:|---:|---:|---:|---:|
+| 32 | **38** | 187 | 291 | 869 |
+| 70 | **45** | 224 | 270 | 928 |
+
+**The Apple-GPU win extends to multi-model: MLX ~38-45 ms/it, ~5x over torch-CPU**
+(and MPS still loses). Converged LL matches torch-float32 (32ch -3.0883 both; the
+one-iteration sufficient stats agree to float32 precision, `tests/mlx_tests`).
+Component sharing stays a fast-follow for MLX; in torch, sharing activates (70ch
+LL -2.943 -> -3.049) while numpy's sharing diverges -- multi-model is not
+partition-identifiable and has no bit-exact oracle (#27/#60), so cross-backend LL
+differs by intrinsic estimator spread, not a defect.
 
 ## Findings
 
@@ -60,19 +68,20 @@ spread, not a defect.
    implementation, not a production path. (numpy is benchmarked with the same
    fixed block_size=512 and `do_opt_block=False`; leaving its default on ran an
    in-fit block-size auto-tune that ~doubled its time -- fixed in the harness.)
-6. **Multi-model has no GPU acceleration today**: MLX (the only Apple-GPU win) is
-   single-model-only (v1 MVP), and MPS loses. **Extending `AMICAMLXNG` to
-   multi-model is the highest-value fast-follow** -- it would carry the ~7x MLX
-   win to multi-model AMICA.
+6. **Multi-model MLX now carries the win (issue #81)**: ~38-45 ms/it, ~5x over
+   torch-CPU (MPS still loses), LL matching torch-float32. The remaining MLX
+   fast-follow is component sharing; a 128-256 ch / many-model sweep would find
+   the eventual MLX/CUDA crossover.
 
 ## Recommendation
 
-- **Apple Silicon: use the MLX backend** for single-model AMICA (~7x over CPU);
-  avoid `device="mps"` (no gain). **NVIDIA: float64-CUDA** stays the bit-safe
-  production GPU path.
-- **Fast-follow: multi-model MLX** (issue TBD) to extend the win beyond
-  single-model; and a high-dimensional (128-256 ch, many-model) sweep to find the
-  MLX/CUDA crossover.
+- **Apple Silicon: use the MLX backend** for single- and multi-model AMICA (~5-7x
+  over CPU); avoid `device="mps"` (no gain). **NVIDIA: float64-CUDA** stays the
+  bit-safe production GPU path.
+- **Fast-follows:** MLX component sharing; a high-dimensional (128-256 ch,
+  many-model) sweep to find the MLX/CUDA crossover; and a native-Fortran /
+  CPU-core-scaling cross-platform benchmark (its own effort, on a native-x86
+  Linux + CUDA host, since Apple's Fortran binary is x86-under-Rosetta).
 
 ## Caveats / pending
 

--- a/.context/issue-77/benchmark_findings.md
+++ b/.context/issue-77/benchmark_findings.md
@@ -1,0 +1,84 @@
+# Phase B: cross-platform result + performance benchmark (issue #77)
+
+The epic (#74) deferred one question through Phases A and C: **does an Apple/NVIDIA
+GPU actually beat the CPU for AMICA, and where?** Phase B answers it, on **real
+70-channel EEG** (OpenNeuro ds002718 sub-002, Wakeman-Henson faces), comparing
+every backend on **both** performance (ms/iteration, warmed, min-of-repeats) and
+results (converged log-likelihood). Harness: `benchmarks/benchmark_dimsweep.py`;
+data prep in `benchmarks/README_dimsweep.md`. Matched settings: n_mix=3,
+pdftype=0, do_newton=False, block_size=512, seed=42, samples=30000 (single-model)
+/ 20000 (multi-model), 25 / 20 iters.
+
+Hosts: **Apple Silicon** (this Mac: cpu / mps / mlx) and **hallu** (RTX 4090:
+cuda; its CPU was load-contended so CPU backends were run on the Mac). MLX and
+CUDA are on *different machines*, so MLX-vs-CUDA is "best Apple-GPU path vs a
+strong NVIDIA GPU", not a same-box comparison.
+
+## Single-model (m1) -- performance, ms / iteration
+
+| channels | mlx-f32 | cuda-f32 | cuda-f64 | torch-cpu-f32 | torch-cpu-f64 | torch-mps-f32 | numpy-cpu-f64 |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 16 | **15.4** | 35.5 | 35.0 | 52 | 71 | 189 | 142 |
+| 32 | **21.3** | 35.5 | 36.2 | 143 | 161 | 162 | 287 |
+| 48 | **19.5** | 36.0 | 35.9 | 151 | 168 | 168 | 426 |
+| 70 | **25.2** | 35.6 | 38.6 | 173 | 193 | 255 | 622 |
+
+## Single-model (m1) -- results, converged LL (all agree to ~3 digits)
+
+| channels | mlx-f32 | cuda-f64 | torch-cpu-f64 | torch-mps-f32 | numpy-cpu-f64 |
+|---:|---:|---:|---:|---:|---:|
+| 32 | -3.28634 | -3.28635 | -3.28636 | -3.28635 | -3.28620 |
+| 48 | -3.20951 | -3.20952 | -3.20953 | -3.20951 | -3.21019 |
+| 70 | -3.21579 | -3.21562 | -3.21560 | -3.21570 | -3.21315 |
+
+## Multi-model -- ms/it and LL (Mac; MLX excluded = single-model MVP; CUDA pending)
+
+m2 (no share), 70ch: torch-cpu-f32 **224** / cpu-f64 253 / mps-f32 270 / numpy 928 ms.
+m2+share, 70ch: cpu-f32 **224** / cpu-f64 253 / mps-f32 262 / numpy 934 ms.
+Sharing activates in torch (70ch LL -2.943 -> -3.049); numpy's sharing diverges
+(-2.919 -> -2.917) -- multi-model is not partition-identifiable and has no
+bit-exact oracle (#27/#60), so cross-backend LL differs by intrinsic estimator
+spread, not a defect.
+
+## Findings
+
+1. **MLX is the decisive Apple-GPU win: ~15-25 ms/it, flat with channel count --
+   ~7x faster than torch-CPU, and faster than the RTX 4090 (CUDA ~36 ms) at
+   EEG scale.** (MLX's fused lazy graph + unified memory beat both PyTorch's
+   dispatch overhead and CUDA's kernel-launch overhead when the per-op tensors
+   are small, as 70ch/30k are. On a much larger workload CUDA would likely
+   overtake MLX -- worth a future high-dimensional check.)
+2. **PyTorch-MPS is NOT a win: 162-255 ms/it, at or WORSE than the CPU** (255 vs
+   193 at 70ch), single- AND multi-model. So the Apple-GPU acceleration comes
+   from **MLX, not `device="mps"`** -- an actionable steer for users.
+3. **CUDA (RTX 4090) is a flat ~35-39 ms/it**, second only to MLX here, and (as in
+   #63) f32 ~= f64 at this size (launch-bound, not compute-bound).
+4. **Results agree across every platform / device / precision**: single-model LL
+   matches to ~3 digits (mlx = cuda = cpu = mps ~ -3.216 at 70ch; numpy within
+   ~0.004). This validates the whole backend family end-to-end on real data.
+5. **numpy is ~10-25x slower than MLX** (142-622 ms/it vs 15-25) -- the reference
+   implementation, not a production path. (numpy is benchmarked with the same
+   fixed block_size=512 and `do_opt_block=False`; leaving its default on ran an
+   in-fit block-size auto-tune that ~doubled its time -- fixed in the harness.)
+6. **Multi-model has no GPU acceleration today**: MLX (the only Apple-GPU win) is
+   single-model-only (v1 MVP), and MPS loses. **Extending `AMICAMLXNG` to
+   multi-model is the highest-value fast-follow** -- it would carry the ~7x MLX
+   win to multi-model AMICA.
+
+## Recommendation
+
+- **Apple Silicon: use the MLX backend** for single-model AMICA (~7x over CPU);
+  avoid `device="mps"` (no gain). **NVIDIA: float64-CUDA** stays the bit-safe
+  production GPU path.
+- **Fast-follow: multi-model MLX** (issue TBD) to extend the win beyond
+  single-model; and a high-dimensional (128-256 ch, many-model) sweep to find the
+  MLX/CUDA crossover.
+
+## Caveats / pending
+
+- MLX vs CUDA is cross-machine (Apple M-series vs RTX 4090 host), not a controlled
+  same-box comparison; read it as "best available Apple-GPU vs a strong NVIDIA
+  GPU", not silicon-vs-silicon.
+- **Multi-model CUDA is pending** (the hallu SSH session dropped mid-run); the
+  single-model CUDA data is complete. Re-run `--n-models 2 [--share] --backends
+  torch-cuda-f64,torch-cuda-f32` on the CUDA host to fill it in.

--- a/.context/mps_pathways.md
+++ b/.context/mps_pathways.md
@@ -48,21 +48,28 @@ shrinks to ~1.5-2x" framing is retired. The float64-accumulation mixed-precision
 mode is an *unneeded* CPU/CUDA-only option, not the Apple-GPU door. float32 stays
 ~7-significant-digit, not float64-parity (use float64 for Fortran-parity runs).
 
-## Pathway B: exploit the large-workload regime (measure the crossover)
+## Pathway B: measure the crossover -- DONE (#77)
 
-MPS's problem on our data is **dispatch overhead**, not raw throughput: for small
-tensors, per-operator Metal kernel launches (limited fusion, generic kernels)
-dominate, and CPU with Accelerate/oneDNN wins ([elanapearl blog](https://elanapearl.github.io/blog/2025/the-bug-that-taught-me-pytorch/),
-[runebook MPS](https://runebook.dev/en/docs/pytorch/mps)). Our 32-channel /
-512-block ops are firmly in the small regime (MPS 0.51x).
+MPS's problem is **dispatch overhead**, not raw throughput: for small tensors,
+per-operator Metal kernel launches (limited fusion, generic kernels) dominate and
+CPU with Accelerate/oneDNN wins ([elanapearl blog](https://elanapearl.github.io/blog/2025/the-bug-that-taught-me-pytorch/),
+[runebook MPS](https://runebook.dev/en/docs/pytorch/mps)). The hypothesis was that
+this amortizes on larger tensors (128-256 ch), so MPS might overtake CPU there.
 
-That overhead is **fixed per op**, so it amortizes as tensors grow. High-channel
-montages (128-256 ch), many-model runs, and larger blocks produce much bigger
-per-op tensors where MPS can plausibly overtake CPU. **Actionable:** now that
-float32 is stable (Pathway A, #75), benchmark MPS-float32 vs CPU across channel
-count / block size / n_models to find the crossover, rather than concluding from
-32 channels.
-`benchmarks/benchmark_gpu.py` already sweeps devices; add a dimension sweep.
+**Measured (#77, `benchmarks/benchmark_dimsweep.py`, real 70-channel EEG,
+`.context/issue-77/benchmark_findings.md`):** the answer is more decisive than
+"MPS eventually wins" -- it splits by *framework*, not just workload size:
+- **MLX is the Apple-GPU win: ~15-25 ms/it, flat across 16-70 channels, ~7x over
+  torch-CPU, and faster than an RTX 4090 (CUDA ~36 ms) at EEG scale.** MLX's fused
+  lazy graph + unified memory beat both PyTorch's dispatch overhead and CUDA's
+  kernel-launch overhead when per-op tensors are small.
+- **PyTorch-MPS never wins: 162-255 ms/it, at or *worse* than CPU (255 vs 193 at
+  70ch), single- and multi-model.** The Apple-GPU acceleration is MLX, not
+  `device="mps"`.
+- Results agree across cpu/mps/cuda/mlx and f32/f64 to ~3 digits on real data.
+- **Multi-model has no GPU path today** (MLX is single-model MVP; MPS loses), so
+  the top fast-follow is multi-model MLX; a 128-256 ch sweep would find the
+  eventual MLX/CUDA crossover.
 
 ## Pathway C: MLX port -- v1 MVP LANDED (#76)
 

--- a/.context/mps_pathways.md
+++ b/.context/mps_pathways.md
@@ -3,7 +3,8 @@
 Research into whether and how the natural-gradient EM backend (`AMICATorchNG`)
 can be accelerated on Apple-Silicon GPUs. Motivated by MPS's growing traction,
 and by the #63/#70 findings that MPS was *slower* than CPU on the 32-channel
-sample data and that float32 diverges on full-size data.
+sample data and that float32 diverged on full-size data (the latter now fixed in
+#75; see Pathway A).
 
 ## The one fact that governs everything: no FP64 on Apple GPUs
 
@@ -22,29 +23,30 @@ Consequently:
 
 `AMICATorchNG` computes in **float64 for Fortran parity**. So the parity path can
 never run on an Apple GPU. **Every MPS pathway therefore requires a numerically
-stable float32 (or mixed-precision) AMICA** -- exactly the wall #70 hit.
+stable float32 AMICA** -- the wall #70 hit, now cleared by #75 (Pathway A).
 
-## Pathway A (enabler): stabilize float32 with compensated / mixed precision
+## Pathway A (enabler): stabilize float32 -- DONE (#75)
 
-This is the prerequisite for all Apple-GPU acceleration. #70 established float32
-diverges (precision-driven, not a divide-by-zero) and that float64
-responsibilities alone don't fix it. The research surfaces a stronger tool than
-the reductions-only approach tried there:
+This was the prerequisite for all Apple-GPU acceleration, and it is **resolved**
+(epic #74 Phase A, issue #75). The fix was **not** compensated summation or mixed
+precision -- diagnostics on the real data ruled those out: accumulating the block
+sufficient statistics in float64 (and Neumaier compensated summation) did **not**
+stop the divergence, and neither did computing the density or responsibilities in
+float64.
 
-- **Kahan / compensated summation** gives float32 sums *near float64 accuracy*
-  with an error bound independent of the term count N -- at ~2-3x the cost of a
-  naive sum ([optimi](https://optimi.benjaminwarner.dev/kahan_summation/),
-  [Dmitruk 2023](https://onlinelibrary.wiley.com/doi/abs/10.1002/cpe.7763)). The
-  AMICA sufficient-stat accumulation sums ~30504 samples per block/component --
-  a classic float32 precision sink and a prime suspect for the divergence.
-- Combined with a **mixed-precision** split (float64 for the density `|y|^rho`,
-  the LL, and the accumulation; float32 for the matmuls), this is the credible
-  route to a stable float32 fit. Kahan training reportedly lets pure low-precision
-  match full mixed-precision ([optimi](https://optimi.benjaminwarner.dev/kahan_summation/)).
+The real cause was a **single per-element divide-by-zero**. The mu-denominator
+statistic is `sbeta*sum(ufp/y)` with `ufp = u*fp`; at a sample sitting on a
+mixture mean, float32 rounds the scaled activation `y` to *exactly* 0, and the
+score `fp(0)=0`, so that term is `0/0 = NaN` and one NaN summand poisons the whole
+denominator (float64 never lands `y` on exact 0). Guarding that division
+(`ufp / where(y==0, 1, y)`, contributing 0 for the measure-zero sample) makes
+full-data float32 converge across seeds and match the float64 LL to ~5 significant
+digits. Crucially the guard **needs no float64**, so it holds on MPS.
 
-Effort: moderate. Payoff on *CUDA* is limited (float64-CUDA already gives 4.5x),
-but on Apple GPUs it is the *only* door. Reopen the #70 technical work under this
-angle if MPS is pursued.
+Consequence: the earlier "Kahan / mixed-precision is the credible route, payoff
+shrinks to ~1.5-2x" framing is retired. The float64-accumulation mixed-precision
+mode is an *unneeded* CPU/CUDA-only option, not the Apple-GPU door. float32 stays
+~7-significant-digit, not float64-parity (use float64 for Fortran-parity runs).
 
 ## Pathway B: exploit the large-workload regime (measure the crossover)
 
@@ -56,9 +58,10 @@ dominate, and CPU with Accelerate/oneDNN wins ([elanapearl blog](https://elanape
 
 That overhead is **fixed per op**, so it amortizes as tensors grow. High-channel
 montages (128-256 ch), many-model runs, and larger blocks produce much bigger
-per-op tensors where MPS can plausibly overtake CPU. **Actionable:** once float32
-is stable (Pathway A), benchmark MPS-float32 vs CPU across channel count / block
-size / n_models to find the crossover, rather than concluding from 32 channels.
+per-op tensors where MPS can plausibly overtake CPU. **Actionable:** now that
+float32 is stable (Pathway A, #75), benchmark MPS-float32 vs CPU across channel
+count / block size / n_models to find the crossover, rather than concluding from
+32 channels.
 `benchmarks/benchmark_gpu.py` already sweeps devices; add a dimension sweep.
 
 ## Pathway C: MLX port (longer-term, higher ceiling)
@@ -69,9 +72,9 @@ and is Apple-native with a real compiler / lazy graph ([WWDC25](https://develope
 unfused, and sometimes falls back to CPU ([State of PyTorch HW 2025](https://tunguz.github.io/PyTorch_Hardware_2025/)).
 An MLX backend could both cut dispatch overhead and fuse the per-block work.
 
-Cost: a full backend rewrite, still float32-only on GPU (so Pathway A is still
-required first), and a new dependency. High effort, uncertain until A lands. Best
-seen as a v2 acceleration option, not a near-term step.
+Cost: a full backend rewrite, still float32-only on GPU (Pathway A, #75, already
+provides that), and a new dependency. High effort. Best seen as a v2 acceleration
+option, not a near-term step.
 
 ## Pathway D: software FP64 emulation -- DEAD END
 
@@ -86,14 +89,17 @@ AMICA and would be slower than the CPU even if it could. Ruled out.
 
 1. **Apple-GPU acceleration is gated on a stable float32 AMICA (Pathway A)** --
    there is no float64 GPU path on Apple hardware, now or on the visible horizon.
-2. The right first step, if pursued, is **compensated (Kahan) + mixed-precision
-   float32** targeting the sufficient-stat accumulation and the density/LL, then
-   a **dimension-sweep MPS benchmark (Pathway B)** to see where MPS actually wins
-   (likely high channel counts, not 32).
-3. **MLX (Pathway C)** is the higher-ceiling but higher-cost option for later.
-4. Until then, **float64-CUDA (4.5x, bit-safe) remains the production GPU path**;
-   MPS/float32 stay experimental (documented in `issue-63/perf_findings.md`).
+2. **Pathway A is DONE (#75)** -- and the fix was a per-element divide-by-zero
+   guard, not compensated/mixed precision (those were tried and ruled out). float32
+   converges on full data across seeds, needs no float64, so the MPS prerequisite
+   is met.
+3. **Next: the dimension-sweep MPS benchmark (Pathway B)** to find where MPS
+   actually beats CPU (likely high channel counts, not 32), then **MLX (Pathway C)**
+   as the higher-ceiling backend.
+4. Meanwhile **float64-CUDA (4.5x, bit-safe) remains the production GPU path**;
+   float32 is ~7-sig-digit (not float64-parity), for speed / Apple-GPU
+   (documented in `issue-63/perf_findings.md`).
 
 Cost/benefit note: on CUDA the float32 work buys little (float64 already works);
-its real value is unlocking Apple GPUs *at all*. Prioritize it by how much the
-user base runs on Apple Silicon with large montages.
+its real value is unlocking Apple GPUs *at all*. Prioritize Pathways B/C by how
+much the user base runs on Apple Silicon with large montages.

--- a/.context/mps_pathways.md
+++ b/.context/mps_pathways.md
@@ -64,7 +64,7 @@ count / block size / n_models to find the crossover, rather than concluding from
 32 channels.
 `benchmarks/benchmark_gpu.py` already sweeps devices; add a dimension sweep.
 
-## Pathway C: MLX port (longer-term, higher ceiling)
+## Pathway C: MLX port -- v1 MVP LANDED (#76)
 
 MLX consistently beats PyTorch MPS on the same hardware (2-3x for LLM inference)
 and is Apple-native with a real compiler / lazy graph ([WWDC25](https://developer.apple.com/videos/play/wwdc2025/315/),
@@ -72,9 +72,21 @@ and is Apple-native with a real compiler / lazy graph ([WWDC25](https://develope
 unfused, and sometimes falls back to CPU ([State of PyTorch HW 2025](https://tunguz.github.io/PyTorch_Hardware_2025/)).
 An MLX backend could both cut dispatch overhead and fuse the per-block work.
 
-Cost: a full backend rewrite, still float32-only on GPU (Pathway A, #75, already
-provides that), and a new dependency. High effort. Best seen as a v2 acceleration
-option, not a near-term step.
+**Status (#76):** `AMICAMLXNG` (`pyAMICA/mlx_impl/core.py`) is a v1 MVP -- single-model,
+generalized-Gaussian, natural gradient. It is a **hybrid**: the E/M-step hot path runs on
+the GPU in float32 (with the Phase A `ufp/y` guard), while all `mlx.core.linalg` is CPU-only
+in MLX 0.32, so `inv(A)`/`slogdet(W)` run on the CPU stream (hoisted to once per iteration --
+measured ~42 us/iter vs a ~13 ms GPU E-pass, so not the bottleneck; `mx.eval` placement is).
+`lgamma`/`digamma` (absent in MLX) are computed host-side via SciPy on the small `rho` array.
+It matches the PyTorch float32 backend's converged LL to ~2e-6 and the NumPy reference stats to
+rtol ~1e-4. MLX is an optional dependency (Apple Silicon only), so CI skips these tests. Newton,
+the other PDF families, sharing, multi-model, and save/load are fast-follows. Whether it beats
+CPU/MPS is Pathway B's question.
+
+Cost (estimated before landing, now borne by the #76 MVP): a backend rewrite,
+still float32-only on GPU (Pathway A, #75, provides that), and a new optional
+dependency. The MVP is in-tree (see Status above); Newton, the other families,
+sharing and multi-model remain fast-follows.
 
 ## Pathway D: software FP64 emulation -- DEAD END
 

--- a/.context/mps_pathways.md
+++ b/.context/mps_pathways.md
@@ -67,9 +67,9 @@ this amortizes on larger tensors (128-256 ch), so MPS might overtake CPU there.
   70ch), single- and multi-model.** The Apple-GPU acceleration is MLX, not
   `device="mps"`.
 - Results agree across cpu/mps/cuda/mlx and f32/f64 to ~3 digits on real data.
-- **Multi-model has no GPU path today** (MLX is single-model MVP; MPS loses), so
-  the top fast-follow is multi-model MLX; a 128-256 ch sweep would find the
-  eventual MLX/CUDA crossover.
+- **Multi-model MLX (#81) also wins** (~5x over torch-CPU; MPS still loses). The
+  remaining MLX fast-follow is component sharing; a 128-256 ch sweep would find
+  the eventual MLX/CUDA crossover.
 
 ## Pathway C: MLX port -- v1 MVP LANDED (#76)
 
@@ -86,14 +86,14 @@ in MLX 0.32, so `inv(A)`/`slogdet(W)` run on the CPU stream (hoisted to once per
 measured ~42 us/iter vs a ~13 ms GPU E-pass, so not the bottleneck; `mx.eval` placement is).
 `lgamma`/`digamma` (absent in MLX) are computed host-side via SciPy on the small `rho` array.
 It matches the PyTorch float32 backend's converged LL to ~2e-6 and the NumPy reference stats to
-rtol ~1e-4. MLX is an optional dependency (Apple Silicon only), so CI skips these tests. Newton,
-the other PDF families, sharing, multi-model, and save/load are fast-follows. Whether it beats
-CPU/MPS is Pathway B's question.
+rtol ~1e-4. Multi-model landed in #81 (see the benchmark findings). MLX is an optional dependency
+(Apple Silicon only), so CI skips these tests. Newton, the other PDF families, sharing, and
+save/load remain fast-follows. Whether it beats CPU/MPS is Pathway B's question.
 
-Cost (estimated before landing, now borne by the #76 MVP): a backend rewrite,
+Cost (estimated before landing, now borne by #76/#81): a backend rewrite,
 still float32-only on GPU (Pathway A, #75, provides that), and a new optional
-dependency. The MVP is in-tree (see Status above); Newton, the other families,
-sharing and multi-model remain fast-follows.
+dependency. It is in-tree (see Status above); Newton, the other families,
+sharing and save/load remain fast-follows (multi-model landed in #81).
 
 ## Pathway D: software FP64 emulation -- DEAD END
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ pyAMICA/tests/torch_tests/_ng_e2e_tmp/
 
 # Benchmark run artifacts
 benchmarks/results/
+# Real EEG benchmark data (fetched from OpenNeuro, not committed) + result JSONs
+benchmarks/data/
+benchmarks/*.json
 
 # Local secrets (never commit)
 .env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,10 +43,12 @@ computes in float64 for Fortran parity, which MPS cannot represent, so parity ru
 **Performance (#63, `.context/issue-63/perf_findings.md`, `benchmarks/benchmark_gpu.py`):** the E-step
 pow-dedup (dropping the unused `dpdf`) is ~-35% and bit-identical; `block_size` default is 512 (was
 128, ~-18%). CUDA float64 is ~4.5x over a 16-thread CPU (RTX 4090, warmed) and agrees with the CPU LL
-to 5 sig digits (auto-selected by the wrapper). float32 is 5-19x faster but seed-flaky NaN on
-full-size data (mixture underflow ~iter 23), so it is experimental only; stabilization is tracked in
-#70. CPU intra-op threads are workload-limited (~4 was the sweet spot in the measured laptop sweep;
-8+ regressed).
+to 5 sig digits (auto-selected by the wrapper). float32 is 5-19x faster and now converges on
+full-size data across seeds (#75 guarded the one float32-only divide-by-zero: a sample rounding an
+activation to exactly 0 gave `0/0` in the mu denominator; not a summation-precision problem, so it
+needs no float64 and holds on MPS). float32 is ~7-sig-digit, not float64-parity, so use float64 for
+Fortran-parity runs. CPU intra-op threads are workload-limited (~4 was the sweet spot in the measured
+laptop sweep; 8+ regressed).
 
 ## Key Files
 - **Main interface:** `pyAMICA/amica.py` (thin wrapper over `AMICATorchNG`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,14 @@ needs no float64 and holds on MPS). float32 is ~7-sig-digit, not float64-parity,
 Fortran-parity runs. CPU intra-op threads are workload-limited (~4 was the sweet spot in the measured
 laptop sweep; 8+ regressed).
 
+**Cross-platform benchmark (#77, `.context/issue-77/benchmark_findings.md`, `benchmarks/benchmark_dimsweep.py`,
+real 70-ch EEG):** on Apple Silicon the **MLX backend is the GPU win: ~15-25 ms/it, flat across 16-70
+channels, ~7x over torch-CPU and faster than an RTX 4090 (CUDA ~36 ms/it) at EEG scale**; **PyTorch-MPS
+never wins (162-255 ms/it, at or worse than CPU)**, so use MLX, not `device="mps"`, on Apple hardware.
+CUDA float64 stays the bit-safe NVIDIA path. All backends agree on the LL to ~3 digits on real data.
+Multi-model has no GPU path yet (MLX MVP is single-model; MPS loses) -- multi-model MLX is the top
+follow-up.
+
 ## Key Files
 - **Main interface:** `pyAMICA/amica.py` (thin wrapper over `AMICATorchNG`)
 - **PyTorch backend:** `pyAMICA/torch_impl/core.py` (`AMICATorchNG`, natural-gradient EM,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,10 @@ pyAMICA/
 ├── amica.py                 # Main scikit-learn-style AMICA interface (wraps AMICATorchNG)
 ├── __init__.py              # Exposes AMICA (PyTorch), AMICA_NumPy (legacy), numpy_impl, torch_impl
 ├── torch_impl/              # PyTorch backend
-│   ├── core.py              #   Natural-gradient EM port (AMICATorchNG); Fortran-parity, sole backend
+│   ├── core.py              #   Natural-gradient EM port (AMICATorchNG); Fortran-parity, primary backend
 │   └── utils.py             #   Preprocessing (sphering, PCA), device selection
+├── mlx_impl/                # Optional MLX backend (Apple GPU; AMICAMLXNG, issue #76)
+│   └── core.py              #   float32 GPU E/M-step + CPU-stream linalg (v1 MVP: single-model GG, NG)
 ├── numpy_impl/              # Legacy NumPy reference (topic-named modules, issue #34)
 │   ├── core.py              #   AMICA_NumPy; newton.py, pdf.py, data.py, load.py, viz.py, utils.py, cli.py
 │   └── ...
@@ -25,7 +27,9 @@ validate_implementations.py  # Runs both implementations, Hungarian component ma
 Module names are topic-based (`core`/`newton`/`pdf`/`data`/... under `numpy_impl/`,
 `core`/`utils` under `torch_impl/`); the old `pyAMICA.py`/`amica_*.py`/`amica_torch_ng.py`
 prefixes were dropped in issue #34. The public import surface is stable:
-`from pyAMICA import AMICA, AMICA_NumPy, AMICATorchNG`.
+`from pyAMICA import AMICA, AMICA_NumPy, AMICATorchNG`. The optional MLX backend is
+imported separately (`from pyAMICA.mlx_impl import AMICAMLXNG`) so `import pyAMICA` never
+requires MLX; install it with `uv pip install mlx` or the `mlx` extra (Apple Silicon only).
 
 ## Environment Setup
 Canonical environment is **UV** (per global standards). The PyTorch stack is declared in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,8 @@ pyAMICA/
 ├── torch_impl/              # PyTorch backend
 │   ├── core.py              #   Natural-gradient EM port (AMICATorchNG); Fortran-parity, primary backend
 │   └── utils.py             #   Preprocessing (sphering, PCA), device selection
-├── mlx_impl/                # Optional MLX backend (Apple GPU; AMICAMLXNG, issue #76)
-│   └── core.py              #   float32 GPU E/M-step + CPU-stream linalg (v1 MVP: single-model GG, NG)
+├── mlx_impl/                # Optional MLX backend (Apple GPU; AMICAMLXNG, #76/#81)
+│   └── core.py              #   float32 GPU E/M-step + CPU-stream linalg (single- & multi-model GG, NG)
 ├── numpy_impl/              # Legacy NumPy reference (topic-named modules, issue #34)
 │   ├── core.py              #   AMICA_NumPy; newton.py, pdf.py, data.py, load.py, viz.py, utils.py, cli.py
 │   └── ...
@@ -59,8 +59,8 @@ real 70-ch EEG):** on Apple Silicon the **MLX backend is the GPU win: ~15-25 ms/
 channels, ~7x over torch-CPU and faster than an RTX 4090 (CUDA ~36 ms/it) at EEG scale**; **PyTorch-MPS
 never wins (162-255 ms/it, at or worse than CPU)**, so use MLX, not `device="mps"`, on Apple hardware.
 CUDA float64 stays the bit-safe NVIDIA path. All backends agree on the LL to ~3 digits on real data.
-Multi-model has no GPU path yet (MLX MVP is single-model; MPS loses) -- multi-model MLX is the top
-follow-up.
+Multi-model MLX (#81) also wins (~5x over torch-CPU; MPS still loses); the remaining MLX follow-up
+is component sharing.
 
 ## Key Files
 - **Main interface:** `pyAMICA/amica.py` (thin wrapper over `AMICATorchNG`)

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ python -m pyAMICA.numpy_impl.cli params.json --outdir results
 
 - `amica.py`: Main scikit-learn-style AMICA interface (PyTorch backend)
 - `torch_impl/core.py`: PyTorch natural-gradient EM backend (`AMICATorchNG`)
+- `mlx_impl/core.py`: Optional Apple-GPU MLX backend (`AMICAMLXNG`, single- & multi-model)
 - `numpy_impl/core.py`: Legacy NumPy reference (`AMICA_NumPy`)
 - `numpy_impl/pdf.py`: PDF type implementations
 - `numpy_impl/newton.py`: Newton optimization

--- a/benchmarks/README_dimsweep.md
+++ b/benchmarks/README_dimsweep.md
@@ -1,0 +1,54 @@
+# Cross-platform dimension-sweep benchmark (issue #77, epic #74 Phase B)
+
+`benchmark_dimsweep.py` measures **both results (converged log-likelihood) and
+performance (ms/iteration)** for every AMICA backend the host supports, sweeping
+the channel count on real 70-channel EEG, to answer where an Apple/NVIDIA GPU
+actually beats the CPU. Backends: `numpy-cpu-f64`, `torch-cpu-f64/f32`,
+`torch-mps-f32`, `torch-cuda-f64/f32`, `mlx-f32` (the MLX backend is single-model
+only, so it participates only in the `m1` config).
+
+## Data (real, not committed)
+
+Real 70-channel EEG from OpenNeuro **ds002718** (Wakeman-Henson faces), subject
+sub-002. The data is not committed (`benchmarks/data/` is gitignored); fetch and
+extract it once:
+
+```bash
+# 1. download one subject's EEGLAB .set (public, no credentials; ~224 MB)
+aws s3 cp --no-sign-request \
+  s3://openneuro.org/ds002718/sub-002/eeg/sub-002_task-FaceRecognition_eeg.set \
+  /tmp/ds002718_sub-002.set
+
+# 2. extract the 70 EEG channels to a (70, n_samples) float64 .npy (needs mne)
+uv pip install mne
+uv run python - <<'PY'
+import mne, numpy as np
+raw = mne.io.read_raw_eeglab("/tmp/ds002718_sub-002.set", preload=True, verbose="ERROR")
+data = raw.get_data(picks=raw.ch_names[:70]) * 1e6   # first 70 are EEG; V -> uV
+np.save("benchmarks/data/ds002718_sub-002_eeg70.npy", data[:, :60000].astype(np.float64))
+PY
+```
+
+(NEMAR mirrors the same dataset at data.nemar.org / ww2.nemar.org/dataset/ds002718.)
+
+## Run
+
+```bash
+# Local (Apple Silicon: cpu / mps / mlx auto-detected)
+uv run python benchmarks/benchmark_dimsweep.py \
+  --data benchmarks/data/ds002718_sub-002_eeg70.npy --out mac.json
+
+# A CUDA host (skip the CPU backends if its CPU is busy)
+uv run python benchmarks/benchmark_dimsweep.py \
+  --data benchmarks/data/ds002718_sub-002_eeg70.npy \
+  --backends torch-cuda-f64,torch-cuda-f32 --out cuda.json
+
+# Multi-model + component sharing (MLX auto-excluded: single-model MVP)
+uv run python benchmarks/benchmark_dimsweep.py --data DATA --n-models 2 --out mac_m2.json
+uv run python benchmarks/benchmark_dimsweep.py --data DATA --n-models 2 --share --out mac_m2share.json
+
+# Merge per-platform JSONs into ms/it + LL tables, one block per config
+uv run python benchmarks/benchmark_dimsweep.py --report mac.json cuda.json mac_m2.json ...
+```
+
+Findings live in `.context/issue-77/benchmark_findings.md`.

--- a/benchmarks/README_dimsweep.md
+++ b/benchmarks/README_dimsweep.md
@@ -4,8 +4,9 @@
 performance (ms/iteration)** for every AMICA backend the host supports, sweeping
 the channel count on real 70-channel EEG, to answer where an Apple/NVIDIA GPU
 actually beats the CPU. Backends: `numpy-cpu-f64`, `torch-cpu-f64/f32`,
-`torch-mps-f32`, `torch-cuda-f64/f32`, `mlx-f32` (the MLX backend is single-model
-only, so it participates only in the `m1` config).
+`torch-mps-f32`, `torch-cuda-f64/f32`, `mlx-f32` (the MLX backend supports single-
+and multi-model but has no component sharing yet, so it is excluded only from the
+`--share` configs).
 
 ## Data (real, not committed)
 
@@ -43,7 +44,7 @@ uv run python benchmarks/benchmark_dimsweep.py \
   --data benchmarks/data/ds002718_sub-002_eeg70.npy \
   --backends torch-cuda-f64,torch-cuda-f32 --out cuda.json
 
-# Multi-model + component sharing (MLX auto-excluded: single-model MVP)
+# Multi-model + component sharing (MLX runs multi-model; auto-excluded only from --share)
 uv run python benchmarks/benchmark_dimsweep.py --data DATA --n-models 2 --out mac_m2.json
 uv run python benchmarks/benchmark_dimsweep.py --data DATA --n-models 2 --share --out mac_m2share.json
 

--- a/benchmarks/benchmark_dimsweep.py
+++ b/benchmarks/benchmark_dimsweep.py
@@ -111,13 +111,13 @@ def _run_torch(data, device, dtype_str, iters, repeats, n_models=1, share=False)
     return min(times) / iters * 1000.0, ll
 
 
-def _run_mlx(data, iters, repeats):
+def _run_mlx(data, iters, repeats, n_models=1):
     from pyAMICA.mlx_impl import AMICAMLXNG
 
     def one(n_iter):
         m = AMICAMLXNG(
             n_channels=data.shape[0],
-            n_models=1,
+            n_models=n_models,
             n_mix=N_MIX,
             do_newton=False,
             block_size=BLOCK_SIZE,
@@ -193,8 +193,8 @@ def _available(name: str, n_models: int = 1, share: bool = False) -> bool:
     if kind == "torch":
         return _torch_available(kw["device"])
     if kind == "mlx":
-        # AMICAMLXNG (v1 MVP) is single-model only, no sharing.
-        if n_models != 1 or share:
+        # AMICAMLXNG supports single- and multi-model (#81); sharing not yet.
+        if share:
             return False
         try:
             import mlx.core as mx
@@ -214,7 +214,7 @@ def _run_backend(name, data, iters, repeats, n_models=1, share=False):
             data, iters=iters, repeats=repeats, n_models=n_models, share=share, **kw
         )
     if kind == "mlx":
-        return _run_mlx(data, iters=iters, repeats=repeats)
+        return _run_mlx(data, iters=iters, repeats=repeats, n_models=n_models)
     return _run_numpy(
         data, iters=iters, repeats=repeats, n_models=n_models, share=share
     )

--- a/benchmarks/benchmark_dimsweep.py
+++ b/benchmarks/benchmark_dimsweep.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python
+"""Cross-platform result + performance benchmark for AMICA backends (issue #77).
+
+Sweeps the channel count on real 70-channel EEG (OpenNeuro ds002718 sub-002, the
+Wakeman-Henson faces data) and, for every backend the current host supports,
+records BOTH performance (ms/iteration, warmed, min-of-repeats) and results
+(converged log-likelihood) so the two questions the epic (#74) has deferred can
+finally be answered together:
+
+  * do the backends/platforms/precisions agree on the *result*?
+  * where does an Apple/NVIDIA GPU actually *beat* the CPU?
+
+Backends (auto-detected per platform):
+  numpy-cpu-f64   AMICA_NumPy (the float64 reference implementation)
+  torch-cpu-f64   AMICATorchNG, CPU, float64 (the Fortran-parity path)
+  torch-cpu-f32   AMICATorchNG, CPU, float32
+  torch-mps-f32   AMICATorchNG, Apple GPU (MPS), float32
+  torch-cuda-f64  AMICATorchNG, NVIDIA GPU, float64
+  torch-cuda-f32  AMICATorchNG, NVIDIA GPU, float32
+  mlx-f32         AMICAMLXNG, Apple GPU (MLX), float32
+
+All backends run at matched settings (n_models=1, n_mix=3, pdftype=0,
+do_newton=False, same block_size/seed/channels/samples/iters) so the comparison
+is apples-to-apples. Emits JSON (``--out``) so a Mac run (cpu/mps/mlx) and a CUDA
+host run can be merged by ``--report``.
+
+Data: pass ``--data path/to/ds002718_sub-002_eeg70.npy`` -- a (70, n_samples)
+float64 array of the 70 EEG channels (see ``benchmarks/README_dimsweep.md`` for
+how to fetch/extract it; not committed).
+
+Usage:
+    uv run python benchmarks/benchmark_dimsweep.py --data DATA --out mac.json
+    uv run python benchmarks/benchmark_dimsweep.py --data DATA --backends torch-cuda-f64,torch-cuda-f32 --out cuda.json
+    uv run python benchmarks/benchmark_dimsweep.py --report mac.json cuda.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+from time import perf_counter
+
+import numpy as np
+
+# Matched fit settings for every backend.
+N_MIX = 3
+SEED = 42
+BLOCK_SIZE = 512
+
+
+# --------------------------------------------------------------------------
+# Backend adapters: each returns (ms_per_iter, final_ll) for one fit.
+# --------------------------------------------------------------------------
+def _torch_available(device: str) -> bool:
+    try:
+        import torch
+    except ImportError:
+        return False
+    if device == "cpu":
+        return True
+    if device == "mps":
+        return torch.backends.mps.is_available()
+    if device == "cuda":
+        return torch.cuda.is_available()
+    return False
+
+
+def _share_kw_torch(share):
+    # share_start/share_iter tuned so a merge actually fires inside the short
+    # benchmark budget (share_iter must be > 6); no-op when share is off.
+    return (
+        dict(share_comps=True, share_start=5, share_iter=8, comp_thresh=0.99)
+        if share
+        else {}
+    )
+
+
+def _run_torch(data, device, dtype_str, iters, repeats, n_models=1, share=False):
+    import torch
+
+    from pyAMICA.torch_impl import AMICATorchNG
+
+    dtype = torch.float64 if dtype_str == "f64" else torch.float32
+
+    def one(n_iter):
+        m = AMICATorchNG(
+            n_channels=data.shape[0],
+            n_models=n_models,
+            n_mix=N_MIX,
+            device=device,
+            dtype=dtype,
+            do_newton=False,
+            block_size=BLOCK_SIZE,
+            seed=SEED,
+            **_share_kw_torch(share),
+        )
+        if device == "cuda":
+            torch.cuda.synchronize()
+        t0 = perf_counter()
+        m.fit(data, max_iter=n_iter, verbose=False)
+        if device == "cuda":
+            torch.cuda.synchronize()
+        return perf_counter() - t0, float(m.final_ll_)
+
+    one(min(5, iters))  # warmup (kernel compile / context init)
+    times, ll = [], float("nan")
+    for _ in range(repeats):
+        t, ll = one(iters)
+        times.append(t)
+    return min(times) / iters * 1000.0, ll
+
+
+def _run_mlx(data, iters, repeats):
+    from pyAMICA.mlx_impl import AMICAMLXNG
+
+    def one(n_iter):
+        m = AMICAMLXNG(
+            n_channels=data.shape[0],
+            n_models=1,
+            n_mix=N_MIX,
+            do_newton=False,
+            block_size=BLOCK_SIZE,
+            seed=SEED,
+        )
+        t0 = perf_counter()
+        m.fit(data, max_iter=n_iter, verbose=False)  # fit's mx.eval syncs
+        return perf_counter() - t0, float(m.final_ll_)
+
+    one(min(5, iters))
+    times, ll = [], float("nan")
+    for _ in range(repeats):
+        t, ll = one(iters)
+        times.append(t)
+    return min(times) / iters * 1000.0, ll
+
+
+def _run_numpy(data, iters, repeats, n_models=1, share=False):
+    from pyAMICA.numpy_impl.core import AMICA as AMICA_NumPy
+
+    # NumPy uses share_int (torch uses share_iter).
+    share_kw = (
+        dict(share_comps=True, share_start=5, share_int=8, comp_thresh=0.99)
+        if share
+        else {}
+    )
+
+    def one(n_iter):
+        m = AMICA_NumPy(
+            num_models=n_models,
+            num_mix=N_MIX,
+            max_iter=n_iter,
+            do_newton=False,
+            # Match the fixed block_size and skip AMICA_NumPy's do_opt_block
+            # auto-tune, which otherwise runs a wall-clock block-size search
+            # INSIDE fit() -- unmatched settings + timing pollution vs torch/mlx.
+            block_size=BLOCK_SIZE,
+            do_opt_block=False,
+            use_tqdm=False,
+            verbose=False,
+            **share_kw,
+        )
+        t0 = perf_counter()
+        m.fit(data)
+        # AMICA_NumPy.ll is summed over samples*channels; normalize to the
+        # per-sample-per-channel scale the torch/mlx backends report, so the
+        # results column is directly comparable (numpy-f64 then matches
+        # torch-cpu-f64 to ~5 digits, as the parity suite guarantees).
+        ll = float(m.ll[-1]) / (data.shape[0] * data.shape[1]) if m.ll else float("nan")
+        return perf_counter() - t0, ll
+
+    one(min(3, iters))
+    times, ll = [], float("nan")
+    for _ in range(repeats):
+        t, ll = one(iters)
+        times.append(t)
+    return min(times) / iters * 1000.0, ll
+
+
+_BACKENDS = {
+    "numpy-cpu-f64": ("numpy", {}),
+    "torch-cpu-f64": ("torch", {"device": "cpu", "dtype_str": "f64"}),
+    "torch-cpu-f32": ("torch", {"device": "cpu", "dtype_str": "f32"}),
+    "torch-mps-f32": ("torch", {"device": "mps", "dtype_str": "f32"}),
+    "torch-cuda-f64": ("torch", {"device": "cuda", "dtype_str": "f64"}),
+    "torch-cuda-f32": ("torch", {"device": "cuda", "dtype_str": "f32"}),
+    "mlx-f32": ("mlx", {}),
+}
+
+
+def _available(name: str, n_models: int = 1, share: bool = False) -> bool:
+    kind, kw = _BACKENDS[name]
+    if kind == "torch":
+        return _torch_available(kw["device"])
+    if kind == "mlx":
+        # AMICAMLXNG (v1 MVP) is single-model only, no sharing.
+        if n_models != 1 or share:
+            return False
+        try:
+            import mlx.core as mx
+
+            return mx.default_device().type == mx.DeviceType.gpu
+        except Exception:
+            return False
+    if kind == "numpy":
+        return True
+    return False
+
+
+def _run_backend(name, data, iters, repeats, n_models=1, share=False):
+    kind, kw = _BACKENDS[name]
+    if kind == "torch":
+        return _run_torch(
+            data, iters=iters, repeats=repeats, n_models=n_models, share=share, **kw
+        )
+    if kind == "mlx":
+        return _run_mlx(data, iters=iters, repeats=repeats)
+    return _run_numpy(
+        data, iters=iters, repeats=repeats, n_models=n_models, share=share
+    )
+
+
+def _platform_info() -> dict:
+    info = {"machine": platform.machine(), "system": platform.system()}
+    try:
+        import torch
+
+        info["torch"] = torch.__version__
+        if torch.cuda.is_available():
+            info["cuda_device"] = torch.cuda.get_device_name(0)
+    except ImportError:
+        pass
+    try:
+        info["loadavg"] = [round(x, 1) for x in __import__("os").getloadavg()]
+    except OSError:
+        pass
+    return info
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--data", help="path to the (70, n_samples) real-EEG .npy")
+    ap.add_argument("--channels", default="16,32,48,70")
+    ap.add_argument("--samples", type=int, default=30000)
+    ap.add_argument("--iters", type=int, default=30)
+    ap.add_argument("--repeats", type=int, default=3)
+    ap.add_argument("--backends", default="auto")
+    ap.add_argument("--out", help="write results JSON here")
+    ap.add_argument("--report", nargs="+", help="merge these result JSONs into tables")
+    ap.add_argument("--n-models", type=int, default=1, dest="n_models")
+    ap.add_argument(
+        "--share", action="store_true", help="enable component sharing (n_models>1)"
+    )
+    args = ap.parse_args()
+
+    if args.report:
+        _report(args.report)
+        return 0
+
+    if not args.data:
+        ap.error("--data is required unless --report is given")
+
+    n_models, share = args.n_models, args.share
+    config = f"m{n_models}" + ("+share" if share else "")  # e.g. m1, m2, m2+share
+
+    full = np.load(args.data).astype(np.float64)
+    channels = [int(c) for c in args.channels.split(",") if int(c) <= full.shape[0]]
+    if args.backends == "auto":
+        backends = [b for b in _BACKENDS if _available(b, n_models, share)]
+    else:
+        backends = [
+            b for b in args.backends.split(",") if _available(b, n_models, share)
+        ]
+
+    info = _platform_info()
+    print(f"platform: {info}")
+    print(
+        f"data {full.shape} | config {config} | channels {channels} | "
+        f"samples {args.samples} | iters {args.iters} x {args.repeats} | {backends}"
+    )
+
+    rows = []
+    for nc in channels:
+        data = np.ascontiguousarray(full[:nc, : args.samples])
+        for b in backends:
+            try:
+                ms, ll = _run_backend(
+                    b, data, args.iters, args.repeats, n_models, share
+                )
+                rows.append(
+                    {
+                        "config": config,
+                        "channels": nc,
+                        "backend": b,
+                        "ms_per_iter": ms,
+                        "final_ll": ll,
+                    }
+                )
+                print(f"  [{config}] {nc:3d}ch {b:16s} {ms:9.2f} ms/it   LL={ll:+.5f}")
+            except Exception as exc:  # noqa: BLE001 - report and continue
+                print(
+                    f"  [{config}] {nc:3d}ch {b:16s} FAILED: {type(exc).__name__}: {str(exc)[:70]}"
+                )
+                rows.append(
+                    {
+                        "config": config,
+                        "channels": nc,
+                        "backend": b,
+                        "error": str(exc)[:120],
+                    }
+                )
+
+    out = {"platform": info, "config": vars(args), "rows": rows}
+    if args.out:
+        with open(args.out, "w") as f:
+            json.dump(out, f, indent=2)
+        print(f"wrote {args.out}")
+    return 0
+
+
+def _report(paths):
+    """Merge per-platform JSONs into ms/it + LL tables, one block per config."""
+    # merged[config][channels][backend] = row
+    merged: dict = {}
+    plats = []
+    for p in paths:
+        with open(p) as f:
+            d = json.load(f)
+        plats.append(d.get("platform", {}))
+        for r in d["rows"]:
+            if "error" in r:
+                continue
+            cfg = r.get("config", "m1")  # rows from before the config axis => m1
+            merged.setdefault(cfg, {}).setdefault(r["channels"], {})[r["backend"]] = r
+
+    for cfg in sorted(merged):
+        by_ch = merged[cfg]
+        backends = sorted({b for ch in by_ch.values() for b in ch})
+        chans = sorted(by_ch)
+
+        def table(field, fmt):
+            hdr = "channels | " + " | ".join(f"{b:>15}" for b in backends)
+            print(hdr)
+            print("-" * len(hdr))
+            for c in chans:
+                cells = [
+                    f"{format(by_ch[c][b][field], fmt):>15}"
+                    if b in by_ch[c] and by_ch[c][b].get(field) is not None
+                    else f"{'-':>15}"
+                    for b in backends
+                ]
+                print(f"{c:8d} | " + " | ".join(cells))
+
+        print(f"\n########## config: {cfg} ##########")
+        print("=== performance: ms / iteration ===")
+        table("ms_per_iter", ".2f")
+        print("=== results: converged log-likelihood ===")
+        table("final_ll", "+.5f")
+    print(f"\nplatforms: {plats}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/benchmark_gpu.py
+++ b/benchmarks/benchmark_gpu.py
@@ -4,10 +4,10 @@
 Times the natural-gradient EM backend across ``(device, dtype)`` combinations on
 the real sample EEG, to characterize the GPU fast path. float64 is the
 Fortran-parity default and the safe GPU win (~4.5x on an RTX 4090 vs a 16-thread
-CPU). float32 is faster still (~5x CPU / ~10-19x CUDA) but currently EXPERIMENTAL:
-it is seed-flaky NaN on full-size data (mixture underflow), so it is not a
-production fast path yet -- stabilization is tracked in issue #70. MPS cannot do
-float64, and only float32 there.
+CPU). float32 is faster still (~5x CPU / ~10-19x CUDA) and now converges on
+full-size data across seeds (issue #75 guarded the one float32-only
+divide-by-zero); it is ~7-significant-digit, not float64-parity, so use float64
+for Fortran-parity runs. MPS has no float64, so it runs float32 only.
 
 Run on a CUDA host (e.g. via ssh) for real GPU numbers:
     uv run python benchmarks/benchmark_gpu.py

--- a/pyAMICA/mlx_impl/__init__.py
+++ b/pyAMICA/mlx_impl/__init__.py
@@ -1,0 +1,16 @@
+"""MLX backend for pyAMICA (Apple-Silicon GPU).
+
+Mirrors ``torch_impl`` but targets Apple's MLX array framework. MLX is an
+*optional* dependency (Apple Silicon only); importing this subpackage requires
+``mlx`` to be installed, so the top-level ``pyAMICA`` package never imports it
+eagerly. Install with ``uv pip install mlx`` (or the ``mlx`` extra).
+
+The backend (:class:`AMICAMLXNG`) runs the natural-gradient EM E/M-step on the
+Apple GPU in float32 (Apple GPUs have no FP64), with the small per-iteration
+linear algebra on MLX's CPU stream (issue #76, epic #74 Phase C). It is a v1
+MVP: single-model, generalized-Gaussian (``pdftype=0``), natural gradient.
+"""
+
+from .core import AMICAMLXNG
+
+__all__ = ["AMICAMLXNG"]

--- a/pyAMICA/mlx_impl/__init__.py
+++ b/pyAMICA/mlx_impl/__init__.py
@@ -7,8 +7,9 @@ eagerly. Install with ``uv pip install mlx`` (or the ``mlx`` extra).
 
 The backend (:class:`AMICAMLXNG`) runs the natural-gradient EM E/M-step on the
 Apple GPU in float32 (Apple GPUs have no FP64), with the small per-iteration
-linear algebra on MLX's CPU stream (issue #76, epic #74 Phase C). It is a v1
-MVP: single-model, generalized-Gaussian (``pdftype=0``), natural gradient.
+linear algebra on MLX's CPU stream (issues #76/#81, epic #74 Phase C/D). It
+supports single- and multi-model, generalized-Gaussian (``pdftype=0``), natural
+gradient; component sharing remains a fast-follow.
 """
 
 from .core import AMICAMLXNG

--- a/pyAMICA/mlx_impl/core.py
+++ b/pyAMICA/mlx_impl/core.py
@@ -1,0 +1,516 @@
+"""MLX natural-gradient EM backend for AMICA (issue #76, epic #74 Phase C).
+
+``AMICAMLXNG`` is a v1 MVP port of :class:`pyAMICA.torch_impl.core.AMICATorchNG`
+to Apple's MLX array framework, so the per-block E/M-step runs on the Apple GPU.
+It is structurally parallel to the PyTorch backend (same method names/order and
+Fortran citations) so the two can be diffed method-by-method.
+
+Design constraints (verified against MLX 0.32, see ``.context/mps_pathways.md``):
+
+* **float32 only on the GPU** -- Apple GPUs have no FP64, and MLX raises on GPU
+  float64. Full-data float32 converges thanks to the ``ufp/y`` divide-by-zero
+  guard from issue #75, which is reproduced here.
+* **All ``mlx.core.linalg`` is CPU-stream only** -- ``inv(A)`` and ``slogdet(W)``
+  run under ``mx.stream(mx.cpu)``. They are hoisted to once per iteration (the
+  PyTorch ``_forward`` recomputes ``slogdet`` inside the block loop; here it is a
+  cached constant), so the GPU pipeline sees one cross-stream handoff per
+  iteration, not one per block.
+* **No ``lgamma``/``digamma`` in MLX** -- the GG normalizer ``lgamma(1+1/rho)``
+  and the rho-update ``digamma(1+1/rho)`` depend only on the small ``rho`` array,
+  so they are computed host-side with SciPy once per iteration.
+
+MVP scope: single model (``n_models=1``), generalized Gaussian (``pdftype=0``),
+natural gradient (``do_newton=False``). Newton, the other PDF families and
+multi-model are rejected in ``__init__`` with a clear ``NotImplementedError``
+(``transform`` likewise). Component sharing, outlier rejection, ``keep_best``
+and save/load are simply absent (no such parameter/method) -- all fast-follows.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Optional
+
+import mlx.core as mx
+import numpy as np
+from scipy.special import digamma, gammaln
+
+logger = logging.getLogger(__name__)
+
+_LOG2 = math.log(2.0)
+# Fortran epsdble: zero the rho*ln|y| term when |y|^rho underflows below this
+# (amica17.f90:1570), matching AMICATorchNG.
+_EPSDBLE = 1e-16
+# MLX linalg runs on the CPU stream only (float32-accurate); the GPU stream
+# raises "not yet supported on the GPU" for inv/slogdet/eigh/solve.
+_CPU = mx.cpu
+
+
+def _score_gg(y: mx.array, rho: mx.array) -> mx.array:
+    """GG score ``fp = rho*sign(y)*|y|^(rho-1)`` (AMICATorchNG ``_score``, GG
+    branch, core.py:176-183). ``fp(0)=0`` for ``rho>=1``, which the ``ufp/y``
+    guard relies on."""
+    abs_y = mx.abs(y)
+    sign_y = mx.sign(y)
+    fp_gg = rho * sign_y * mx.power(abs_y, rho - 1.0)
+    # rho is generically in (1, 2); keep the exact Laplace/Gaussian endpoints.
+    return mx.where(rho == 2.0, 2.0 * y, mx.where(rho == 1.0, sign_y, fp_gg))
+
+
+def _log_pdf_gg(
+    y: mx.array, rho: mx.array, lgamma_table: mx.array
+) -> tuple[mx.array, mx.array]:
+    """GG log-density and ``|y|^rho`` (AMICATorchNG ``_log_pdf_only``, GG branch,
+    core.py:216-224). ``lgamma_table = lgamma(1+1/rho)`` is precomputed host-side
+    (MLX has no ``lgamma``); it makes the uniform GG form reduce to the exact
+    Laplace (rho=1) and Gaussian (rho=2) log-densities."""
+    abs_y = mx.abs(y)
+    az_rho = mx.power(abs_y, rho)  # reused by the rho-update accumulator
+    log_pdf = -az_rho - _LOG2 - lgamma_table
+    return log_pdf, az_rho
+
+
+class AMICAMLXNG:
+    """MLX natural-gradient EM backend (single-model GG MVP, issue #76).
+
+    Parameters mirror the subset of :class:`AMICATorchNG` that the MVP supports;
+    the same ``seed`` produces the same initial parameters as the PyTorch/NumPy
+    backends, so cross-backend equivalence is testable.
+    """
+
+    def __init__(
+        self,
+        n_channels: int,
+        n_models: int = 1,
+        n_mix: int = 3,
+        block_size: int = 512,
+        lrate: float = 0.1,
+        minlrate: float = 1e-12,
+        lratefact: float = 0.5,
+        maxdecs: int = 5,
+        newt_ramp: int = 10,
+        do_newton: bool = False,
+        rho0: float = 1.5,
+        minrho: float = 1.0,
+        maxrho: float = 2.0,
+        rholrate: float = 0.05,
+        rholratefact: float = 0.1,
+        pdftype: int = 0,
+        invsigmin: float = 1e-4,
+        invsigmax: float = 1000.0,
+        doscaling: bool = True,
+        scalestep: int = 1,
+        do_mean: bool = True,
+        do_sphere: bool = True,
+        do_approx_sphere: bool = True,
+        seed: Optional[int] = None,
+    ):
+        # --- MVP boundaries: reject the deferred configurations up front. -----
+        if n_models != 1:
+            raise NotImplementedError(
+                "AMICAMLXNG (v1) supports single-model only (n_models=1); "
+                "multi-model is a fast-follow. Use AMICATorchNG for n_models>1."
+            )
+        if pdftype != 0:
+            raise NotImplementedError(
+                "AMICAMLXNG (v1) supports the generalized-Gaussian family "
+                "(pdftype=0) only; the other families are a fast-follow."
+            )
+        if do_newton:
+            raise NotImplementedError(
+                "AMICAMLXNG (v1) supports the natural gradient only "
+                "(do_newton=False); Newton is a fast-follow."
+            )
+
+        self.n_channels = n_channels
+        self.n_models = 1
+        self.n_mix = n_mix
+        self.n_comps = n_channels
+        self.block_size = block_size
+
+        self.lrate0 = lrate
+        self.lrate = lrate
+        self.lrate_cap = lrate
+        self.minlrate = minlrate
+        self.lratefact = lratefact
+        self.maxdecs = maxdecs
+        self.newt_ramp = newt_ramp
+        self.do_newton = False
+
+        self.rho0 = rho0
+        self.minrho = minrho
+        self.maxrho = maxrho
+        self.rholrate0 = rholrate
+        self.rholrate = rholrate
+        self.rholratefact = rholratefact
+        self.dorho = True  # GG shape adapts (Fortran dorho, pdftype==0)
+
+        self.pdftype = 0
+        self.invsigmin = invsigmin
+        self.invsigmax = invsigmax
+        self.doscaling = doscaling
+        self.scalestep = scalestep
+
+        self.do_mean = do_mean
+        self.do_sphere = do_sphere
+        self.do_approx_sphere = do_approx_sphere
+        self.seed = seed
+
+        self.iteration = 0
+        self.ll_history: list[float] = []
+        self.final_ll_: Optional[float] = None
+        self.stop_reason: Optional[str] = None
+
+        # Populated by fit()/_initialize_parameters().
+        self.A = self.W = self.mu = self.alpha = self.beta = self.rho = None
+        self.gm = self.mean = self.sphere = None
+        self.sldet = 0.0
+        self._lgamma_table = None  # mx.array (n_mix, n_channels): lgamma(1+1/rho)
+        self._logdet_W = None  # mx.array scalar: log|det W|, refreshed per iter
+
+    _DEGENERATE_STOP_REASONS = ("nan_ll", "singular_ll", "nan_params")
+
+    # ------------------------------------------------------------------
+    # Preprocessing (host / numpy; mirrors AMICATorchNG._preprocess in float64)
+    # ------------------------------------------------------------------
+    def _preprocess(self, X: np.ndarray) -> mx.array:
+        """Mean-removal + sphering in float64 on the host, then handed to MLX as
+        float32. Done in numpy (not MLX) because it reuses the exact float64
+        preprocessing AMICATorchNG already validates, so the sphere/sldet match
+        the PyTorch backend. (MLX's CPU-stream ``eigh`` is full float64 -- only
+        the GPU stream is unsupported -- so this is a code-sharing choice, not a
+        precision workaround.)"""
+        Xc = np.ascontiguousarray(X).astype(np.float64)
+        data_dim = Xc.shape[0]
+
+        if self.do_mean:
+            mean = Xc.mean(axis=1, keepdims=True)
+            Xc = Xc - mean
+        else:
+            mean = np.zeros((data_dim, 1))
+
+        if self.do_sphere:
+            # Population covariance (/N), matching Fortran's DSYRK scatter, not
+            # numpy's default sample covariance (/(N-1)) -- see core.py:635-639.
+            cov = np.cov(Xc, bias=True)
+            evals, evecs = np.linalg.eigh(cov)
+            order = np.argsort(evals)[::-1]
+            evals = evals[order]
+            evecs = evecs[:, order]
+            inv_sqrt = np.diag(1.0 / np.sqrt(evals))
+            if self.do_approx_sphere:
+                # Symmetric ZCA sphere V diag(1/sqrt) V^T (Fortran default).
+                sphere = evecs @ inv_sqrt @ evecs.T
+            else:
+                sphere = inv_sqrt @ evecs.T
+            Xc = sphere @ Xc
+            sldet = float(-0.5 * np.log(evals).sum())
+        else:
+            sphere = np.eye(data_dim)
+            sldet = 0.0
+
+        self.mean = mx.array(mean.astype(np.float32))
+        self.sphere = mx.array(sphere.astype(np.float32))
+        self.sldet = sldet
+        return mx.array(Xc.astype(np.float32))
+
+    # ------------------------------------------------------------------
+    # Initialization (identical RNG draws to AMICATorchNG for cross-backend test)
+    # ------------------------------------------------------------------
+    def _initialize_parameters(self):
+        """Initialize parameters with the *same* ``np.random.RandomState`` draw
+        order as AMICATorchNG/AMICA_NumPy (core.py:688-725), so a shared seed
+        gives a bit-identical (float32-cast) starting point."""
+        rng = np.random.RandomState(self.seed)
+        n, ncomp, nmix = self.n_channels, self.n_comps, self.n_mix
+
+        A_np = np.eye(n) + 0.01 * (0.5 - rng.rand(n, n))
+
+        mu_np = np.zeros((nmix, ncomp))
+        for k in range(ncomp):
+            mu_np[:, k] = np.linspace(-1, 1, nmix)
+            mu_np[:, k] += 0.05 * (1 - 2 * rng.rand(nmix))
+
+        alpha_np = np.ones((nmix, ncomp)) / nmix
+        beta_np = np.ones((nmix, ncomp)) + 0.1 * (0.5 - rng.rand(nmix, ncomp))
+        rho_np = self.rho0 * np.ones((nmix, ncomp))
+
+        self.A = mx.array(A_np.astype(np.float32))
+        self.mu = mx.array(mu_np.astype(np.float32))
+        self.alpha = mx.array(alpha_np.astype(np.float32))
+        self.beta = mx.array(beta_np.astype(np.float32))
+        self.rho = mx.array(rho_np.astype(np.float32))
+        self.gm = mx.array(np.ones(1, dtype=np.float32))
+
+        self.lrate = self.lrate0
+        self.lrate_cap = self.lrate0
+        self.rholrate = self.rholrate0
+        self.iteration = 0
+        self._refresh_lgamma_table()
+        self._update_unmixing_matrices()
+
+    def _refresh_lgamma_table(self):
+        """Recompute ``lgamma(1+1/rho)`` host-side (MLX has no lgamma). Called at
+        init and after every rho update. Cheap: rho is ``(n_mix, n_channels)``."""
+        rho_np = np.array(self.rho, dtype=np.float64)
+        self._lgamma_table = mx.array(gammaln(1.0 + 1.0 / rho_np).astype(np.float32))
+
+    def _update_unmixing_matrices(self):
+        """W = inv(A) and the LL Jacobian log|det W|, both on the CPU stream
+        (MLX linalg is CPU-only) and hoisted to once per iteration.
+
+        These build lazy graph nodes; a singular ``A`` therefore raises not here
+        but where the graph is materialized (the ``mx.eval`` in ``fit``), so a
+        LinAlg traceback rooted in ``fit`` actually originates in this method.
+        """
+        self.W = mx.linalg.inv(self.A, stream=_CPU)
+        self._logdet_W = mx.linalg.slogdet(self.W, stream=_CPU)[1]
+
+    # ------------------------------------------------------------------
+    # E-step
+    # ------------------------------------------------------------------
+    def _forward(self, Xb: mx.array):
+        """E-step forward pass for one block (single model). ``Xb`` is
+        ``(n_channels, batch)``. Returns ``(logV, b, z, y, az_rho)``."""
+        b = Xb.T @ self.W  # (batch, n_channels); c == 0 for single model
+        mu_h = self.mu.T[None]  # (1, n_channels, n_mix)
+        beta_h = self.beta.T[None]
+        rho_h = self.rho.T[None]
+        alpha_h = self.alpha.T[None]
+        lgamma_h = self._lgamma_table.T[None]
+
+        y = beta_h * (b[..., None] - mu_h)  # (batch, n_channels, n_mix)
+        log_pdf, az_rho = _log_pdf_gg(y, rho_h, lgamma_h)
+        z0 = mx.log(alpha_h) + mx.log(beta_h) + log_pdf
+        ll_i = mx.logsumexp(z0, axis=-1)  # (batch, n_channels)
+        z = mx.softmax(z0, axis=-1)
+        # Single model: log(gm)=0; logdet_W + sldet are the Jacobian terms.
+        logV = self._logdet_W + self.sldet + ll_i.sum(axis=-1)  # (batch,)
+        return logV, b, z, y, az_rho
+
+    def _get_block_updates(self, Xb: mx.array) -> dict:
+        """Exact-EM sufficient statistics for one block (single-model,
+        non-Newton subset of AMICATorchNG._get_block_updates, core.py:891-944;
+        the bias-c accumulator is excluded -- single-model has no c update)."""
+        logV, b, z, y, az_rho = self._forward(Xb)
+        block_ll = logV.sum()  # single model: logsumexp over one model is identity
+        beta_h = self.beta.T[None]  # (1, n_channels, n_mix)
+        rho_h = self.rho.T[None]
+
+        fp = _score_gg(y, rho_h)
+        u = z  # u = v*z with v == 1 (single model)
+        ufp = u * fp
+
+        dgm = mx.array(float(Xb.shape[1]), dtype=mx.float32)  # sum_t v_h = n samples
+        dalpha_n = u.sum(0).T  # (n_mix, n_channels)
+        dmu_n = ufp.sum(0).T
+        # Phase A guard: float32 can round y to exactly 0 (fp(0)=0 => ufp=0), so
+        # ufp/y is 0/0=NaN; where y==0, 0/1 contributes 0 (issue #75).
+        safe_y = mx.where(y == 0, mx.ones_like(y), y)
+        dmu_d = (beta_h[0] * (ufp / safe_y).sum(0)).T
+        dbeta_n = u.sum(0).T
+        dbeta_d = (ufp * y).sum(0).T
+
+        ay = mx.abs(y)
+        tiny = float(np.finfo(np.float32).tiny)
+        logab = rho_h * mx.log(mx.maximum(ay, tiny))
+        logab = mx.where(az_rho < _EPSDBLE, mx.zeros_like(logab), logab)
+        drho_n = (u * (az_rho * logab)).sum(0).T
+
+        g = (beta_h * ufp).sum(-1)  # (batch, n_channels)
+        dWtmp = g.T @ b  # (n_channels, n_channels)
+
+        return {
+            "dgm": dgm,
+            "dalpha_n": dalpha_n,
+            "dmu_n": dmu_n,
+            "dmu_d": dmu_d,
+            "dbeta_n": dbeta_n,
+            "dbeta_d": dbeta_d,
+            "drho_n": drho_n,
+            "dWtmp": dWtmp,
+            "ll": block_ll,
+        }
+
+    def _accumulate_blocks(self, X: mx.array) -> dict:
+        """Sum sufficient statistics over all blocks as one lazy graph (no
+        per-block ``mx.eval`` -- that over-syncs 2.6x)."""
+        n_samples = X.shape[1]
+        acc: Optional[dict] = None
+        for start in range(0, n_samples, self.block_size):
+            end = min(start + self.block_size, n_samples)
+            block_acc = self._get_block_updates(X[:, start:end])
+            if acc is None:
+                acc = block_acc
+            else:
+                for key in acc:
+                    acc[key] = acc[key] + block_acc[key]
+        return acc
+
+    # ------------------------------------------------------------------
+    # M-step
+    # ------------------------------------------------------------------
+    def _update_parameters(self, acc: dict, n_samples: int):
+        """Exact-EM mixture updates + natural-gradient A-update (single-model,
+        non-Newton subset of AMICATorchNG._update_parameters, core.py:1049-1247)."""
+        self.gm = acc["dgm"] / n_samples  # == 1 for single model
+
+        self.alpha = acc["dalpha_n"] / acc["dalpha_n"].sum(axis=0, keepdims=True)
+        self.mu = self.mu + acc["dmu_n"] / acc["dmu_d"]
+        self.beta = mx.clip(
+            self.beta * mx.sqrt(acc["dbeta_n"] / acc["dbeta_d"]),
+            self.invsigmin,
+            self.invsigmax,
+        )
+
+        # GG shape update with the 1/psi(1+1/rho) digamma factor (Fortran
+        # :2013-2014); digamma is computed host-side (MLX has none). A NaN here
+        # (e.g. from an upstream mu/beta blow-up) is reset to rho0 and surfaced,
+        # matching AMICATorchNG (core.py:1140-1151), so it does not silently
+        # poison the lgamma table and every subsequent E-step.
+        if self.dorho:
+            drho = acc["drho_n"] / mx.maximum(acc["dalpha_n"], 1e-8)
+            rho_np = np.array(self.rho, dtype=np.float64)
+            psi = mx.array(digamma(1.0 + 1.0 / rho_np).astype(np.float32))
+            new_rho = self.rho + self.rholrate * (1.0 - (self.rho / psi) * drho)
+            nan_mask = mx.isnan(new_rho)
+            if bool(mx.any(nan_mask).item()):
+                logger.warning(
+                    "NaN in rho update at iter %d; resetting to rho0=%g.",
+                    self.iteration,
+                    self.rho0,
+                )
+                new_rho = mx.where(nan_mask, self.rho0, new_rho)
+            self.rho = mx.clip(new_rho, self.minrho, self.maxrho)
+
+        # Natural-gradient A-update. A is stored as Fortran's A^T, so the update
+        # is a LEFT-multiply by the transposed direction (core.py:1176-1184,
+        # #24 root cause). Single-model collapses the gm-weighted column average.
+        eye = mx.eye(self.n_channels)
+        dA = -acc["dWtmp"] / acc["dgm"] + eye  # I - <g b^T>/dgm
+        self.lrate = min(
+            self.lrate_cap, self.lrate + min(1.0 / self.newt_ramp, self.lrate)
+        )
+        self.A = self.A - self.lrate * (dA.T @ self.A)
+
+        if self.doscaling and (self.iteration % self.scalestep == 0):
+            scale = mx.sqrt((self.A**2).sum(axis=0))  # (n_comps,)
+            # A zero-norm (collapsed) column is left untouched, not rescaled:
+            # safe_scale is 1 there, so A/beta are unchanged and mu*safe_scale
+            # keeps its prior value (matching AMICATorchNG's nonzero mask,
+            # core.py:1229-1234 -- using raw `scale` would zero mu instead).
+            safe_scale = mx.where(scale > 0, scale, mx.ones_like(scale))
+            self.A = self.A / safe_scale
+            self.mu = self.mu * safe_scale
+            self.beta = self.beta / safe_scale
+
+        self._refresh_lgamma_table()
+        self._update_unmixing_matrices()
+
+    # ------------------------------------------------------------------
+    # Fit
+    # ------------------------------------------------------------------
+    def fit(
+        self, X: np.ndarray, max_iter: int = 100, verbose: bool = True
+    ) -> "AMICAMLXNG":
+        """Fit the model. ``X`` is ``(n_channels, n_samples)``."""
+        if X.ndim != 2:
+            raise ValueError(f"X must be 2D (n_channels, n_samples), got {X.shape}")
+        if X.shape[0] != self.n_channels:
+            raise ValueError(
+                f"X has {X.shape[0]} channels, model expects {self.n_channels}"
+            )
+
+        X_t = self._preprocess(X)
+        n_total = X_t.shape[1]
+        self._initialize_parameters()
+        self.ll_history = []
+        self.stop_reason = "max_iter"
+        numdecs = 0
+
+        rng = range(max_iter)
+        if verbose:
+            try:
+                from tqdm import tqdm
+
+                rng = tqdm(rng, desc="AMICA-MLX")
+            except ImportError:
+                pass
+
+        for it in rng:
+            self.iteration = it
+            acc = self._accumulate_blocks(X_t)
+
+            ll_arr = acc["ll"] / (n_total * self.n_channels)
+            mx.eval(ll_arr)  # materialize the accumulate graph once
+            ll = float(ll_arr.item())
+            if not math.isfinite(ll):
+                self.stop_reason = "nan_ll" if math.isnan(ll) else "singular_ll"
+                logger.warning(
+                    "Non-finite log-likelihood (%s) at iteration %d; stopping.", ll, it
+                )
+                break
+
+            self._update_parameters(acc, n_total)
+            # One eval per iteration bounds the lazy graph to a single iteration's
+            # worth of ops (the updated params feed the next accumulate).
+            mx.eval(self.A, self.W, self.mu, self.alpha, self.beta, self.rho)
+
+            # Surface a corrupted M-step (component collapse / float32 overflow)
+            # at the iteration it happens. The ll check above only catches a
+            # corruption via the NEXT iteration's E-step, so a final-iteration
+            # blow-up would otherwise complete as max_iter with silently NaN
+            # parameters (the torch backend has state_dict as a backstop; the
+            # MLX MVP does not, so guard in fit()). Params are already
+            # materialized by the mx.eval above, so this is a cheap read.
+            params_finite = (
+                mx.all(mx.isfinite(self.A))
+                & mx.all(mx.isfinite(self.mu))
+                & mx.all(mx.isfinite(self.alpha))
+                & mx.all(mx.isfinite(self.beta))
+                & mx.all(mx.isfinite(self.rho))
+            )
+            if not bool(params_finite.item()):
+                logger.warning(
+                    "Non-finite parameters at iter %d (a mixture component "
+                    "likely collapsed); stopping.",
+                    it,
+                )
+                self.stop_reason = "nan_params"
+                break
+
+            self.ll_history.append(ll)
+
+            # Learning-rate control (Fortran amica17.f90:1062-1108): anneal on an
+            # LL decrease; ratchet the ceiling after maxdecs persistent decreases.
+            if len(self.ll_history) > 1 and ll < self.ll_history[-2]:
+                if self.lrate <= self.minlrate:
+                    logger.warning(
+                        "lrate floor (%g) reached at iter %d; stopping.",
+                        self.minlrate,
+                        it,
+                    )
+                    self.stop_reason = "lrate_floor"
+                    break
+                self.lrate *= self.lratefact
+                self.rholrate *= self.rholratefact
+                numdecs += 1
+                if numdecs >= self.maxdecs:
+                    self.lrate_cap *= self.lratefact
+                    numdecs = 0
+
+        if self.stop_reason in self._DEGENERATE_STOP_REASONS:
+            self.final_ll_ = float("nan")
+        else:
+            self.final_ll_ = self.ll_history[-1] if self.ll_history else float("nan")
+        return self
+
+    def transform(self, X: np.ndarray, model_idx: int = 0) -> np.ndarray:
+        """Not in the v1 MVP -- fail with a clear boundary rather than a bare
+        AttributeError. Use ``AMICATorchNG.transform`` for source extraction; the
+        MLX backend (issue #76) validates via ``final_ll_``/``ll_history``."""
+        raise NotImplementedError(
+            "AMICAMLXNG (v1) does not implement transform yet; it is a "
+            "fast-follow. Use AMICATorchNG for source extraction."
+        )

--- a/pyAMICA/mlx_impl/core.py
+++ b/pyAMICA/mlx_impl/core.py
@@ -1,6 +1,6 @@
-"""MLX natural-gradient EM backend for AMICA (issue #76, epic #74 Phase C).
+"""MLX natural-gradient EM backend for AMICA (issue #76/#81, epic #74 Phase C/D).
 
-``AMICAMLXNG`` is a v1 MVP port of :class:`pyAMICA.torch_impl.core.AMICATorchNG`
+``AMICAMLXNG`` is a port of :class:`pyAMICA.torch_impl.core.AMICATorchNG`
 to Apple's MLX array framework, so the per-block E/M-step runs on the Apple GPU.
 It is structurally parallel to the PyTorch backend (same method names/order and
 Fortran citations) so the two can be diffed method-by-method.
@@ -19,11 +19,12 @@ Design constraints (verified against MLX 0.32, see ``.context/mps_pathways.md``)
   and the rho-update ``digamma(1+1/rho)`` depend only on the small ``rho`` array,
   so they are computed host-side with SciPy once per iteration.
 
-MVP scope: single model (``n_models=1``), generalized Gaussian (``pdftype=0``),
-natural gradient (``do_newton=False``). Newton, the other PDF families and
-multi-model are rejected in ``__init__`` with a clear ``NotImplementedError``
-(``transform`` likewise). Component sharing, outlier rejection, ``keep_best``
-and save/load are simply absent (no such parameter/method) -- all fast-follows.
+Scope: single- and multi-model (``n_models >= 1``, issue #81), generalized
+Gaussian (``pdftype=0``), natural gradient (``do_newton=False``). Newton and the
+other PDF families are rejected in ``__init__`` with a clear
+``NotImplementedError`` (``transform`` likewise). Component sharing, outlier
+rejection, ``keep_best`` and save/load are simply absent (no such
+parameter/method) -- all fast-follows.
 """
 
 from __future__ import annotations
@@ -72,9 +73,9 @@ def _log_pdf_gg(
 
 
 class AMICAMLXNG:
-    """MLX natural-gradient EM backend (single-model GG MVP, issue #76).
+    """MLX natural-gradient EM backend (GG, single- and multi-model; #76/#81).
 
-    Parameters mirror the subset of :class:`AMICATorchNG` that the MVP supports;
+    Parameters mirror the subset of :class:`AMICATorchNG` that is supported;
     the same ``seed`` produces the same initial parameters as the PyTorch/NumPy
     backends, so cross-backend equivalence is testable.
     """
@@ -106,27 +107,22 @@ class AMICAMLXNG:
         do_approx_sphere: bool = True,
         seed: Optional[int] = None,
     ):
-        # --- MVP boundaries: reject the deferred configurations up front. -----
-        if n_models != 1:
-            raise NotImplementedError(
-                "AMICAMLXNG (v1) supports single-model only (n_models=1); "
-                "multi-model is a fast-follow. Use AMICATorchNG for n_models>1."
-            )
+        # --- Boundaries: reject the still-deferred configurations up front. ---
         if pdftype != 0:
             raise NotImplementedError(
-                "AMICAMLXNG (v1) supports the generalized-Gaussian family "
+                "AMICAMLXNG supports the generalized-Gaussian family "
                 "(pdftype=0) only; the other families are a fast-follow."
             )
         if do_newton:
             raise NotImplementedError(
-                "AMICAMLXNG (v1) supports the natural gradient only "
+                "AMICAMLXNG supports the natural gradient only "
                 "(do_newton=False); Newton is a fast-follow."
             )
 
         self.n_channels = n_channels
-        self.n_models = 1
+        self.n_models = n_models  # multi-model supported (issue #81); no sharing yet
         self.n_mix = n_mix
-        self.n_comps = n_channels
+        self.n_comps = n_channels * n_models
         self.block_size = block_size
 
         self.lrate0 = lrate
@@ -164,9 +160,9 @@ class AMICAMLXNG:
 
         # Populated by fit()/_initialize_parameters().
         self.A = self.W = self.mu = self.alpha = self.beta = self.rho = None
-        self.gm = self.mean = self.sphere = None
+        self.gm = self.c = self.comp_list = self.mean = self.sphere = None
         self.sldet = 0.0
-        self._lgamma_table = None  # mx.array (n_mix, n_channels): lgamma(1+1/rho)
+        self._lgamma_table = None  # mx.array (n_mix, n_comps): lgamma(1+1/rho)
         self._logdet_W = None  # mx.array scalar: log|det W|, refreshed per iter
 
     _DEGENERATE_STOP_REASONS = ("nan_ll", "singular_ll", "nan_params")
@@ -223,9 +219,16 @@ class AMICAMLXNG:
         order as AMICATorchNG/AMICA_NumPy (core.py:688-725), so a shared seed
         gives a bit-identical (float32-cast) starting point."""
         rng = np.random.RandomState(self.seed)
-        n, ncomp, nmix = self.n_channels, self.n_comps, self.n_mix
+        n, m, ncomp, nmix = self.n_channels, self.n_models, self.n_comps, self.n_mix
 
-        A_np = np.eye(n) + 0.01 * (0.5 - rng.rand(n, n))
+        # Per-model mixing blocks + comp_list mapping each (channel, model) to its
+        # column in A (identical RNG draw order to AMICATorchNG; for m=1 the loop
+        # runs once, so single-model init stays byte-for-byte).
+        A_np = np.zeros((n, ncomp))
+        comp_list_np = np.zeros((n, m), dtype=np.int64)
+        for h in range(m):
+            A_np[:, h * n : (h + 1) * n] = np.eye(n) + 0.01 * (0.5 - rng.rand(n, n))
+            comp_list_np[:, h] = np.arange(h * n, (h + 1) * n)
 
         mu_np = np.zeros((nmix, ncomp))
         for k in range(ncomp):
@@ -237,11 +240,13 @@ class AMICAMLXNG:
         rho_np = self.rho0 * np.ones((nmix, ncomp))
 
         self.A = mx.array(A_np.astype(np.float32))
+        self.comp_list = mx.array(comp_list_np)  # (n_channels, n_models) int
         self.mu = mx.array(mu_np.astype(np.float32))
         self.alpha = mx.array(alpha_np.astype(np.float32))
         self.beta = mx.array(beta_np.astype(np.float32))
         self.rho = mx.array(rho_np.astype(np.float32))
-        self.gm = mx.array(np.ones(1, dtype=np.float32))
+        self.gm = mx.array((np.ones(m) / m).astype(np.float32))
+        self.c = mx.array(np.zeros((n, m), dtype=np.float32))
 
         self.lrate = self.lrate0
         self.lrate_cap = self.lrate0
@@ -252,84 +257,120 @@ class AMICAMLXNG:
 
     def _refresh_lgamma_table(self):
         """Recompute ``lgamma(1+1/rho)`` host-side (MLX has no lgamma). Called at
-        init and after every rho update. Cheap: rho is ``(n_mix, n_channels)``."""
+        init and after every rho update. Cheap: rho is ``(n_mix, n_comps)``."""
         rho_np = np.array(self.rho, dtype=np.float64)
         self._lgamma_table = mx.array(gammaln(1.0 + 1.0 / rho_np).astype(np.float32))
 
     def _update_unmixing_matrices(self):
-        """W = inv(A) and the LL Jacobian log|det W|, both on the CPU stream
-        (MLX linalg is CPU-only) and hoisted to once per iteration.
+        """Per-model ``W_h = inv(A[:, comp_list[:, h]])`` and the LL Jacobian
+        ``log|det W_h|``, on the CPU stream (MLX linalg is CPU-only), hoisted to
+        once per iteration. ``W`` is ``(n_models, n, n)`` and ``_logdet_W`` is
+        ``(n_models,)``. For n_models=1 this is ``inv(A)`` unchanged.
 
         These build lazy graph nodes; a singular ``A`` therefore raises not here
         but where the graph is materialized (the ``mx.eval`` in ``fit``), so a
         LinAlg traceback rooted in ``fit`` actually originates in this method.
         """
-        self.W = mx.linalg.inv(self.A, stream=_CPU)
-        self._logdet_W = mx.linalg.slogdet(self.W, stream=_CPU)[1]
+        ws, logdets = [], []
+        for h in range(self.n_models):
+            wh = mx.linalg.inv(self.A[:, self.comp_list[:, h]], stream=_CPU)
+            ws.append(wh)
+            logdets.append(mx.linalg.slogdet(wh, stream=_CPU)[1])
+        self.W = mx.stack(ws, axis=0)  # (n_models, n, n)
+        self._logdet_W = mx.stack(logdets)  # (n_models,)
 
     # ------------------------------------------------------------------
     # E-step
     # ------------------------------------------------------------------
     def _forward(self, Xb: mx.array):
-        """E-step forward pass for one block (single model). ``Xb`` is
-        ``(n_channels, batch)``. Returns ``(logV, b, z, y, az_rho)``."""
-        b = Xb.T @ self.W  # (batch, n_channels); c == 0 for single model
-        mu_h = self.mu.T[None]  # (1, n_channels, n_mix)
-        beta_h = self.beta.T[None]
-        rho_h = self.rho.T[None]
-        alpha_h = self.alpha.T[None]
-        lgamma_h = self._lgamma_table.T[None]
+        """E-step forward pass for one block, per model (AMICATorchNG._forward,
+        core.py:762-825). ``Xb`` is ``(n_channels, batch)``. Returns ``logV``
+        ``(batch, n_models)`` and per-model lists ``(b, z, y, az_rho)``. For
+        n_models=1 (c=0, gm=1, comp_list=identity) this is numerically identical
+        to the single-model path."""
+        b_list, z_list, y_list, azrho_list, logv_cols = [], [], [], [], []
+        for h in range(self.n_models):
+            idx = self.comp_list[:, h]
+            b = (Xb - self.c[:, h][:, None]).T @ self.W[h]  # (batch, n_channels)
+            mu_h = self.mu[:, idx].T[None]  # (1, n_channels, n_mix)
+            beta_h = self.beta[:, idx].T[None]
+            rho_h = self.rho[:, idx].T[None]
+            alpha_h = self.alpha[:, idx].T[None]
+            lgamma_h = self._lgamma_table[:, idx].T[None]
 
-        y = beta_h * (b[..., None] - mu_h)  # (batch, n_channels, n_mix)
-        log_pdf, az_rho = _log_pdf_gg(y, rho_h, lgamma_h)
-        z0 = mx.log(alpha_h) + mx.log(beta_h) + log_pdf
-        ll_i = mx.logsumexp(z0, axis=-1)  # (batch, n_channels)
-        z = mx.softmax(z0, axis=-1)
-        # Single model: log(gm)=0; logdet_W + sldet are the Jacobian terms.
-        logV = self._logdet_W + self.sldet + ll_i.sum(axis=-1)  # (batch,)
-        return logV, b, z, y, az_rho
+            y = beta_h * (b[..., None] - mu_h)  # (batch, n_channels, n_mix)
+            log_pdf, az_rho = _log_pdf_gg(y, rho_h, lgamma_h)
+            z0 = mx.log(alpha_h) + mx.log(beta_h) + log_pdf
+            ll_i = mx.logsumexp(z0, axis=-1)  # (batch, n_channels)
+            z = mx.softmax(z0, axis=-1)
+            logv_cols.append(
+                mx.log(self.gm[h]) + self._logdet_W[h] + self.sldet + ll_i.sum(axis=-1)
+            )
+            b_list.append(b)
+            z_list.append(z)
+            y_list.append(y)
+            azrho_list.append(az_rho)
+        logV = mx.stack(logv_cols, axis=1)  # (batch, n_models)
+        return logV, b_list, z_list, y_list, azrho_list
 
     def _get_block_updates(self, Xb: mx.array) -> dict:
-        """Exact-EM sufficient statistics for one block (single-model,
-        non-Newton subset of AMICATorchNG._get_block_updates, core.py:891-944;
-        the bias-c accumulator is excluded -- single-model has no c update)."""
-        logV, b, z, y, az_rho = self._forward(Xb)
-        block_ll = logV.sum()  # single model: logsumexp over one model is identity
-        beta_h = self.beta.T[None]  # (1, n_channels, n_mix)
-        rho_h = self.rho.T[None]
-
-        fp = _score_gg(y, rho_h)
-        u = z  # u = v*z with v == 1 (single model)
-        ufp = u * fp
-
-        dgm = mx.array(float(Xb.shape[1]), dtype=mx.float32)  # sum_t v_h = n samples
-        dalpha_n = u.sum(0).T  # (n_mix, n_channels)
-        dmu_n = ufp.sum(0).T
-        # Phase A guard: float32 can round y to exactly 0 (fp(0)=0 => ufp=0), so
-        # ufp/y is 0/0=NaN; where y==0, 0/1 contributes 0 (issue #75).
-        safe_y = mx.where(y == 0, mx.ones_like(y), y)
-        dmu_d = (beta_h[0] * (ufp / safe_y).sum(0)).T
-        dbeta_n = u.sum(0).T
-        dbeta_d = (ufp * y).sum(0).T
-
-        ay = mx.abs(y)
+        """Exact-EM sufficient statistics for one block (non-Newton subset of
+        AMICATorchNG._get_block_updates, core.py:833-953). Mixture stats are
+        scattered into their ``comp_list`` columns; ``dWtmp``/``dgm``/``dc_numer``
+        are per-model. For n_models=1 (v==1, identity comp_list) this reproduces
+        the single-model accumulators exactly."""
+        logV, b_list, z_list, y_list, azrho_list = self._forward(Xb)
+        block_ll = mx.logsumexp(logV, axis=1).sum()
+        v = mx.softmax(logV, axis=1)  # (batch, n_models) model responsibilities
+        nmix, ncomp = self.n_mix, self.n_comps
         tiny = float(np.finfo(np.float32).tiny)
-        logab = rho_h * mx.log(mx.maximum(ay, tiny))
-        logab = mx.where(az_rho < _EPSDBLE, mx.zeros_like(logab), logab)
-        drho_n = (u * (az_rho * logab)).sum(0).T
 
-        g = (beta_h * ufp).sum(-1)  # (batch, n_channels)
-        dWtmp = g.T @ b  # (n_channels, n_channels)
+        def zeros():
+            return mx.zeros((nmix, ncomp), dtype=mx.float32)
+
+        dalpha_n, dmu_n, dmu_d = zeros(), zeros(), zeros()
+        dbeta_n, dbeta_d, drho_n = zeros(), zeros(), zeros()
+        dgm_cols, dwtmp_mods, dc_cols = [], [], []
+
+        for h in range(self.n_models):
+            idx = self.comp_list[:, h]
+            b, zr, y, az_rho = b_list[h], z_list[h], y_list[h], azrho_list[h]
+            v_h = v[:, h]
+            beta_h = self.beta[:, idx].T[None]  # (1, n_channels, n_mix)
+            rho_h = self.rho[:, idx].T[None]
+
+            fp = _score_gg(y, rho_h)
+            u = v_h[:, None, None] * zr  # u = v*z, (batch, n_channels, n_mix)
+            ufp = u * fp
+
+            dgm_cols.append(v_h.sum())
+            dalpha_n = dalpha_n.at[:, idx].add(u.sum(0).T)
+            dmu_n = dmu_n.at[:, idx].add(ufp.sum(0).T)
+            # Phase A guard: float32 can round y to exactly 0 (fp(0)=0 => ufp=0),
+            # so ufp/y is 0/0=NaN; where y==0, 0/1 contributes 0 (issue #75).
+            safe_y = mx.where(y == 0, mx.ones_like(y), y)
+            dmu_d = dmu_d.at[:, idx].add((beta_h[0] * (ufp / safe_y).sum(0)).T)
+            dbeta_n = dbeta_n.at[:, idx].add(u.sum(0).T)
+            dbeta_d = dbeta_d.at[:, idx].add((ufp * y).sum(0).T)
+
+            logab = rho_h * mx.log(mx.maximum(mx.abs(y), tiny))
+            logab = mx.where(az_rho < _EPSDBLE, mx.zeros_like(logab), logab)
+            drho_n = drho_n.at[:, idx].add((u * (az_rho * logab)).sum(0).T)
+
+            g = (beta_h * ufp).sum(-1)  # (batch, n_channels)
+            dwtmp_mods.append(g.T @ b)  # (n_channels, n_channels)
+            dc_cols.append(Xb @ v_h)  # data-space bias numerator sum_t v_h*x
 
         return {
-            "dgm": dgm,
+            "dgm": mx.stack(dgm_cols),  # (n_models,)
             "dalpha_n": dalpha_n,
             "dmu_n": dmu_n,
             "dmu_d": dmu_d,
             "dbeta_n": dbeta_n,
             "dbeta_d": dbeta_d,
             "drho_n": drho_n,
-            "dWtmp": dWtmp,
+            "dWtmp": mx.stack(dwtmp_mods, axis=0),  # (n_models, n_ch, n_ch)
+            "dc_numer": mx.stack(dc_cols, axis=1),  # (n_channels, n_models)
             "ll": block_ll,
         }
 
@@ -352,9 +393,27 @@ class AMICAMLXNG:
     # M-step
     # ------------------------------------------------------------------
     def _update_parameters(self, acc: dict, n_samples: int):
-        """Exact-EM mixture updates + natural-gradient A-update (single-model,
-        non-Newton subset of AMICATorchNG._update_parameters, core.py:1049-1247)."""
-        self.gm = acc["dgm"] / n_samples  # == 1 for single model
+        """Exact-EM mixture updates + natural-gradient A-update (non-Newton subset
+        of AMICATorchNG._update_parameters, core.py:1049-1247)."""
+        self.gm = acc["dgm"] / n_samples  # (n_models,); == 1 for single model
+        tiny = float(np.finfo(np.float32).tiny)
+
+        # Per-model data-space bias c[i,h] = sum_t v_h*x / sum_t v_h (Fortran
+        # update_c, core.py:1083-1092). Skipped for n_models=1 (v==1 => c is the
+        # zero data mean; the update would add a float-sum residual and break the
+        # #24 bit-exact single-model path). A dead model (dgm[h]==0) keeps its
+        # prior c rather than writing 0/0, and is surfaced (matching AMICATorchNG).
+        if self.n_models > 1:
+            dgm = acc["dgm"]
+            live = dgm > 0.0
+            new_c = acc["dc_numer"] / mx.maximum(dgm, tiny)[None, :]
+            self.c = mx.where(live[None, :], new_c, self.c)
+            if not bool(mx.all(live).item()):
+                logger.warning(
+                    "Zero-responsibility model(s) at iter %d; kept their prior "
+                    "bias c (dead-model guard).",
+                    self.iteration,
+                )
 
         self.alpha = acc["dalpha_n"] / acc["dalpha_n"].sum(axis=0, keepdims=True)
         self.mu = self.mu + acc["dmu_n"] / acc["dmu_d"]
@@ -386,13 +445,25 @@ class AMICAMLXNG:
 
         # Natural-gradient A-update. A is stored as Fortran's A^T, so the update
         # is a LEFT-multiply by the transposed direction (core.py:1176-1184,
-        # #24 root cause). Single-model collapses the gm-weighted column average.
+        # #24 root cause). Each model's direction is scattered into its mixing
+        # columns as a gm-weighted average (Fortran dAk/zeta, core.py:1231-1247):
+        # for the default disjoint comp_list every column has one contributor, so
+        # gm cancels and n_models=1 is byte-for-byte the old `A - lrate*(dA.T@A)`.
         eye = mx.eye(self.n_channels)
-        dA = -acc["dWtmp"] / acc["dgm"] + eye  # I - <g b^T>/dgm
+        directions = [
+            -acc["dWtmp"][h] / acc["dgm"][h] + eye for h in range(self.n_models)
+        ]
         self.lrate = min(
             self.lrate_cap, self.lrate + min(1.0 / self.newt_ramp, self.lrate)
         )
-        self.A = self.A - self.lrate * (dA.T @ self.A)
+        dAk = mx.zeros_like(self.A)
+        zeta = mx.zeros((self.n_comps,), dtype=mx.float32)
+        for h in range(self.n_models):
+            idx = self.comp_list[:, h]
+            dAk = dAk.at[:, idx].add(self.gm[h] * (directions[h].T @ self.A[:, idx]))
+            zeta = zeta.at[idx].add(self.gm[h] + mx.zeros((self.n_channels,)))
+        dAk = dAk / mx.maximum(zeta, tiny)
+        self.A = self.A - self.lrate * dAk
 
         if self.doscaling and (self.iteration % self.scalestep == 0):
             scale = mx.sqrt((self.A**2).sum(axis=0))  # (n_comps,)
@@ -454,15 +525,26 @@ class AMICAMLXNG:
 
             self._update_parameters(acc, n_total)
             # One eval per iteration bounds the lazy graph to a single iteration's
-            # worth of ops (the updated params feed the next accumulate).
-            mx.eval(self.A, self.W, self.mu, self.alpha, self.beta, self.rho)
+            # worth of ops (the updated params feed the next accumulate). gm/c are
+            # included so their dependency chain is materialized each iteration too
+            # (c depends on the prior iteration's c), not left to grow unbounded.
+            mx.eval(
+                self.A,
+                self.W,
+                self.mu,
+                self.alpha,
+                self.beta,
+                self.rho,
+                self.gm,
+                self.c,
+            )
 
             # Surface a corrupted M-step (component collapse / float32 overflow)
             # at the iteration it happens. The ll check above only catches a
             # corruption via the NEXT iteration's E-step, so a final-iteration
             # blow-up would otherwise complete as max_iter with silently NaN
             # parameters (the torch backend has state_dict as a backstop; the
-            # MLX MVP does not, so guard in fit()). Params are already
+            # MLX backend does not, so guard in fit()). Params are already
             # materialized by the mx.eval above, so this is a cheap read.
             params_finite = (
                 mx.all(mx.isfinite(self.A))
@@ -470,6 +552,8 @@ class AMICAMLXNG:
                 & mx.all(mx.isfinite(self.alpha))
                 & mx.all(mx.isfinite(self.beta))
                 & mx.all(mx.isfinite(self.rho))
+                & mx.all(mx.isfinite(self.gm))
+                & mx.all(mx.isfinite(self.c))
             )
             if not bool(params_finite.item()):
                 logger.warning(
@@ -507,10 +591,10 @@ class AMICAMLXNG:
         return self
 
     def transform(self, X: np.ndarray, model_idx: int = 0) -> np.ndarray:
-        """Not in the v1 MVP -- fail with a clear boundary rather than a bare
+        """Not yet implemented -- fail with a clear boundary rather than a bare
         AttributeError. Use ``AMICATorchNG.transform`` for source extraction; the
-        MLX backend (issue #76) validates via ``final_ll_``/``ll_history``."""
+        MLX backend validates via ``final_ll_``/``ll_history``."""
         raise NotImplementedError(
-            "AMICAMLXNG (v1) does not implement transform yet; it is a "
-            "fast-follow. Use AMICATorchNG for source extraction."
+            "AMICAMLXNG does not implement transform yet; it is a fast-follow. "
+            "Use AMICATorchNG for source extraction."
         )

--- a/pyAMICA/tests/mlx_tests/test_mlx_backend.py
+++ b/pyAMICA/tests/mlx_tests/test_mlx_backend.py
@@ -1,0 +1,149 @@
+"""MLX backend (AMICAMLXNG) tests -- issue #76, epic #74 Phase C.
+
+Apple-Silicon only. Real sample EEG (no synthetic/mock). The whole module
+self-skips when MLX or an Apple GPU is unavailable, so CI on ubuntu skips it.
+
+Correctness is checked two ways: the per-block sufficient statistics match the
+validated NumPy float64 reference (tight, independent oracle), and a full fit's
+converged log-likelihood matches the PyTorch float32 backend (the epic's
+backend-vs-backend acceptance).
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+SAMPLE_DIR = Path(__file__).resolve().parents[2] / "sample_data"
+DATA_FILE = SAMPLE_DIR / "eeglab_data.fdt"
+NW = 32
+FIELD = 30504
+NMIX = 3
+SEED = 42
+
+pytestmark = [
+    pytest.mark.skipif(not DATA_FILE.exists(), reason="sample data missing"),
+    pytest.mark.skipif(
+        mx.default_device().type != mx.DeviceType.gpu, reason="no Apple GPU"
+    ),
+]
+
+# Sufficient-stat keys the MLX backend produces (single-model, non-Newton).
+_STAT_KEYS = [
+    "dgm",
+    "dalpha_n",
+    "dmu_n",
+    "dmu_d",
+    "dbeta_n",
+    "dbeta_d",
+    "drho_n",
+    "dWtmp",
+]
+
+
+def _load_real_data() -> np.ndarray:
+    from pyAMICA.torch_impl.utils import load_eeglab_data
+
+    return load_eeglab_data(str(DATA_FILE), data_dim=NW, field_dim=FIELD).astype(
+        np.float64
+    )
+
+
+def test_mvp_rejects_unsupported_config():
+    """The v1 MVP boundaries fail loudly, not silently."""
+    from pyAMICA.mlx_impl import AMICAMLXNG
+
+    for kw in ({"n_models": 2}, {"do_newton": True}, {"pdftype": 2, "n_mix": NMIX}):
+        with pytest.raises(NotImplementedError):
+            AMICAMLXNG(n_channels=NW, n_mix=kw.pop("n_mix", 1), **kw)
+
+
+def test_sufficient_stats_match_numpy_reference():
+    """Tight algorithmic faithfulness: the MLX (float32) per-block sufficient
+    statistics match the validated NumPy float64 reference on an identical block
+    with identical (shared-seed) parameters. rtol=1e-3 accommodates float32
+    vs float64 (measured max relerr ~1.6e-4 on dWtmp/dmu_d)."""
+    from pyAMICA.mlx_impl import AMICAMLXNG
+    from pyAMICA.numpy_impl.core import AMICA as AMICA_NumPy
+
+    data = _load_real_data()
+    m = AMICAMLXNG(n_channels=NW, n_mix=NMIX, seed=SEED, block_size=256)
+    x_t = m._preprocess(data)
+    m._initialize_parameters()
+
+    blk = 256
+    block = np.array(x_t[:, :blk])  # float32 sphered block, on host
+    mlx_upd = m._get_block_updates(mx.array(block))
+
+    npm = AMICA_NumPy(num_models=1, num_mix=NMIX, do_newton=False)
+    npm.data_dim = NW
+    npm.num_comps = NW
+    npm.num_models = 1
+    npm.num_mix = NMIX
+    npm.block_size = blk
+    npm.comp_list = np.arange(NW).reshape(NW, 1)
+    npm.A = np.array(m.A, dtype=np.float64)
+    npm.W = np.array(m.W, dtype=np.float64)[:, :, None]  # NumPy expects (n,n,models)
+    npm.c = np.zeros((NW, 1))
+    npm.mu = np.array(m.mu, dtype=np.float64)
+    npm.alpha = np.array(m.alpha, dtype=np.float64)
+    npm.beta = np.array(m.beta, dtype=np.float64)
+    npm.rho = np.array(m.rho, dtype=np.float64)
+    npm.gm = np.array(m.gm, dtype=np.float64)
+    np_upd = npm._get_block_updates(block.astype(np.float64))
+
+    for key in _STAT_KEYS:
+        a = np.asarray(np.array(mlx_upd[key]), dtype=np.float64)
+        b = np.asarray(np_upd[key], dtype=np.float64).reshape(a.shape)
+        assert np.allclose(a, b, rtol=1e-3, atol=1e-4), (
+            f"{key} differs from NumPy reference by {np.max(np.abs(a - b)):.3e}"
+        )
+
+
+def test_backend_stable_on_full_data():
+    """The MLX backend fits the full 30504-sample EEG on the Apple GPU (float32)
+    without diverging (the Phase A ``ufp/y`` guard is carried into MLX), and the
+    log-likelihood improves over the run."""
+    from pyAMICA.mlx_impl import AMICAMLXNG
+
+    m = AMICAMLXNG(n_channels=NW, n_mix=NMIX, seed=SEED)
+    m.fit(_load_real_data(), max_iter=100, verbose=False)
+
+    hist = np.asarray(m.ll_history, dtype=float)
+    assert np.all(np.isfinite(hist))
+    assert np.isfinite(m.final_ll_)
+    assert np.all(np.isfinite(np.array(m.A)))
+    assert m.stop_reason not in AMICAMLXNG._DEGENERATE_STOP_REASONS
+    assert hist[-1] > hist[0]  # ascent
+
+
+def test_converged_ll_matches_torch_float32():
+    """Epic acceptance: the MLX backend is equivalent to the PyTorch float32
+    backend. At matched settings/seed both reach the same natural-gradient GG
+    fixed point; the converged per-sample-per-channel LL agrees within 1e-2
+    (measured gap ~2e-6). Bit-identity is impossible (GPU-vs-CPU float32 +
+    reduction order), so the tolerance is relational, never a hardcoded LL."""
+    import torch
+
+    from pyAMICA.mlx_impl import AMICAMLXNG
+    from pyAMICA.torch_impl import AMICATorchNG
+
+    data = _load_real_data()
+    mlx_m = AMICAMLXNG(n_channels=NW, n_mix=NMIX, seed=SEED)
+    mlx_m.fit(data, max_iter=100, verbose=False)
+
+    torch_m = AMICATorchNG(
+        n_channels=NW,
+        n_models=1,
+        n_mix=NMIX,
+        seed=SEED,
+        device="cpu",
+        dtype=torch.float32,
+        do_newton=False,
+    )
+    torch_m.fit(data, max_iter=100, verbose=False)
+
+    assert np.isfinite(mlx_m.final_ll_)
+    assert abs(mlx_m.final_ll_ - torch_m.final_ll_) < 1e-2

--- a/pyAMICA/tests/mlx_tests/test_mlx_backend.py
+++ b/pyAMICA/tests/mlx_tests/test_mlx_backend.py
@@ -51,11 +51,12 @@ def _load_real_data() -> np.ndarray:
     )
 
 
-def test_mvp_rejects_unsupported_config():
-    """The v1 MVP boundaries fail loudly, not silently."""
+def test_rejects_unsupported_config():
+    """The still-deferred configs (Newton, non-GG families) fail loudly, not
+    silently. Multi-model IS supported (issue #81), so it is not rejected."""
     from pyAMICA.mlx_impl import AMICAMLXNG
 
-    for kw in ({"n_models": 2}, {"do_newton": True}, {"pdftype": 2, "n_mix": NMIX}):
+    for kw in ({"do_newton": True}, {"pdftype": 2, "n_mix": NMIX}):
         with pytest.raises(NotImplementedError):
             AMICAMLXNG(n_channels=NW, n_mix=kw.pop("n_mix", 1), **kw)
 
@@ -85,7 +86,8 @@ def test_sufficient_stats_match_numpy_reference():
     npm.block_size = blk
     npm.comp_list = np.arange(NW).reshape(NW, 1)
     npm.A = np.array(m.A, dtype=np.float64)
-    npm.W = np.array(m.W, dtype=np.float64)[:, :, None]  # NumPy expects (n,n,models)
+    # MLX W is (n_models, n, n); NumPy expects (n, n, n_models).
+    npm.W = np.array(m.W, dtype=np.float64).transpose(1, 2, 0)
     npm.c = np.zeros((NW, 1))
     npm.mu = np.array(m.mu, dtype=np.float64)
     npm.alpha = np.array(m.alpha, dtype=np.float64)
@@ -117,6 +119,9 @@ def test_backend_stable_on_full_data():
     assert np.all(np.isfinite(np.array(m.A)))
     assert m.stop_reason not in AMICAMLXNG._DEGENERATE_STOP_REASONS
     assert hist[-1] > hist[0]  # ascent
+    # Single-model must never touch the bias c (the n_models>1-only update); a
+    # nonzero c would signal the #24 bit-exact single-model path was perturbed.
+    assert np.all(np.array(m.c) == 0.0)
 
 
 def test_converged_ll_matches_torch_float32():
@@ -147,3 +152,86 @@ def test_converged_ll_matches_torch_float32():
 
     assert np.isfinite(mlx_m.final_ll_)
     assert abs(mlx_m.final_ll_ - torch_m.final_ll_) < 1e-2
+
+
+def test_multimodel_matches_torch_float32():
+    """Multi-model (n_models=2) MLX matches the PyTorch float32 backend (issue
+    #81): the one-iteration sufficient stats agree to float32 precision, and the
+    converged LL matches (measured gap ~1e-5). Single-model stays byte-identical
+    (covered by the tests above)."""
+    import torch
+
+    from pyAMICA.mlx_impl import AMICAMLXNG
+    from pyAMICA.torch_impl import AMICATorchNG
+
+    data = _load_real_data()
+    m = 2
+
+    # One iteration of sufficient stats from identical (shared-seed) init.
+    mlx_m = AMICAMLXNG(n_channels=NW, n_models=m, n_mix=NMIX, seed=SEED, block_size=512)
+    xt = mlx_m._preprocess(data)
+    mlx_m._initialize_parameters()
+    ma = mlx_m._accumulate_blocks(xt)
+
+    ng = AMICATorchNG(
+        n_channels=NW,
+        n_models=m,
+        n_mix=NMIX,
+        seed=SEED,
+        device="cpu",
+        dtype=torch.float32,
+        do_newton=False,
+        block_size=512,
+    )
+    xt2 = ng._preprocess(data)
+    ng._initialize_parameters()
+    na = ng._accumulate_blocks(xt2)
+    # Every accumulator, including dWtmp (input to the gm-weighted comp_list A
+    # scatter) and the scattered mixture stats. rtol=5e-3 (looser than the 1e-3
+    # single-model-vs-numpy check) because this compares two float32 backends on
+    # different devices, whose reduction orders diverge more than float32-vs-f64.
+    for key in (
+        "dgm",
+        "dalpha_n",
+        "dmu_n",
+        "dmu_d",
+        "dbeta_d",
+        "drho_n",
+        "dc_numer",
+        "dWtmp",
+    ):
+        a = np.asarray(np.array(ma[key]), dtype=np.float64)
+        b = na[key].cpu().numpy().astype(np.float64)
+        if key == "dWtmp":  # torch (n, n, n_models) -> MLX (n_models, n, n)
+            b = np.transpose(b, (2, 0, 1))
+        assert np.allclose(a, b.reshape(a.shape), rtol=5e-3, atol=1e-4), (
+            f"{key}: {np.abs(a - b.reshape(a.shape)).max():.2e}"
+        )
+
+    # The per-model bias c update (the n_models>1-only formula) is the
+    # responsibility-weighted data mean c[:,h] = sum_t v_h*x / sum_t v_h, and the
+    # two models' c must differ (a would-be no-op would leave them equal at 0).
+    mlx_m._update_parameters(ma, xt.shape[1])
+    c = np.array(mlx_m.c)
+    dc = np.array(ma["dc_numer"]) / np.array(ma["dgm"])[None, :]
+    assert np.allclose(c, dc, rtol=1e-5, atol=1e-6)
+    assert not np.allclose(c[:, 0], c[:, 1])
+
+    # Converged LL (multi-model is not partition-identifiable, but at matched
+    # init/settings both backends track the same trajectory).
+    mlx_c = AMICAMLXNG(n_channels=NW, n_models=m, n_mix=NMIX, seed=SEED)
+    mlx_c.fit(data, max_iter=60, verbose=False)
+    ng_c = AMICATorchNG(
+        n_channels=NW,
+        n_models=m,
+        n_mix=NMIX,
+        seed=SEED,
+        device="cpu",
+        dtype=torch.float32,
+        do_newton=False,
+        keep_best=False,
+    )
+    ng_c.fit(data, max_iter=60, verbose=False)
+    assert np.isfinite(mlx_c.final_ll_)
+    assert mlx_c.stop_reason not in AMICAMLXNG._DEGENERATE_STOP_REASONS
+    assert abs(mlx_c.final_ll_ - ng_c.final_ll_) < 1e-2

--- a/pyAMICA/tests/mlx_tests/test_mlx_backend.py
+++ b/pyAMICA/tests/mlx_tests/test_mlx_backend.py
@@ -235,3 +235,68 @@ def test_multimodel_matches_torch_float32():
     assert np.isfinite(mlx_c.final_ll_)
     assert mlx_c.stop_reason not in AMICAMLXNG._DEGENERATE_STOP_REASONS
     assert abs(mlx_c.final_ll_ - ng_c.final_ll_) < 1e-2
+
+
+def test_degenerate_fit_stops_and_reports_nan():
+    """A NaN in the data drives fit() to a degenerate stop with a NaN final_ll,
+    exercising the MLX degenerate-stop machinery (the same path the new
+    ``nan_params`` guard uses) rather than only the happy path. Sphering/mean are
+    off so the NaN reaches the E-step (numpy eigh would otherwise raise on it)."""
+    from pyAMICA.mlx_impl import AMICAMLXNG
+
+    data = _load_real_data()[:, :4096].copy()
+    data[0, 0] = np.nan
+    m = AMICAMLXNG(n_channels=NW, n_mix=NMIX, seed=SEED, do_sphere=False, do_mean=False)
+    m.fit(data, max_iter=5, verbose=False)
+    assert m.stop_reason in AMICAMLXNG._DEGENERATE_STOP_REASONS
+    assert np.isnan(m.final_ll_)
+
+
+def test_init_matches_torch_seed():
+    """Pin the shared-seed init contract directly: AMICAMLXNG and AMICATorchNG
+    produce the same starting A/mu/alpha/beta/rho (same RNG draw order), for both
+    single- and multi-model -- rather than inferring it from downstream LL."""
+    import torch
+
+    from pyAMICA.mlx_impl import AMICAMLXNG
+    from pyAMICA.torch_impl import AMICATorchNG
+
+    data = _load_real_data()
+    for nm in (1, 2):
+        mlx_m = AMICAMLXNG(n_channels=NW, n_models=nm, n_mix=NMIX, seed=SEED)
+        mlx_m._preprocess(data)
+        mlx_m._initialize_parameters()
+        ng = AMICATorchNG(
+            n_channels=NW,
+            n_models=nm,
+            n_mix=NMIX,
+            seed=SEED,
+            device="cpu",
+            dtype=torch.float32,
+        )
+        ng._preprocess(data)
+        ng._initialize_parameters()
+        for attr in ("A", "mu", "alpha", "beta", "rho"):
+            a = np.array(getattr(mlx_m, attr))
+            b = getattr(ng, attr).cpu().numpy()
+            assert np.allclose(a, b, atol=1e-6), f"{attr} init differs (n_models={nm})"
+
+
+def test_multimodel_dead_model_keeps_prior_c():
+    """A zero-responsibility model (dgm[h]==0) keeps its prior bias c rather than
+    writing 0/0 (the dead-model guard), mirroring AMICATorchNG."""
+    from pyAMICA.mlx_impl import AMICAMLXNG
+
+    data = _load_real_data()
+    m = AMICAMLXNG(n_channels=NW, n_models=2, n_mix=NMIX, seed=SEED)
+    xt = m._preprocess(data)
+    m._initialize_parameters()
+    acc = m._accumulate_blocks(xt)
+    # Kill model 1's responsibility mass and give it a marker prior c.
+    dgm = np.array(acc["dgm"], dtype=np.float32)
+    dgm[1] = 0.0
+    acc["dgm"] = mx.array(dgm)
+    marker = np.arange(NW, dtype=np.float32) + 1.0
+    m.c = mx.array(np.stack([np.zeros(NW, np.float32), marker], axis=1))
+    m._update_parameters(acc, xt.shape[1])
+    assert np.allclose(np.array(m.c)[:, 1], marker)  # dead model kept its prior c

--- a/pyAMICA/tests/torch_tests/test_ng_float32_stability.py
+++ b/pyAMICA/tests/torch_tests/test_ng_float32_stability.py
@@ -1,0 +1,135 @@
+"""float32 full-data stability (issue #75, epic #74 Phase A).
+
+Before #75, ``AMICATorchNG`` in float32 diverged to NaN on the full 30504-sample
+sample EEG across every seed (Newton on and off, crashing iter ~9-105), while
+float64 converged. Root cause: at a sample sitting on a mixture mean, float32
+rounds the scaled activation ``y`` to *exactly* 0, and the score ``fp(0)=0`` (for
+the supported ``rho >= 1``), so the mu-denominator term ``ufp/y`` is ``0/0 = NaN``
+(float64 never hits exact 0). Diagnostics (`.context/issue-63/`, `.context/mps_pathways.md`)
+ruled out summation precision: accumulating the block sufficient statistics in
+float64 did *not* help, but guarding that single division does. The guard is a
+no-op in float64 (bit-identical, so single-model #24 parity is preserved) and
+needs no float64, so it also stabilizes the MPS/float32 path.
+
+Real sample EEG only (no synthetic/mock). The full-data fit is the only regime
+that reproduces the divergence, so it is the necessary regression surface.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from pyAMICA.torch_impl import AMICATorchNG
+from pyAMICA.torch_impl.core import _score
+from pyAMICA.torch_impl.utils import load_eeglab_data
+
+SAMPLE_DIR = Path(__file__).resolve().parents[2] / "sample_data"
+DATA_FILE = SAMPLE_DIR / "eeglab_data.fdt"
+NW = 32
+FIELD = 30504
+# Past the historical divergence window (naive float32 crashed by iter ~105); a
+# reintroduced 0/0 would surface as a nan_ll stop well within this budget.
+MAX_ITER = 150
+# Reference the backend's own set so a new degenerate stop reason cannot go stale.
+_DEGENERATE = AMICATorchNG._DEGENERATE_STOP_REASONS
+
+
+@pytest.fixture(scope="module")
+def real_data() -> np.ndarray:
+    if not DATA_FILE.exists():
+        pytest.skip("sample data missing")
+    return load_eeglab_data(str(DATA_FILE), data_dim=NW, field_dim=FIELD).astype(
+        np.float64
+    )
+
+
+def _fit(data, dtype, seed, do_newton, device="cpu", max_iter=MAX_ITER, n_samples=None):
+    m = AMICATorchNG(
+        n_channels=NW,
+        n_models=1,
+        n_mix=3,
+        device=device,
+        dtype=dtype,
+        do_newton=do_newton,
+        seed=seed,
+    )
+    x = data if n_samples is None else data[:, :n_samples]
+    m.fit(x, max_iter=max_iter, verbose=False)
+    return m
+
+
+# --- the invariant the guard relies on --------------------------------------
+
+
+def test_score_is_zero_at_zero_activation():
+    """``fp(0)=0`` for every family at the supported ``rho >= 1``, so at ``y==0``
+    the numerator ``ufp=u*fp`` is 0 too and the guarded ``ufp/1`` contributes 0
+    (not ``0/0=NaN``). (For an unsupported ``rho < 1`` the GG ``fp`` is itself
+    NaN at 0, which the guard does not and need not address.)"""
+    y = torch.zeros(4, dtype=torch.float32)
+    for rho in (1.0, 1.5, 2.0):  # Laplace, GG, Gaussian (pdtype None path)
+        assert torch.all(_score(y, torch.full_like(y, rho)) == 0)
+    for pdtype in (1, 2, 3, 4):  # the fixed families
+        fp = _score(y, torch.full_like(y, 1.5), torch.full((4,), pdtype))
+        assert torch.all(fp == 0)
+
+
+# --- the regression: full-data float32 no longer diverges -------------------
+
+# Five distinct seeds spanning both Newton settings. The 0/0 is in the always-on
+# E-step accumulation (Newton-independent), so the full 5x2 cross-product is
+# unnecessary CI cost; this still covers >=5 seeds with Newton on and off.
+_STABILITY_CASES = [(1, True), (2, False), (3, True), (4, False), (5, True)]
+
+
+@pytest.mark.parametrize("seed,do_newton", _STABILITY_CASES)
+def test_float32_stable_on_full_data(real_data, seed, do_newton):
+    m = _fit(real_data, torch.float32, seed, do_newton)
+    assert np.all(np.isfinite(np.asarray(m.ll_history, dtype=float)))
+    assert np.isfinite(m.final_ll_)
+    assert torch.isfinite(m.A).all()
+    # The exact failure mode was a nan_ll stop; a singular W would also be wrong.
+    assert m.stop_reason not in _DEGENERATE
+
+
+# --- quality: float32 tracks the float64 optimum ----------------------------
+
+
+@pytest.mark.parametrize("do_newton", [False, True])
+def test_float32_ll_matches_float64(real_data, do_newton):
+    seed = 0
+    # This quality check does not need the full divergence window (that is the
+    # sweep above); float32 tracks float64 from the first iteration, so a shorter
+    # matched budget keeps the two extra float64 fits cheap in CI.
+    f32 = _fit(real_data, torch.float32, seed, do_newton, max_iter=100)
+    f64 = _fit(real_data, torch.float64, seed, do_newton, max_iter=100)
+    # Relational to the in-test float64 fit, never a hardcoded LL. One-sided
+    # "not materially worse" is load-bearing; the trajectories diverge only
+    # chaotically, so the two-sided band is a loose sanity guard.
+    assert f32.final_ll_ >= f64.final_ll_ - 0.05
+    assert abs(f32.final_ll_ - f64.final_ll_) < 0.1
+
+
+# --- MPS smoke: the actual Apple-GPU target (self-skips in CI) ---------------
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="MPS device not available"
+)
+def test_float32_mps_smoke(real_data):
+    """float32 on MPS (no float64 on Apple GPUs) stays finite. Short slice/iters:
+    a smoke check that the guard also holds on-device, not a convergence gate."""
+    m = _fit(
+        real_data,
+        torch.float32,
+        seed=1,
+        do_newton=True,
+        device="mps",
+        max_iter=30,
+        n_samples=8192,
+    )
+    assert np.isfinite(m.final_ll_)
+    assert torch.isfinite(m.A).all()
+    assert m.stop_reason not in _DEGENERATE

--- a/pyAMICA/torch_impl/core.py
+++ b/pyAMICA/torch_impl/core.py
@@ -23,7 +23,9 @@ Key design points (see ``.context/decisions/0001-torch-backend-natural-gradient-
   across blocks, so peak memory scales with ``block_size``, not with the
   total number of samples.
 * Parameters default to float64 for numerical parity with Fortran's
-  double-precision arithmetic; float32 is available for speed.
+  double-precision arithmetic; float32 is available for speed and for MPS
+  (which has no float64), stabilized on full-size data by the mu-denominator
+  divide-by-zero guard in ``_get_block_updates`` (issue #75).
 
 Log-likelihood: this module computes the per-source log-likelihood from the
 pre-normalization mixture logits via ``logsumexp`` plus the ``log|det W|`` +
@@ -380,12 +382,14 @@ class AMICATorchNG:
         always done in float64 on CPU regardless of device, since eigh is
         not reliably supported on MPS.
     dtype : torch.dtype, default=torch.float64
-        Parameter/computation dtype. float64 is the parity default and the
-        reliable choice (float64-CUDA is ~4.5x over CPU, issue #63). float32 is
-        faster still but EXPERIMENTAL: the natural-gradient EM is precision-
-        limited and diverges to NaN on full-size data (any seed, Newton on/off,
-        issue #70), so use it only for small slices or on MPS (which cannot
-        represent float64). MPS also requires float32.
+        Parameter/computation dtype. float64 is the parity default (Fortran
+        bit-parity) and ~4.5x on CUDA over CPU (issue #63). float32 converges on
+        full-size data across seeds (issue #75 guarded the one float32-only
+        divide-by-zero -- a sample rounding an activation to exactly 0 gave
+        ``0/0`` in the mu denominator) and is the required precision on MPS,
+        which has no float64. float32 is NOT bit-parity with float64 (~7
+        significant digits), so use float64 for Fortran-parity runs and float32
+        for speed / Apple-GPU.
     """
 
     def __init__(
@@ -899,8 +903,24 @@ class AMICATorchNG:
             dgm[h] = v_h.sum()
             dalpha_n.index_add_(1, idx, u.sum(0).T)  # sum(u) (:1524)
             dmu_n.index_add_(1, idx, ufp.sum(0).T)  # sum(ufp) (:1532)
+            # mu denominator sbeta*sum(ufp/y) (:1537). In float32 a sample sitting
+            # on a mixture mean can round y to *exactly* 0; the score fp(0)=0 (for
+            # the supported rho>=1), so the raw ufp/y is 0/0 = NaN -- the sole
+            # trigger of the full-data float32 divergence (issue #75; NOT a
+            # summation-precision problem, so compensated accumulation does not
+            # help). The true term ufp/y = u*rho*|y|^(rho-2) is NOT 0 in the limit:
+            # a nonzero constant at rho==2, and an integrable singularity that
+            # diverges as y->0 for rho<2 -- so once y underflows to exactly 0 the
+            # real contribution is unrepresentable. Substituting 0 (ufp==0 there,
+            # so 0/1) drops that one sample instead of poisoning all of dmu_d with a
+            # NaN: a bounded, empirically negligible bias (it fires <=1 sample per
+            # iteration on the sample EEG, and float32 still matches the float64 LL
+            # to ~5 sig digits). float64 never rounds y to exactly 0, so the guard
+            # is a bit-identical no-op there (single-model #24 parity preserved),
+            # and it needs no float64, so it also stabilizes the MPS/float32 path.
+            safe_y = torch.where(y == 0, torch.ones_like(y), y)
             dmu_d.index_add_(
-                1, idx, (beta_h.squeeze(0) * (ufp / y).sum(0)).T
+                1, idx, (beta_h.squeeze(0) * (ufp / safe_y).sum(0)).T
             )  # (:1537)
             dbeta_n.index_add_(1, idx, u.sum(0).T)  # sum(u) (:1550)
             dbeta_d.index_add_(1, idx, (ufp * y).sum(0).T)  # sum(ufp*y) (:1556)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,12 @@ dependencies = [
     "torch>=2.12.1",
 ]
 
+# Optional Apple-Silicon GPU backend (AMICAMLXNG). MLX is Apple-only, so it is
+# NOT a core dependency; install with `uv pip install mlx` or `pip install
+# pyAMICA[mlx]`. `import pyAMICA` never requires it (mlx_impl is imported lazily).
+[project.optional-dependencies]
+mlx = ["mlx>=0.32"]
+
 [project.urls]
 Homepage = "http://github.com/neuromechanist/pyAMICA"
 Repository = "http://github.com/neuromechanist/pyAMICA"
@@ -40,7 +46,7 @@ Repository = "http://github.com/neuromechanist/pyAMICA"
 [tool.setuptools]
 # List subpackages explicitly so the wheel is deterministic across platforms
 # (a bare ["pyAMICA"] dropped torch_impl/ on some setuptools versions).
-packages = ["pyAMICA", "pyAMICA.numpy_impl", "pyAMICA.torch_impl"]
+packages = ["pyAMICA", "pyAMICA.numpy_impl", "pyAMICA.torch_impl", "pyAMICA.mlx_impl"]
 # numpy_impl/params.json is the NumPy backend's default parameter file, loaded at
 # runtime via importlib/__file__, so it must ship in the wheel.
 package-data = {"pyAMICA" = ["data/*"], "pyAMICA.numpy_impl" = ["params.json"]}
@@ -60,6 +66,10 @@ omit = [
     "pyAMICA/tests/*",
     # argparse CLI entrypoint: exercised via subprocess, not unit-covered here.
     "pyAMICA/numpy_impl/cli.py",
+    # Optional MLX backend (Apple Silicon only): its tests require MLX + an Apple
+    # GPU, so CI (ubuntu, no mlx) cannot exercise it and always measures 0%. It is
+    # covered locally by tests/mlx_tests/ on Apple hardware (issue #76).
+    "pyAMICA/mlx_impl/*",
 ]
 
 [tool.coverage.report]

--- a/uv.lock
+++ b/uv.lock
@@ -523,6 +523,47 @@ wheels = [
 ]
 
 [[package]]
+name = "mlx"
+version = "0.32.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mlx-metal", marker = "sys_platform == 'darwin'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/a6/489176d8a2a06137a299910057cc44dc3fccfb73151f7562fea2b75894d9/mlx-0.32.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:ea5a594355c89c0095eaba413fd39d4caa8642fa13432dfb0c9354d141046467", size = 558889, upload-time = "2026-07-07T17:55:45.268Z" },
+    { url = "https://files.pythonhosted.org/packages/85/2a/5d1f1cb1b073c39c822e0c0be1e68f4ced6fd32ab15cf8bb1f448028842c/mlx-0.32.0-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:e5f778001562ccce26cf6e5be1050d2afc78e2902bad206201ab9f5a6d0f886a", size = 558890, upload-time = "2026-07-07T17:55:46.701Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/01/02110ceacf4efd00ec172f60b4cd42c8b1509ac50ffa65a6a77d723133aa/mlx-0.32.0-cp312-cp312-macosx_26_0_arm64.whl", hash = "sha256:8dfb577faa4dc413cfd0d6eb78f230d3b3b6169df4473e84408abdeb21346e9d", size = 558856, upload-time = "2026-07-07T17:55:48.09Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/af/b16b7ab2670edf0f8f2cdeb2b6b3d5ab27a749b31ed74cb6825958ca0892/mlx-0.32.0-cp312-cp312-manylinux_2_35_aarch64.whl", hash = "sha256:50bc29bfaf31dff5138a472b56963bd6ece0fa67800c6c382745aaa41126d01f", size = 617769, upload-time = "2026-07-07T17:55:49.596Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ef/c326e05070f35c43a9775ce9dceaf155c8a9b2706a4c52d64e8999d4929a/mlx-0.32.0-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:78804098c9f64978b6048ffdfd78689b9e06efa2a530c541d0bd73ce44d2f589", size = 675402, upload-time = "2026-07-07T17:55:51.148Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/e9/04cd133d18b4da1c00515c595c1cb6de7e2534938d2c3de2f3f2301c3466/mlx-0.32.0-cp312-cp312-win_amd64.whl", hash = "sha256:13ac6469479cda4bfd6954e0b574b92930b87073f7c79be121a68b31a3a6c596", size = 558048, upload-time = "2026-07-07T17:55:52.471Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f6/f27397f44c84138bcae00592a377fc5b1fc79d1dbfa820c1af20042f4c33/mlx-0.32.0-cp312-cp312-win_arm64.whl", hash = "sha256:7c8d3a7b506ab45b3f7976495126c16830d988ec53289134b2bb64dae1efb835", size = 543631, upload-time = "2026-07-07T17:55:53.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/be/ddc888d4a20c7602da06ad1a244f495010c6c7d2457f6253e8fa3c99ceea/mlx-0.32.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:abb786ee1e9638759be82583222fc7d09c5650ef90ad2b7c5da7d1931a8676dc", size = 558795, upload-time = "2026-07-07T17:55:54.907Z" },
+    { url = "https://files.pythonhosted.org/packages/38/b9/4f0ae7785fdb3fa7e44434908d832cbc7a9a1e096d046ac6fe953812c52c/mlx-0.32.0-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:deb284f3a5cd0c3e87bed80c2bee9dcbf946bdad44d75592f6fb784da878c1c0", size = 558799, upload-time = "2026-07-07T17:55:56.844Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/a8/7bc999ce5d09dfac8961dcda4ed47e173fca2857492f34599b237380f20d/mlx-0.32.0-cp313-cp313-macosx_26_0_arm64.whl", hash = "sha256:4192a2d02014a13a6a1030bf13dfb4e4fe05ec3ffa47678ee37da29111e25cb1", size = 558786, upload-time = "2026-07-07T17:55:58.272Z" },
+    { url = "https://files.pythonhosted.org/packages/83/cf/90980e28e6adaaf47d7951604ff2ac4ceb3952040f941bececb9b7a07a4c/mlx-0.32.0-cp313-cp313-manylinux_2_35_aarch64.whl", hash = "sha256:102043c6455fe0939509c1e96caec4678f51e241981238da97c83beeed5653f6", size = 617228, upload-time = "2026-07-07T17:55:59.603Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fa/e3608936caa02ebf7fc645e3289134918facb0cff6dcb563d51996a5b70e/mlx-0.32.0-cp313-cp313-manylinux_2_35_x86_64.whl", hash = "sha256:e5cdb9bf7c1a9320827a65f7ed63e3742d5b9280d31affc0c277e77982d465ae", size = 675294, upload-time = "2026-07-07T17:56:00.993Z" },
+    { url = "https://files.pythonhosted.org/packages/65/96/4979a82390a69e7ff48a43d3ea5cac222ae6bc41c2ba56550f6f5bd416b3/mlx-0.32.0-cp313-cp313-win_amd64.whl", hash = "sha256:9fea39d8ecf1d08e5c3d5d70936d5a1ca6b890353c1b0b96c4e6232349d48e36", size = 558017, upload-time = "2026-07-07T17:56:02.307Z" },
+    { url = "https://files.pythonhosted.org/packages/15/94/1b2a1e3b60fce6bd61ca8af3ccfe0da30f42184352a70123870fd960ce0d/mlx-0.32.0-cp313-cp313-win_arm64.whl", hash = "sha256:df6fa6785fb7a6f8d8e3e91c41074c885aa253b09c2b69e3c4d4f905e3c457e3", size = 543559, upload-time = "2026-07-07T17:56:03.644Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/90/5e49c183f9024f86dc1f038866ccd743aaec1fe412a7e7dc76fec9271f48/mlx-0.32.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2ee79b1f8c2c2a329afc95ece7dce0be798d43f3de771a6370d2b9f9702bbd9a", size = 561387, upload-time = "2026-07-07T17:56:05.177Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/33/e3d7f7a18331523762e9968b6716e81514649af81ffd9ba4364e3df95823/mlx-0.32.0-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:e0db558267bb2d13fac4f85674456adbe0f085c570b9219e03d4e95fdc11c4d0", size = 561389, upload-time = "2026-07-07T17:56:06.743Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/58/bd847d3fed65296573a4bb3399adde6934c0a718813b5636000d7d1b4063/mlx-0.32.0-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:23e83c8e74a23156696e9f9905d16a17b7d27b5a596c1bc0f720a98df1c5aadf", size = 561392, upload-time = "2026-07-07T17:56:08.237Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f3/0c3c8bb11362a97ebc6407a1c3e24a45de470e9326ef53dcc96e83263e84/mlx-0.32.0-cp314-cp314-manylinux_2_35_aarch64.whl", hash = "sha256:253c5d20c573b277fc64a3eec491984e7ad4c64f9b246c1b3fee903b7d1db824", size = 618758, upload-time = "2026-07-07T17:56:09.729Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/94/61b29c561045576e78d6f992c22d0bb301e8e6eec65588560f942d59c88d/mlx-0.32.0-cp314-cp314-manylinux_2_35_x86_64.whl", hash = "sha256:4edffbdb1f7c185e35dc4e48611966d012b1dda9225a0dabd0fbd31651374a71", size = 675130, upload-time = "2026-07-07T17:56:11.059Z" },
+    { url = "https://files.pythonhosted.org/packages/01/fe/5a0dd8784e0335aa7d472365177a6a13245b4aa28cf102c9bac6d65675c8/mlx-0.32.0-cp314-cp314-win_amd64.whl", hash = "sha256:f67557bd9ce31cbb519b39e9455b19cca698eb153ab6f4deef5b4d5509d94df3", size = 572405, upload-time = "2026-07-07T17:56:12.427Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/26/f9efe51f7f32afc7da95fc832cc3e2744f9284b846e0e18ebd98b6bd2458/mlx-0.32.0-cp314-cp314-win_arm64.whl", hash = "sha256:13f793c354ea9dc589bbd113f4b7d299900fb440199bbb403546845852b2499b", size = 558174, upload-time = "2026-07-07T17:56:13.694Z" },
+]
+
+[[package]]
+name = "mlx-metal"
+version = "0.32.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/ef/d74ae99cfe9ddb59fd08abd14f47754c3d199291a93756903fa595b31b8a/mlx_metal-0.32.0-py3-none-macosx_14_0_arm64.whl", hash = "sha256:5b64b20ac24b0c401f489de01e8209edc4d372125201f19314e6f39e385322aa", size = 40824649, upload-time = "2026-07-07T17:55:20.7Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/38/b96a3de98cfbb009592b3870af46ff63657b192f8d1e06c6c1faea5fbef3/mlx_metal-0.32.0-py3-none-macosx_15_0_arm64.whl", hash = "sha256:1bd94a1ce5b03a0c898771a3e759f0124300c6ab5155127906a1d50b1f3fcf19", size = 40818869, upload-time = "2026-07-07T17:55:25.059Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/59/65d32520175379df33f107749193aa94ea9db069167a36a1a100ff689f62/mlx_metal-0.32.0-py3-none-macosx_26_0_arm64.whl", hash = "sha256:3af76a498d84804f66119800499f9d143d7dffb0878a0dd0d7c2846e58565fd7", size = 56511379, upload-time = "2026-07-07T17:55:36.045Z" },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -845,6 +886,11 @@ dependencies = [
     { name = "tqdm" },
 ]
 
+[package.optional-dependencies]
+mlx = [
+    { name = "mlx" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
@@ -857,11 +903,13 @@ dev = [
 requires-dist = [
     { name = "json5" },
     { name = "matplotlib" },
+    { name = "mlx", marker = "extra == 'mlx'", specifier = ">=0.32" },
     { name = "numpy" },
     { name = "scipy" },
     { name = "torch", specifier = ">=2.12.1" },
     { name = "tqdm" },
 ]
+provides-extras = ["mlx"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
Epic #74 delivers Apple-Silicon GPU acceleration for AMICA, governed by one hard constraint the research (#72) surfaced: **Apple GPUs have no FP64 hardware** (neither PyTorch MPS nor MLX offers GPU float64), so the whole path was gated on a numerically stable **float32** AMICA. Four phases, each a reviewed + squash-merged PR:

- **Phase A (#75, PR #78) -- float32 stabilization.** Full-data float32 diverged to NaN across every seed. Diagnosis (not the planned summation-precision fix) found the real cause: a per-element `0/0` in the mu denominator `ufp/y` when float32 rounds an activation to exactly 0. A one-line divide-by-zero guard fixes it -- bit-identical in float64 (#24 Fortran parity preserved), needs no float64, so it also unblocks MPS/MLX.
- **Phase C (#76, PR #79) -- MLX backend `AMICAMLXNG`.** An optional Apple-GPU backend: GPU float32 E/M-step hot path + CPU-stream linalg (hoisted per iteration) + host-side SciPy for MLX's missing `lgamma`/`digamma`. Optional dependency (CI skips it; omitted from the coverage gate).
- **Phase B (#77, PR #80) -- cross-platform benchmark.** On real 70-channel EEG (OpenNeuro ds002718): **MLX is the Apple-GPU win -- ~15-25 ms/it, ~7x over torch-CPU, faster than an RTX 4090 at EEG scale; PyTorch-MPS never wins (>= CPU).** Results agree across cpu/mps/cuda/mlx to ~3 digits.
- **Phase D (#81, PR #82) -- multi-model MLX.** Extends `AMICAMLXNG` to `n_models > 1`; single-model stays byte-identical; the win extends to multi-model (~5x over CPU). Matches AMICATorchNG float32 (one-iter stats to float32 precision, converged LL ~1e-5).

## Net result
On Apple Silicon, **use the MLX backend** for single- and multi-model AMICA (~5-7x over CPU); avoid `device="mps"` (no gain). float64-CUDA stays the bit-safe NVIDIA path. Every phase preserved #24 Fortran parity (float64 byte-identical) and the full torch suite.

## Merge strategy
Regular merge (NOT squash) to preserve the per-phase history above (per repo policy for epic branches). Each phase PR was already squash-merged into this branch with its own review.

## Follow-ups (tracked separately)
- MLX component sharing; a 128-256 ch / many-model sweep for the eventual MLX/CUDA crossover.
- A comprehensive native-Fortran + CPU-core-scaling + CUDA cross-platform benchmark (its own epic, on a native-x86 Linux + CUDA host).

Closes #74