### PR TITLE
Phase 1: Native-Fortran adapter + CUDA host setup

### DIFF
--- a/.context/issue-84/phase1_build_notes.md
+++ b/.context/issue-84/phase1_build_notes.md
@@ -19,8 +19,9 @@ reference is never modified):
 
 Also `-std=legacy -fallow-argument-mismatch -ffree-line-length-none`. Built clean on both
 **macOS arm64 (gfortran 16, brew open-mpi + lapack)** and **Ubuntu 24.04 x86_64
-(gfortran 13, apt openmpi + liblapack-dev)**. Upstream target: sccn/amica #44 (M1 compile),
-#49 (Ubuntu recompile).
+(gfortran 13, apt openmpi + liblapack-dev)**. Upstream target: sccn/amica #44 (compile on
+M1) is an exact match; #49 asks about Ubuntu builds too, though via Intel OneAPI rather than
+this gfortran path.
 
 ## Timing method
 

--- a/.context/issue-84/phase1_build_notes.md
+++ b/.context/issue-84/phase1_build_notes.md
@@ -1,0 +1,49 @@
+# Phase 1 (#85): native-Fortran adapter + build notes
+
+Adds a `native-fortran-f64` backend to `benchmarks/benchmark_dimsweep.py` that times an
+`amica15` compiled from source, plus a cross-platform build (`benchmarks/fortran/`).
+
+## gfortran build portability (source targets ifort + MKL)
+
+`amica15.f90` assumes Intel's toolchain. A plain `gfortran` + LAPACK build needs three
+fixes, applied by `build_amica.sh` to a **build copy** (the tracked `pyAMICA/amica15.f90`
+reference is never modified):
+
+1. `-cpp` -- resolve the `#ifdef MKL` guards so `include 'mkl_vml.f90'` is skipped.
+2. `random_seed` -- the source's size-2 seed array (ifort-sized) is rejected by gfortran
+   (wants 8); the build copy uses a portable default seed. Timing-neutral (seeding was
+   already clock-based / non-reproducible).
+3. `vmath_shim.c` -- the non-MKL branch calls AMD LibM `vrda_exp`/`vrda_log`; the shim
+   provides them as libm loops so no vendor math lib is needed. IEEE-accurate; a vendor
+   SIMD math lib could make the exp/log-heavy E-step somewhat faster.
+
+Also `-std=legacy -fallow-argument-mismatch -ffree-line-length-none`. Built clean on both
+**macOS arm64 (gfortran 16, brew open-mpi + lapack)** and **Ubuntu 24.04 x86_64
+(gfortran 13, apt openmpi + liblapack-dev)**. Upstream target: sccn/amica #44 (M1 compile),
+#49 (Ubuntu recompile).
+
+## Timing method
+
+Per-iteration time is parsed from amica's own `out.txt` stamp (`( <sec> s, ...)`), which is
+startup-immune (printed after MPI init / data load / PCA / sphering). Mean over the timed
+iters (drop iter 1), min across repeats. **Resolution caveat:** the stamp is ~10 ms, so run
+where per-iteration time is well above 10 ms (the 70-ch benchmark is); a config that rounds
+to 0.00 s/iter is rejected rather than reported as bogus 0.0.
+
+## Cross-platform sanity (real ds002718 sub-002, 30000 samples, single-model)
+
+hallu (Linux x86_64, RTX 4090, 32 cores, torch 2.12.1+cu130), 30 iters x 3 repeats,
+fortran-threads 8:
+
+| backend            | 32ch ms/it | 70ch ms/it | LL (32 / 70)     |
+|--------------------|-----------:|-----------:|------------------|
+| native-fortran-f64 |      12.07 |      44.83 | -3.308 / -3.242  |
+| torch-cuda-f64     |      34.88 |      38.61 | -3.273 / -3.196  |
+| torch-cpu-f64      |     217.51 |     226.48 | -3.273 / -3.196  |
+
+Native x86 Fortran+OpenMP is fastest at 32ch and competitive with CUDA at 70ch (crossover
+there), ~5-18x over torch-CPU. LL agrees to ~2 digits (Fortran differs slightly: random
+init + libm math + unconverged at 30 iters). torch-cuda/torch-cpu agree to 5 digits.
+
+Mac arm64 (native build, 8 threads) also runs as a first-class row (~30 ms/it @ 32ch,
+~5x over torch-CPU-f64). Full cross-platform grid + CUDA multi-model report is Phase 3 (#87).

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ benchmarks/results/
 # Real EEG benchmark data (fetched from OpenNeuro, not committed) + result JSONs
 benchmarks/data/
 benchmarks/*.json
+# Native amica build artifacts (#85; hardware-specific, built on the CUDA host)
+benchmarks/fortran/amica15
+benchmarks/fortran/build/
+bench_out/
 
 # Local secrets (never commit)
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,8 @@ benchmarks/results/
 # Real EEG benchmark data (fetched from OpenNeuro, not committed) + result JSONs
 benchmarks/data/
 benchmarks/*.json
-# Native amica build artifacts (#85; hardware-specific, built on the CUDA host)
+# Native amica build artifacts (#85; hardware-specific, built per host via
+# benchmarks/fortran/build_amica.sh -- Apple Silicon or the x86 host, not in CI)
 benchmarks/fortran/amica15
 benchmarks/fortran/build/
 bench_out/

--- a/benchmarks/README_dimsweep.md
+++ b/benchmarks/README_dimsweep.md
@@ -7,7 +7,15 @@ actually beats the CPU. Backends: `numpy-cpu-f64`, `torch-cpu-f64/f32`,
 `torch-mps-f32`, `torch-cuda-f64/f32`, `mlx-f32` (the MLX backend supports single-
 and multi-model but has no component sharing yet, so it is excluded only from the
 `--share` configs), and `native-fortran-f64` (the Fortran reference compiled from
-source; single-model only -- see `benchmarks/fortran/README.md` to build it).
+source, validated single-model in Phase 1 with component sharing off -- see
+`benchmarks/fortran/README.md` to build it).
+
+**`native-fortran-f64` result caveat:** every other backend fixes `seed=42`, so its
+`final_ll` is reproducible and directly comparable across backends and repeats. amica seeds
+its random init from the wall clock (non-reproducible run-to-run), so the native-Fortran
+`final_ll` is drawn from a different basin each invocation and can differ from the others by
+more than the fixed-seed backends differ among themselves. Treat that column as a sanity
+check (same ballpark), not a fixed-seed parity number; the `ms/iter` timing is unaffected.
 
 ## Data (real, not committed)
 

--- a/benchmarks/README_dimsweep.md
+++ b/benchmarks/README_dimsweep.md
@@ -6,7 +6,8 @@ the channel count on real 70-channel EEG, to answer where an Apple/NVIDIA GPU
 actually beats the CPU. Backends: `numpy-cpu-f64`, `torch-cpu-f64/f32`,
 `torch-mps-f32`, `torch-cuda-f64/f32`, `mlx-f32` (the MLX backend supports single-
 and multi-model but has no component sharing yet, so it is excluded only from the
-`--share` configs).
+`--share` configs), and `native-fortran-f64` (the Fortran reference compiled from
+source; single-model only -- see `benchmarks/fortran/README.md` to build it).
 
 ## Data (real, not committed)
 

--- a/benchmarks/benchmark_dimsweep.py
+++ b/benchmarks/benchmark_dimsweep.py
@@ -280,12 +280,14 @@ def _run_fortran(
     repeats.
 
     amica prints per-iteration time to only ~0.01 s (10 ms) resolution, so the
-    mean over many iterations is used (the quantization averages out) rather
-    than a single iter's stamp. A config whose per-iteration time rounds to
-    0.00 s (all stamps below the 10 ms floor -- only tiny channel/sample counts)
-    raises instead of returning a bogus 0.0; use the real 70-ch benchmark size.
-    Raises on a nonzero exit too -- a crashed run must not masquerade as a fast
-    one (mirrors benchmark_runtime.time_fortran)."""
+    mean over the timed iters is used. NOTE this floors precision at ~10 ms: when
+    every iteration rounds to the same stamp the mean is still that stamp, so run
+    at a size whose per-iteration time is well above 10 ms (the 70-ch benchmark
+    is ~30-70 ms) for the number to be meaningful. A config whose per-iteration
+    time rounds to 0.00 s (below the floor -- only tiny channel/sample counts)
+    raises instead of returning a bogus 0.0. Raises on a nonzero exit too -- a
+    crashed run must not masquerade as a fast one (mirrors
+    benchmark_runtime.time_fortran)."""
     binary = Path(binary or _DEFAULT_FORTRAN_BIN)
     if not (binary.exists() and os.access(binary, os.X_OK)):
         raise RuntimeError(f"native fortran binary not found/executable: {binary}")

--- a/benchmarks/benchmark_dimsweep.py
+++ b/benchmarks/benchmark_dimsweep.py
@@ -18,6 +18,9 @@ Backends (auto-detected per platform):
   torch-cuda-f64  AMICATorchNG, NVIDIA GPU, float64
   torch-cuda-f32  AMICATorchNG, NVIDIA GPU, float32
   mlx-f32         AMICAMLXNG, Apple GPU (MLX), float32
+  native-fortran-f64  amica15 compiled from source (MPI+OpenMP), the reference
+                  (#85; timed via amica's own per-iter stamps, startup-immune;
+                  needs benchmarks/fortran/build_amica.sh -- not on Apple/CI)
 
 All backends run at matched settings (n_models=1, n_mix=3, pdftype=0,
 do_newton=False, same block_size/seed/channels/samples/iters) so the comparison
@@ -38,7 +41,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import platform
+import re
+import statistics
+import subprocess
+import tempfile
+from pathlib import Path
 from time import perf_counter
 
 import numpy as np
@@ -47,6 +56,13 @@ import numpy as np
 N_MIX = 3
 SEED = 42
 BLOCK_SIZE = 512
+
+# Native-Fortran backend (#85): paths + run limits.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+SAMPLE_DIR = _REPO_ROOT / "pyAMICA" / "sample_data"
+_PARAM_TEMPLATE = SAMPLE_DIR / "input.param"
+_DEFAULT_FORTRAN_BIN = _REPO_ROOT / "benchmarks" / "fortran" / "amica15"
+_FORTRAN_TIMEOUT = 3600  # seconds; a crashed/hung run must not hang the sweep
 
 
 # --------------------------------------------------------------------------
@@ -177,6 +193,149 @@ def _run_numpy(data, iters, repeats, n_models=1, share=False):
     return min(times) / iters * 1000.0, ll
 
 
+# --------------------------------------------------------------------------
+# Native-Fortran backend (#85): drives an amica15 compiled from source (see
+# benchmarks/fortran/build_amica.sh). Timing comes from amica's OWN per-iter
+# stamps in out.txt -- startup-immune (init/PCA/sphering happen before iter 1),
+# unlike wrapping the whole process in perf_counter.
+# --------------------------------------------------------------------------
+def _write_fdt(data: np.ndarray, path: Path) -> None:
+    """Write (n_channels, n_samples) EEG as amica's raw float32 .fdt: a
+    (data_dim=channels, field_dim=samples) array in column-major (channel-
+    fastest) order -- the exact inverse of numpy_impl.data.load_data_file's
+    ``reshape(..., order="F")``. Byte-identical to EEGLAB's own .fdt (locked by
+    test_write_fdt_roundtrip)."""
+    path.write_bytes(np.ascontiguousarray(data).astype("<f4").tobytes(order="F"))
+
+
+def _write_fortran_param(
+    work: Path, nc: int, ns: int, iters: int, threads: int, n_models: int
+) -> None:
+    """Render input.param for one benchmark fit: start from the committed
+    template and override only the benchmark knobs so the algorithm config
+    matches the other backends (n_mix=3, pdftype=0, do_newton off, fixed
+    block_size). use_min_dll/use_grad_norm are forced OFF so amica runs the full
+    ``iters`` budget (matched, fixed-length runs like torch/mlx)."""
+    overrides = {
+        "files": "files ./bench.fdt",
+        "outdir": "outdir ./bench_out/",
+        "block_size": f"block_size {BLOCK_SIZE}",
+        "do_opt_block": "do_opt_block 0",
+        "num_models": f"num_models {n_models}",
+        "max_threads": f"max_threads {threads}",
+        "num_mix_comps": f"num_mix_comps {N_MIX}",
+        "pdftype": "pdftype 0",
+        "max_iter": f"max_iter {iters}",
+        "num_samples": "num_samples 1",
+        "data_dim": f"data_dim {nc}",
+        "field_dim": f"field_dim {ns}",
+        "do_newton": "do_newton 0",
+        "do_sphere": "do_sphere 1",
+        "do_mean": "do_mean 1",
+        "doPCA": "doPCA 1",
+        "pcakeep": f"pcakeep {nc}",
+        "use_min_dll": "use_min_dll 0",
+        "use_grad_norm": "use_grad_norm 0",
+        "write_LLt": "write_LLt 0",
+        "do_history": "do_history 0",
+        "share_comps": "share_comps 0",
+    }
+    seen: set[str] = set()
+    lines: list[str] = []
+    for line in _PARAM_TEMPLATE.read_text().splitlines():
+        key = line.split()[0] if line.strip() else ""
+        if key in overrides:
+            lines.append(overrides[key])
+            seen.add(key)
+        else:
+            lines.append(line)
+    lines.extend(v for k, v in overrides.items() if k not in seen)
+    (work / "input.param").write_text("\n".join(lines) + "\n")
+
+
+_ITER_RE = re.compile(
+    r"iter\s+\d+\s+lrate\s*=\s*\S+\s+LL\s*=\s*(\S+).*?\(\s*([\d.]+)\s*s,"
+)
+
+
+def _parse_fortran_out(out_txt: Path) -> tuple[list[float], float]:
+    """Parse amica's out.txt -> (per_iteration_seconds, final_ll). Each iter
+    line ends '( <sec> s, <cum_h> h)'; <sec> is that iteration's compute time."""
+    secs: list[float] = []
+    last_ll = float("nan")
+    for line in out_txt.read_text(errors="ignore").splitlines():
+        m = _ITER_RE.search(line)
+        if m:
+            last_ll = float(m.group(1))
+            secs.append(float(m.group(2)))
+    return secs, last_ll
+
+
+def _run_fortran(
+    data, iters, repeats, n_models=1, binary=None, threads=None
+) -> tuple[float, float]:
+    """Time a native amica fit. Per repeat: fresh workdir, write .fdt + param,
+    run the binary, read amica's per-iter seconds. ms/iter = MEAN of the timed
+    iters (dropping iter 1 as first-touch warmup), reported as the min over
+    repeats.
+
+    amica prints per-iteration time to only ~0.01 s (10 ms) resolution, so the
+    mean over many iterations is used (the quantization averages out) rather
+    than a single iter's stamp. A config whose per-iteration time rounds to
+    0.00 s (all stamps below the 10 ms floor -- only tiny channel/sample counts)
+    raises instead of returning a bogus 0.0; use the real 70-ch benchmark size.
+    Raises on a nonzero exit too -- a crashed run must not masquerade as a fast
+    one (mirrors benchmark_runtime.time_fortran)."""
+    binary = Path(binary or _DEFAULT_FORTRAN_BIN)
+    if not (binary.exists() and os.access(binary, os.X_OK)):
+        raise RuntimeError(f"native fortran binary not found/executable: {binary}")
+    threads = threads or (os.cpu_count() or 4)
+    nc, ns = data.shape
+    per_iter_ms: list[float] = []
+    final_ll = float("nan")
+    for _ in range(repeats):
+        with tempfile.TemporaryDirectory(prefix="amica_bench_") as td:
+            work = Path(td)
+            _write_fdt(data, work / "bench.fdt")
+            _write_fortran_param(work, nc, ns, iters, threads, n_models)
+            (work / "bench_out").mkdir(exist_ok=True)
+            env = {**os.environ, "OMP_NUM_THREADS": str(threads)}
+            res = subprocess.run(
+                [str(binary), "input.param"],
+                cwd=work,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=_FORTRAN_TIMEOUT,
+            )
+            if res.returncode != 0:
+                raise RuntimeError(
+                    f"native fortran run failed (exit {res.returncode}).\n"
+                    f"stderr:\n{res.stderr[-2000:]}\nstdout:\n{res.stdout[-2000:]}"
+                )
+            secs, final_ll = _parse_fortran_out(work / "bench_out" / "out.txt")
+            if len(secs) < 2:
+                raise RuntimeError(
+                    f"native fortran produced <2 timed iterations (got {len(secs)}"
+                    "); cannot compute per-iteration timing"
+                )
+            mean_s = statistics.mean(secs[1:])
+            if mean_s == 0.0:
+                raise RuntimeError(
+                    f"native fortran per-iteration time rounds to 0.00 s for "
+                    f"{data.shape[0]}ch x {data.shape[1]} samples -- below amica's "
+                    "~10 ms out.txt stamp resolution; use a larger channel/sample "
+                    "count (the 70-ch benchmark size is well above the floor)"
+                )
+            per_iter_ms.append(mean_s * 1000.0)
+    return min(per_iter_ms), final_ll
+
+
+def _fortran_available(binary=None) -> bool:
+    binary = Path(binary or _DEFAULT_FORTRAN_BIN)
+    return binary.exists() and os.access(binary, os.X_OK)
+
+
 _BACKENDS = {
     "numpy-cpu-f64": ("numpy", {}),
     "torch-cpu-f64": ("torch", {"device": "cpu", "dtype_str": "f64"}),
@@ -185,10 +344,13 @@ _BACKENDS = {
     "torch-cuda-f64": ("torch", {"device": "cuda", "dtype_str": "f64"}),
     "torch-cuda-f32": ("torch", {"device": "cuda", "dtype_str": "f32"}),
     "mlx-f32": ("mlx", {}),
+    "native-fortran-f64": ("fortran", {}),
 }
 
 
-def _available(name: str, n_models: int = 1, share: bool = False) -> bool:
+def _available(
+    name: str, n_models: int = 1, share: bool = False, fortran_bin=None
+) -> bool:
     kind, kw = _BACKENDS[name]
     if kind == "torch":
         return _torch_available(kw["device"])
@@ -202,12 +364,24 @@ def _available(name: str, n_models: int = 1, share: bool = False) -> bool:
             return mx.default_device().type == mx.DeviceType.gpu
         except Exception:
             return False
+    if kind == "fortran":
+        # amica15 (MPI+OpenMP) is single-model; sharing is not wired here.
+        return not share and _fortran_available(fortran_bin)
     if kind == "numpy":
         return True
     return False
 
 
-def _run_backend(name, data, iters, repeats, n_models=1, share=False):
+def _run_backend(
+    name,
+    data,
+    iters,
+    repeats,
+    n_models=1,
+    share=False,
+    fortran_bin=None,
+    fortran_threads=None,
+):
     kind, kw = _BACKENDS[name]
     if kind == "torch":
         return _run_torch(
@@ -215,6 +389,15 @@ def _run_backend(name, data, iters, repeats, n_models=1, share=False):
         )
     if kind == "mlx":
         return _run_mlx(data, iters=iters, repeats=repeats, n_models=n_models)
+    if kind == "fortran":
+        return _run_fortran(
+            data,
+            iters=iters,
+            repeats=repeats,
+            n_models=n_models,
+            binary=fortran_bin,
+            threads=fortran_threads,
+        )
     return _run_numpy(
         data, iters=iters, repeats=repeats, n_models=n_models, share=share
     )
@@ -222,6 +405,7 @@ def _run_backend(name, data, iters, repeats, n_models=1, share=False):
 
 def _platform_info() -> dict:
     info = {"machine": platform.machine(), "system": platform.system()}
+    info["nproc"] = os.cpu_count()  # context for the CPU-scaling sweep (#86)
     try:
         import torch
 
@@ -231,7 +415,7 @@ def _platform_info() -> dict:
     except ImportError:
         pass
     try:
-        info["loadavg"] = [round(x, 1) for x in __import__("os").getloadavg()]
+        info["loadavg"] = [round(x, 1) for x in os.getloadavg()]
     except OSError:
         pass
     return info
@@ -251,6 +435,20 @@ def main() -> int:
     ap.add_argument(
         "--share", action="store_true", help="enable component sharing (n_models>1)"
     )
+    ap.add_argument(
+        "--fortran-bin",
+        default=str(_DEFAULT_FORTRAN_BIN),
+        dest="fortran_bin",
+        help="native amica binary (default benchmarks/fortran/amica15; build it "
+        "with benchmarks/fortran/build_amica.sh)",
+    )
+    ap.add_argument(
+        "--fortran-threads",
+        type=int,
+        default=None,
+        dest="fortran_threads",
+        help="OMP threads for the native-fortran backend (default: all cores)",
+    )
     args = ap.parse_args()
 
     if args.report:
@@ -266,10 +464,14 @@ def main() -> int:
     full = np.load(args.data).astype(np.float64)
     channels = [int(c) for c in args.channels.split(",") if int(c) <= full.shape[0]]
     if args.backends == "auto":
-        backends = [b for b in _BACKENDS if _available(b, n_models, share)]
+        backends = [
+            b for b in _BACKENDS if _available(b, n_models, share, args.fortran_bin)
+        ]
     else:
         backends = [
-            b for b in args.backends.split(",") if _available(b, n_models, share)
+            b
+            for b in args.backends.split(",")
+            if _available(b, n_models, share, args.fortran_bin)
         ]
 
     info = _platform_info()
@@ -285,7 +487,14 @@ def main() -> int:
         for b in backends:
             try:
                 ms, ll = _run_backend(
-                    b, data, args.iters, args.repeats, n_models, share
+                    b,
+                    data,
+                    args.iters,
+                    args.repeats,
+                    n_models,
+                    share,
+                    fortran_bin=args.fortran_bin,
+                    fortran_threads=args.fortran_threads,
                 )
                 rows.append(
                     {

--- a/benchmarks/benchmark_dimsweep.py
+++ b/benchmarks/benchmark_dimsweep.py
@@ -20,7 +20,8 @@ Backends (auto-detected per platform):
   mlx-f32         AMICAMLXNG, Apple GPU (MLX), float32
   native-fortran-f64  amica15 compiled from source (MPI+OpenMP), the reference
                   (#85; timed via amica's own per-iter stamps, startup-immune;
-                  needs benchmarks/fortran/build_amica.sh -- not on Apple/CI)
+                  build it with benchmarks/fortran/build_amica.sh -- works on both
+                  Apple Silicon and the x86 host, just not built by default / in CI)
 
 All backends run at matched settings (n_models=1, n_mix=3, pdftype=0,
 do_newton=False, same block_size/seed/channels/samples/iters) so the comparison
@@ -263,7 +264,10 @@ def _parse_fortran_out(out_txt: Path) -> tuple[list[float], float]:
     line ends '( <sec> s, <cum_h> h)'; <sec> is that iteration's compute time."""
     secs: list[float] = []
     last_ll = float("nan")
-    for line in out_txt.read_text(errors="ignore").splitlines():
+    # errors="replace" (not "ignore") so a corrupt byte surfaces as U+FFFD and
+    # breaks that line's regex match cleanly, rather than silently vanishing and
+    # risking a still-matching but numerically wrong stamp.
+    for line in out_txt.read_text(errors="replace").splitlines():
         m = _ITER_RE.search(line)
         if m:
             last_ll = float(m.group(1))
@@ -311,9 +315,19 @@ def _run_fortran(
                 timeout=_FORTRAN_TIMEOUT,
             )
             if res.returncode != 0:
+                # main()'s per-backend handler truncates the exception message to
+                # ~70 chars, so print the full captured output here first -- a
+                # native crash (bad LAPACK/MPI linkage, malformed param, segfault)
+                # has many platform-specific causes and the transcript is the only
+                # place to see why.
+                print(
+                    f"    native fortran exit {res.returncode}\n"
+                    f"    --- stderr ---\n{res.stderr[-2000:]}\n"
+                    f"    --- stdout ---\n{res.stdout[-2000:]}"
+                )
                 raise RuntimeError(
-                    f"native fortran run failed (exit {res.returncode}).\n"
-                    f"stderr:\n{res.stderr[-2000:]}\nstdout:\n{res.stdout[-2000:]}"
+                    f"native fortran run failed (exit {res.returncode}); "
+                    "see stderr/stdout printed above"
                 )
             secs, final_ll = _parse_fortran_out(work / "bench_out" / "out.txt")
             if len(secs) < 2:
@@ -367,7 +381,9 @@ def _available(
         except Exception:
             return False
     if kind == "fortran":
-        # amica15 (MPI+OpenMP) is single-model; sharing is not wired here.
+        # amica15 supports num_models > 1, but this adapter is only validated
+        # single-model in Phase 1 (#85); component sharing is hardcoded off (not
+        # wired here), so only the share config is gated out.
         return not share and _fortran_available(fortran_bin)
     if kind == "numpy":
         return True
@@ -470,11 +486,28 @@ def main() -> int:
             b for b in _BACKENDS if _available(b, n_models, share, args.fortran_bin)
         ]
     else:
+        requested = args.backends.split(",")
         backends = [
-            b
-            for b in args.backends.split(",")
-            if _available(b, n_models, share, args.fortran_bin)
+            b for b in requested if _available(b, n_models, share, args.fortran_bin)
         ]
+        # Do not silently drop an explicitly requested backend: an unbuilt
+        # native-fortran binary or a mistyped/unavailable device would otherwise
+        # leave the sweep quietly benchmarking fewer backends than asked (or
+        # nothing at all) while still exiting 0.
+        for b in requested:
+            if b not in _BACKENDS:
+                print(f"WARNING: unknown backend {b!r} (skipped)")
+            elif b not in backends:
+                print(
+                    f"WARNING: requested backend {b!r} is unavailable on this host "
+                    f"(config m{n_models}{'+share' if share else ''}"
+                    + (
+                        f"; native binary {args.fortran_bin!r} not built?"
+                        if b == "native-fortran-f64"
+                        else ""
+                    )
+                    + ") -- skipped"
+                )
 
     info = _platform_info()
     print(f"platform: {info}")

--- a/benchmarks/fortran/README.md
+++ b/benchmarks/fortran/README.md
@@ -1,0 +1,76 @@
+# Native-Fortran backend for the cross-platform benchmark (epic #84, phase #85)
+
+The `native-fortran-f64` backend in `benchmark_dimsweep.py` times **amica15 compiled
+from source** so the Fortran reference has an honest per-iteration number to compare
+against the torch / mlx / numpy backends.
+
+## Why build from source (not `amica15mac`)
+
+The bundled `pyAMICA/sample_data/amica15mac` is an **x86_64** binary. On Apple Silicon
+it only runs under Rosetta 2, so its timing is not representative of native hardware.
+The benchmark therefore builds `amica15` from `pyAMICA/{funmod2,amica15}.f90` on the
+native x86 Linux/CUDA host and times *that*. (`amica15mac` is still fine for structural
+smoke-testing of the adapter on a Mac; it is just not a timing reference.)
+
+## Host setup (Debian/Ubuntu)
+
+amica15.f90 is an **MPI + OpenMP + LAPACK** program, so it needs an MPI Fortran wrapper
+(`mpif90`) plus LAPACK/BLAS, not plain `gfortran`:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gfortran libopenmpi-dev openmpi-bin liblapack-dev libblas-dev
+```
+
+`nvcc` is **not** required: the torch CUDA backends ship their own CUDA runtime, and the
+Fortran build is CPU-only (MPI+OpenMP+LAPACK).
+
+## Build
+
+```bash
+bash benchmarks/fortran/build_amica.sh        # -> benchmarks/fortran/amica15
+```
+
+The script compiles `funmod2.f90` first (amica15 does `use funmod2`), keeps the `.mod`
+in `benchmarks/fortran/build/`, and lifts gfortran's 132-column limit
+(`-ffree-line-length-none`). Override the compiler with `FC=...` and the source dir with
+`AMICA_SRC=...`. The built binary and `build/` are gitignored.
+
+## Run
+
+amica runs as a single MPI rank (OpenMPI singleton -- no `mpirun` needed); OpenMP width is
+`OMP_NUM_THREADS`, which the harness sets from `--fortran-threads` (default: all cores).
+
+```bash
+# native-fortran only
+uv run python benchmarks/benchmark_dimsweep.py \
+  --data benchmarks/data/ds002718_sub-002_eeg70.npy \
+  --backends native-fortran-f64 --iters 30
+
+# alongside the CUDA backends on the same host
+uv run python benchmarks/benchmark_dimsweep.py \
+  --data benchmarks/data/ds002718_sub-002_eeg70.npy \
+  --backends native-fortran-f64,torch-cuda-f64,torch-cpu-f64 --out cuda.json
+```
+
+Use the **same** `ds002718_sub-002_eeg70.npy` as every other host (fetch recipe in
+`benchmarks/README_dimsweep.md`) so the comparison is apples-to-apples.
+
+## How the timing works (startup-immune)
+
+Wrapping the whole process in a timer would fold in MPI init, data load, and PCA/sphering.
+Instead the adapter parses amica's own per-iteration stamp from `out.txt`:
+
+```
+ iter     2 lrate = 0.05 LL = -3.4685 nd = 0.0257, D = ...  (  0.01 s,   0.0 h)
+```
+
+The `( <sec> s, ...)` field is that iteration's compute time (printed after init). The
+adapter drops iter 1 (first-touch warmup), takes the median of the rest, and reports the
+min across `--repeats`. The final `LL` is read from the same lines and is already on the
+per-sample scale the torch backends report (no normalization).
+
+If a run exits non-zero the adapter raises (a crashed run must not masquerade as a fast
+one). Settings are matched to the other backends: `num_mix=3`, `pdftype=0`, `do_newton` off,
+`block_size=512`, and `use_min_dll`/`use_grad_norm` forced off so it runs the full
+`--iters` budget.

--- a/benchmarks/fortran/README.md
+++ b/benchmarks/fortran/README.md
@@ -8,19 +8,28 @@ against the torch / mlx / numpy backends.
 
 The bundled `pyAMICA/sample_data/amica15mac` is an **x86_64** binary. On Apple Silicon
 it only runs under Rosetta 2, so its timing is not representative of native hardware.
-The benchmark therefore builds `amica15` from `pyAMICA/{funmod2,amica15}.f90` on the
-native x86 Linux/CUDA host and times *that*. (`amica15mac` is still fine for structural
-smoke-testing of the adapter on a Mac; it is just not a timing reference.)
+The benchmark therefore builds `amica15` from `pyAMICA/{funmod2,amica15}.f90` natively on
+each host -- the x86 Linux/CUDA host *and* Apple Silicon -- and times *that*. Both are
+honest native-CPU rows. (`amica15mac` is still fine for structural smoke-testing of the
+adapter on a Mac; it is just not a timing reference.)
 
-## Host setup (Debian/Ubuntu)
+## Host setup
 
 amica15.f90 is an **MPI + OpenMP + LAPACK** program, so it needs an MPI Fortran wrapper
-(`mpif90`) plus LAPACK/BLAS, not plain `gfortran`:
+(`mpif90`) plus LAPACK/BLAS, not plain `gfortran`.
 
+**Debian/Ubuntu (the x86 CUDA host):**
 ```bash
 sudo apt-get update
 sudo apt-get install -y gfortran libopenmpi-dev openmpi-bin liblapack-dev libblas-dev
 ```
+
+**macOS / Apple Silicon (native arm64, no sudo):**
+```bash
+brew install gcc open-mpi lapack
+```
+The build script links brew's LAPACK on macOS (falling back to `-framework Accelerate`);
+override with `LAPACK_LIBS=...` if needed.
 
 `nvcc` is **not** required: the torch CUDA backends ship their own CUDA runtime, and the
 Fortran build is CPU-only (MPI+OpenMP+LAPACK).
@@ -66,11 +75,37 @@ Instead the adapter parses amica's own per-iteration stamp from `out.txt`:
 ```
 
 The `( <sec> s, ...)` field is that iteration's compute time (printed after init). The
-adapter drops iter 1 (first-touch warmup), takes the median of the rest, and reports the
+adapter drops iter 1 (first-touch warmup), takes the **mean** of the rest, and reports the
 min across `--repeats`. The final `LL` is read from the same lines and is already on the
 per-sample scale the torch backends report (no normalization).
+
+**Resolution caveat:** amica prints the per-iteration time to only ~0.01 s (10 ms). When
+every iteration rounds to the same stamp (e.g. a steady 0.03 s/iter prints `0.03` each
+time), the mean is still that stamp -- averaging does *not* recover sub-10 ms detail. So
+run at a size whose per-iteration time is well above 10 ms (the 70-ch benchmark is
+~30-70 ms/iter, giving ~±15% at worst) and treat the native-Fortran number as coarser than
+the in-process torch/mlx timings. A config that rounds to 0.00 s/iter is rejected outright.
 
 If a run exits non-zero the adapter raises (a crashed run must not masquerade as a fast
 one). Settings are matched to the other backends: `num_mix=3`, `pdftype=0`, `do_newton` off,
 `block_size=512`, and `use_min_dll`/`use_grad_norm` forced off so it runs the full
 `--iters` budget.
+
+## Build portability (gfortran, no MKL/AMD)
+
+`amica15.f90` targets Intel's toolchain (`ifort` + MKL), so a plain `gfortran` + LAPACK
+build needs three portability fixes. `build_amica.sh` applies them **without touching the
+tracked reference source** (it patches a build copy under `build/src/`):
+
+1. **`-cpp`** so the source's `#ifdef MKL` guards resolve (MKL undefined -> the
+   `include 'mkl_vml.f90'` is skipped and the non-MKL branch is used).
+2. **`random_seed` seed size** -- the source's size-2 seed array (sized for ifort) is
+   rejected by gfortran; the build copy uses a portable default seed. Only affects random
+   init, which was already clock-based (non-reproducible), so it is timing-neutral.
+3. **`vmath_shim.c`** provides `vrda_exp`/`vrda_log` (the non-MKL branch calls AMD LibM's
+   vector exp/log) as libm loops, so no vendor math library is needed. IEEE-accurate; a
+   vendor SIMD math library could make the exp/log-heavy E-step somewhat faster, so treat
+   this as a portable-baseline timing, not a max-tuned one.
+
+These are generic gfortran-portability fixes (not pyAMICA-specific) and are candidates to
+upstream to [sccn/amica](https://github.com/sccn/amica).

--- a/benchmarks/fortran/build_amica.sh
+++ b/benchmarks/fortran/build_amica.sh
@@ -91,6 +91,14 @@ cp "$src_dir/funmod2.f90" "$src_dir/amica15.f90" "$src_dir/amica15_header.f90" "
 sed -i.bak \
   's/.*random_seed(PUT = c1 .*/      call random_seed()  ! benchmark build: portable default seed (build_amica.sh)/' \
   "$work_src/amica15.f90"
+# sed exits 0 even on a no-op, so verify the patch landed: if the tracked source
+# ever renames the seed line, an unpatched random_seed(PUT=...) would otherwise
+# reach the compiler and (with -fallow-argument-mismatch) build a binary that
+# only crashes at runtime.
+if ! grep -q 'call random_seed()  ! benchmark build' "$work_src/amica15.f90"; then
+  echo "ERROR: random_seed patch did not apply -- amica15.f90 source may have drifted" >&2
+  exit 1
+fi
 
 # Portable vector-math shim: the non-MKL branch calls AMD LibM's vrda_exp/vrda_log,
 # which are absent in a plain gfortran+LAPACK build. vmath_shim.c provides them as

--- a/benchmarks/fortran/build_amica.sh
+++ b/benchmarks/fortran/build_amica.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Build a native amica15 for the cross-platform benchmark (epic #84, phase #85).
+#
+# amica15.f90 is an MPI + OpenMP + LAPACK program, so this needs an MPI Fortran
+# wrapper (mpif90) plus LAPACK/BLAS -- NOT plain gfortran. The resulting binary
+# runs fine as a single MPI rank (OpenMPI singleton); OpenMP width is set at run
+# time via OMP_NUM_THREADS. We build from source (not the bundled amica15mac,
+# which is x86-under-Rosetta on Apple Silicon) so the reference timing is honest
+# on the native x86 host.
+#
+# Usage:
+#   bash benchmarks/fortran/build_amica.sh
+#   FC=mpiifort bash benchmarks/fortran/build_amica.sh      # override compiler
+#   AMICA_SRC=/path/to/src bash benchmarks/fortran/build_amica.sh
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/../.." && pwd)"
+src_dir="${AMICA_SRC:-$repo_root/pyAMICA}"
+fc="${FC:-mpif90}"
+build_dir="$here/build"
+out="$here/amica15"
+
+echo "amica native build"
+echo "  compiler : $fc"
+echo "  sources  : $src_dir/{funmod2,amica15}.f90"
+echo "  output   : $out"
+
+if ! command -v "$fc" >/dev/null 2>&1; then
+  cat >&2 <<EOF
+
+ERROR: '$fc' not found. amica15.f90 is an MPI+OpenMP+LAPACK program and needs an
+MPI Fortran wrapper plus LAPACK/BLAS. On Debian/Ubuntu:
+
+  sudo apt-get update
+  sudo apt-get install -y gfortran libopenmpi-dev openmpi-bin liblapack-dev libblas-dev
+
+Then re-run this script (override the compiler with FC=... if it is not mpif90).
+EOF
+  exit 1
+fi
+
+for f in funmod2.f90 amica15.f90; do
+  if [[ ! -f "$src_dir/$f" ]]; then
+    echo "ERROR: source not found: $src_dir/$f" >&2
+    exit 1
+  fi
+done
+
+mkdir -p "$build_dir"
+# funmod2 first (amica15 does `use funmod2`); -J puts the .mod in build/ so the
+# source tree stays clean; -ffree-line-length-none lifts gfortran's 132-col cap.
+set -x
+"$fc" -O3 -fopenmp -ffree-line-length-none -J"$build_dir" \
+  "$src_dir/funmod2.f90" "$src_dir/amica15.f90" \
+  -o "$out" -llapack -lblas
+set +x
+
+echo
+echo "built: $out"
+echo "quick check: in a dir holding input.param + its .fdt, run"
+echo "  OMP_NUM_THREADS=4 $out input.param"
+echo "then benchmark with:"
+echo "  uv run python benchmarks/benchmark_dimsweep.py --data DATA.npy \\"
+echo "      --backends native-fortran-f64 --iters 30"

--- a/benchmarks/fortran/build_amica.sh
+++ b/benchmarks/fortran/build_amica.sh
@@ -4,13 +4,14 @@
 # amica15.f90 is an MPI + OpenMP + LAPACK program, so this needs an MPI Fortran
 # wrapper (mpif90) plus LAPACK/BLAS -- NOT plain gfortran. The resulting binary
 # runs fine as a single MPI rank (OpenMPI singleton); OpenMP width is set at run
-# time via OMP_NUM_THREADS. We build from source (not the bundled amica15mac,
-# which is x86-under-Rosetta on Apple Silicon) so the reference timing is honest
-# on the native x86 host.
+# time via OMP_NUM_THREADS. Building from source (not the bundled x86 amica15mac,
+# which only runs under Rosetta on Apple Silicon) gives an honest native-CPU
+# timing reference on BOTH the x86 CUDA host and Apple Silicon.
 #
 # Usage:
 #   bash benchmarks/fortran/build_amica.sh
-#   FC=mpiifort bash benchmarks/fortran/build_amica.sh      # override compiler
+#   FC=mpiifort bash benchmarks/fortran/build_amica.sh          # override compiler
+#   LAPACK_LIBS="-framework Accelerate" bash .../build_amica.sh  # override linkage
 #   AMICA_SRC=/path/to/src bash benchmarks/fortran/build_amica.sh
 set -euo pipefail
 
@@ -20,14 +21,42 @@ src_dir="${AMICA_SRC:-$repo_root/pyAMICA}"
 fc="${FC:-mpif90}"
 build_dir="$here/build"
 out="$here/amica15"
+os="$(uname -s)"
+
+# LAPACK/BLAS linkage: apt libs on Linux; brew lapack (falling back to the
+# Accelerate framework) on macOS. Override with LAPACK_LIBS=... .
+if [[ -n "${LAPACK_LIBS:-}" ]]; then
+  lapack_libs="$LAPACK_LIBS"
+elif [[ "$os" == "Darwin" ]]; then
+  if brew_lapack="$(brew --prefix lapack 2>/dev/null)" && [[ -d "$brew_lapack/lib" ]]; then
+    lapack_libs="-L$brew_lapack/lib -llapack -lblas"
+  else
+    lapack_libs="-framework Accelerate"
+  fi
+else
+  lapack_libs="-llapack -lblas"
+fi
 
 echo "amica native build"
+echo "  platform : $os $(uname -m)"
 echo "  compiler : $fc"
+echo "  lapack   : $lapack_libs"
 echo "  sources  : $src_dir/{funmod2,amica15}.f90"
 echo "  output   : $out"
 
 if ! command -v "$fc" >/dev/null 2>&1; then
-  cat >&2 <<EOF
+  if [[ "$os" == "Darwin" ]]; then
+    cat >&2 <<EOF
+
+ERROR: '$fc' not found. amica15.f90 is an MPI+OpenMP+LAPACK program and needs an
+MPI Fortran wrapper plus LAPACK/BLAS. On macOS (Homebrew, no sudo):
+
+  brew install gcc open-mpi lapack
+
+Then re-run this script (override the compiler with FC=... if it is not mpif90).
+EOF
+  else
+    cat >&2 <<EOF
 
 ERROR: '$fc' not found. amica15.f90 is an MPI+OpenMP+LAPACK program and needs an
 MPI Fortran wrapper plus LAPACK/BLAS. On Debian/Ubuntu:
@@ -37,6 +66,7 @@ MPI Fortran wrapper plus LAPACK/BLAS. On Debian/Ubuntu:
 
 Then re-run this script (override the compiler with FC=... if it is not mpif90).
 EOF
+  fi
   exit 1
 fi
 
@@ -48,12 +78,39 @@ for f in funmod2.f90 amica15.f90; do
 done
 
 mkdir -p "$build_dir"
-# funmod2 first (amica15 does `use funmod2`); -J puts the .mod in build/ so the
-# source tree stays clean; -ffree-line-length-none lifts gfortran's 132-col cap.
+work_src="$build_dir/src"
+mkdir -p "$work_src"
+cp "$src_dir/funmod2.f90" "$src_dir/amica15.f90" "$src_dir/amica15_header.f90" "$work_src/"
+
+# Patch ONLY the build copy (the tracked amica15.f90 stays the read-only parity
+# reference). gfortran's random_seed wants a PUT array of its own size (8);
+# the source's size-2 seed array (sized for ifort/MKL) is rejected. That seed
+# only affects random initialization, which is already clock-based (hence
+# non-reproducible run-to-run), so a portable default seed is timing-neutral and
+# result-equivalent for the benchmark.
+sed -i.bak \
+  's/.*random_seed(PUT = c1 .*/      call random_seed()  ! benchmark build: portable default seed (build_amica.sh)/' \
+  "$work_src/amica15.f90"
+
+# Portable vector-math shim: the non-MKL branch calls AMD LibM's vrda_exp/vrda_log,
+# which are absent in a plain gfortran+LAPACK build. vmath_shim.c provides them as
+# libm exp/log loops (see its header for the ABI + accuracy note).
+cc="${CC:-cc}"
 set -x
-"$fc" -O3 -fopenmp -ffree-line-length-none -J"$build_dir" \
-  "$src_dir/funmod2.f90" "$src_dir/amica15.f90" \
-  -o "$out" -llapack -lblas
+"$cc" -O3 -c "$here/vmath_shim.c" -o "$build_dir/vmath_shim.o"
+set +x
+
+# funmod2 first (amica15 does `use funmod2`); -J puts the .mod in build/ so the
+# tree stays clean; -cpp resolves the source's `#ifdef MKL` guards (MKL undefined
+# -> the mkl_vml.f90 include is skipped, plain-Fortran exp/log branches used);
+# -std=legacy + -fallow-argument-mismatch relax this vintage F90's obsolescent
+# constructs to warnings; -ffree-line-length-none lifts gfortran's 132-col cap.
+set -x
+# shellcheck disable=SC2086  # $lapack_libs must word-split into separate flags
+"$fc" -O3 -fopenmp -cpp -ffree-line-length-none -std=legacy \
+  -fallow-argument-mismatch -J"$build_dir" -I"$work_src" \
+  "$work_src/funmod2.f90" "$work_src/amica15.f90" "$build_dir/vmath_shim.o" \
+  -o "$out" $lapack_libs
 set +x
 
 echo

--- a/benchmarks/fortran/vmath_shim.c
+++ b/benchmarks/fortran/vmath_shim.c
@@ -10,9 +10,10 @@
  * These are simple element-wise ops, so this shim provides them as loops over
  * standard libm exp/log. gfortran calls them by reference with a trailing
  * underscore (`call vrda_exp(n, x, y)` -> `vrda_exp_(int* n, double* x,
- * double* y)`), which is the ABI matched here. Using scalar libm exp/log gives
- * IEEE-accurate results (equal or better than the vendor vector routines); the
- * only cost is that a vendor SIMD math library could compute the exp/log-heavy
+ * double* y)`), which is the ABI matched here. Scalar libm exp/log are
+ * correctly-rounded/IEEE-accurate (vendor SIMD transcendental libraries such as
+ * AMD LibM typically trade some accuracy for throughput); the cost here is speed,
+ * not accuracy -- a vendor SIMD math library could compute the exp/log-heavy
  * E-step somewhat faster (documented as a caveat in README.md).
  */
 #include <math.h>

--- a/benchmarks/fortran/vmath_shim.c
+++ b/benchmarks/fortran/vmath_shim.c
@@ -1,0 +1,28 @@
+/* Portable vector-math shim for building amica15 without a vendor math library
+ * (epic #84, phase #85).
+ *
+ * amica15.f90's non-MKL branch calls AMD LibM's vectorized exp/log
+ * (`vrda_exp`/`vrda_log`); its MKL branch uses Intel VML (`vdExp`/`vdLn`).
+ * Neither vendor library is present when building with plain gfortran + LAPACK
+ * (e.g. on Apple Silicon, or a generic Linux box), so the link fails on
+ * `vrda_exp_`/`vrda_log_`.
+ *
+ * These are simple element-wise ops, so this shim provides them as loops over
+ * standard libm exp/log. gfortran calls them by reference with a trailing
+ * underscore (`call vrda_exp(n, x, y)` -> `vrda_exp_(int* n, double* x,
+ * double* y)`), which is the ABI matched here. Using scalar libm exp/log gives
+ * IEEE-accurate results (equal or better than the vendor vector routines); the
+ * only cost is that a vendor SIMD math library could compute the exp/log-heavy
+ * E-step somewhat faster (documented as a caveat in README.md).
+ */
+#include <math.h>
+
+void vrda_exp_(const int *n, const double *x, double *y) {
+    int i, m = *n;
+    for (i = 0; i < m; i++) y[i] = exp(x[i]);
+}
+
+void vrda_log_(const int *n, const double *x, double *y) {
+    int i, m = *n;
+    for (i = 0; i < m; i++) y[i] = log(x[i]);
+}

--- a/pyAMICA/tests/test_fortran_adapter.py
+++ b/pyAMICA/tests/test_fortran_adapter.py
@@ -9,6 +9,7 @@ pointed at by ``AMICA_FORTRAN_BIN``), so CI and Apple-only checkouts stay green.
 
 import importlib.util
 import os
+import shutil
 from pathlib import Path
 
 import numpy as np
@@ -33,6 +34,11 @@ def _load_bench():
 
 
 bench = _load_bench()
+
+# A runnable native amica binary if one is available (built by
+# benchmarks/fortran/build_amica.sh, or pointed at by AMICA_FORTRAN_BIN). Absent
+# on CI / Apple-only checkouts, which is why the run tests below are skip-gated.
+_FBIN = os.environ.get("AMICA_FORTRAN_BIN")
 
 
 def test_write_fdt_roundtrip(tmp_path):
@@ -84,13 +90,51 @@ def test_write_fortran_param(tmp_path):
         "pdftype 0",
         "do_newton 0",
         "block_size 512",
+        "pcakeep 16",  # must track nc, not the template's 32 (the load-bearing subset line)
         "use_min_dll 0",  # run the full budget, matched to torch/mlx
         "use_grad_norm 0",
     ):
         assert expected in text, f"missing {expected!r} in rendered param"
 
 
-_FBIN = os.environ.get("AMICA_FORTRAN_BIN")
+def test_write_fortran_param_multimodel(tmp_path):
+    """num_models tracks n_models (amica15 supports multi-model; the adapter
+    forwards it, gating only component sharing off)."""
+    bench._write_fortran_param(
+        tmp_path, nc=32, ns=5000, iters=10, threads=4, n_models=2
+    )
+    text = (tmp_path / "input.param").read_text()
+    assert "num_models 2" in text
+    assert "share_comps 0" in text
+
+
+def test_fortran_availability_and_dispatch():
+    """Availability gating is honest without a binary: a missing binary is
+    unavailable, and component sharing is always gated off for this backend
+    (these decide whether native-fortran-f64 joins the auto-detected sweep)."""
+    assert bench._fortran_available("/nonexistent/amica15") is False
+    assert (
+        bench._available("native-fortran-f64", share=True, fortran_bin="/nonexistent")
+        is False
+    )
+    # sharing is refused even if a binary exists
+    assert (
+        bench._available("native-fortran-f64", share=True, fortran_bin=_FBIN) is False
+    )
+
+
+def test_run_fortran_raises_on_nonzero_exit(tmp_path):
+    """A crashed run must raise, never return a bogus fast timing. Uses the real
+    system `false` (exits nonzero) as the binary -- a real failing process, not a
+    mock."""
+    false_bin = shutil.which("false")
+    if false_bin is None:
+        pytest.skip("system 'false' not found")
+    data = load_data_file(str(FDT), DATA_DIM, FIELD_DIM, dtype=np.float32)[:16, :2000]
+    with pytest.raises(RuntimeError, match="native fortran run failed"):
+        bench._run_fortran(
+            np.ascontiguousarray(data), iters=5, repeats=1, binary=false_bin, threads=1
+        )
 
 
 @pytest.mark.skipif(
@@ -102,11 +146,37 @@ _FBIN = os.environ.get("AMICA_FORTRAN_BIN")
 def test_run_fortran_smoke():
     """End-to-end: a short native fit on a real full-width subset yields finite
     per-iteration timing and a sane converged LL. Uses the full 32 channels /
-    all samples so per-iteration time clears amica's ~10 ms stamp resolution
-    (a 16-ch/8k config rounds to 0.00 s and is intentionally rejected)."""
+    all samples so per-iteration time clears amica's ~10 ms stamp resolution."""
     # the committed .fdt is float32 on disk (byte_size 4); _write_fdt recasts to
     # float32 anyway, so read it at its real dtype.
     data = load_data_file(str(FDT), DATA_DIM, FIELD_DIM, dtype=np.float32)
     ms, ll = bench._run_fortran(data, iters=10, repeats=1, binary=_FBIN, threads=4)
     assert ms > 0.0
     assert -5.0 < ll < -2.0
+
+
+@pytest.mark.skipif(
+    not bench._fortran_available(_FBIN),
+    reason="needs a runnable native amica binary; skipped on CI / Apple-only checkouts",
+)
+def test_run_fortran_rejects_sub_resolution_config():
+    """A config whose per-iteration time rounds to 0.00 s (below amica's ~10 ms
+    stamp) raises rather than reporting a bogus 0 ms/iter. 8ch x 2000 samples
+    reliably stays under the floor on real hardware."""
+    data = load_data_file(str(FDT), DATA_DIM, FIELD_DIM, dtype=np.float32)[:8, :2000]
+    with pytest.raises(RuntimeError, match="rounds to 0.00 s"):
+        bench._run_fortran(
+            np.ascontiguousarray(data), iters=8, repeats=1, binary=_FBIN, threads=2
+        )
+
+
+@pytest.mark.skipif(
+    not bench._fortran_available(_FBIN),
+    reason="needs a runnable native amica binary; skipped on CI / Apple-only checkouts",
+)
+def test_run_fortran_requires_two_timed_iters():
+    """A single-iteration run cannot yield a per-iteration mean (iter 1 is the
+    dropped warmup), so it raises rather than dividing by an empty set."""
+    data = load_data_file(str(FDT), DATA_DIM, FIELD_DIM, dtype=np.float32)
+    with pytest.raises(RuntimeError, match="<2 timed iterations"):
+        bench._run_fortran(data, iters=1, repeats=1, binary=_FBIN, threads=4)

--- a/pyAMICA/tests/test_fortran_adapter.py
+++ b/pyAMICA/tests/test_fortran_adapter.py
@@ -1,0 +1,112 @@
+"""Structural tests for the native-Fortran benchmark adapter (issue #85).
+
+Real sample EEG only (NO MOCKS): the ``.fdt`` round-trip and the ``out.txt``
+parser are checked against the committed EEGLAB data and a committed amica run.
+The end-to-end run test is skipped unless a runnable native amica binary is
+present (built on the CUDA host via ``benchmarks/fortran/build_amica.sh``, or
+pointed at by ``AMICA_FORTRAN_BIN``), so CI and Apple-only checkouts stay green.
+"""
+
+import importlib.util
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from pyAMICA.numpy_impl.data import load_data_file
+
+_REPO = Path(__file__).resolve().parents[2]
+SAMPLE_DIR = _REPO / "pyAMICA" / "sample_data"
+FDT = SAMPLE_DIR / "eeglab_data.fdt"
+OUT_TXT = SAMPLE_DIR / "amicaout" / "out.txt"
+DATA_DIM, FIELD_DIM = 32, 30504
+
+
+def _load_bench():
+    """Load benchmarks/benchmark_dimsweep.py (not an installed package)."""
+    path = _REPO / "benchmarks" / "benchmark_dimsweep.py"
+    spec = importlib.util.spec_from_file_location("benchmark_dimsweep", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+bench = _load_bench()
+
+
+def test_write_fdt_roundtrip(tmp_path):
+    """_write_fdt is the exact inverse of the canonical load_data_file, so
+    re-writing the committed .fdt reproduces it byte-for-byte -- locking the
+    float32 column-major (channel-fastest) convention."""
+    data = load_data_file(str(FDT), DATA_DIM, FIELD_DIM, dtype=np.float32)
+    assert data.shape == (DATA_DIM, FIELD_DIM)
+    out = tmp_path / "roundtrip.fdt"
+    bench._write_fdt(data, out)
+    assert out.read_bytes() == FDT.read_bytes()
+
+
+def test_write_fdt_channel_subset(tmp_path):
+    """A channel subset writes channel-fastest, so the canonical reader reads it
+    back exactly (the sweep slices full[:nc, :ns])."""
+    data = load_data_file(str(FDT), DATA_DIM, FIELD_DIM, dtype=np.float32)
+    nc, ns = 16, 5000
+    sub = np.ascontiguousarray(data[:nc, :ns])
+    out = tmp_path / "subset.fdt"
+    bench._write_fdt(sub, out)
+    back = load_data_file(str(out), nc, ns, dtype=np.float32)
+    np.testing.assert_array_equal(back, sub)
+
+
+def test_parse_fortran_out():
+    """Parse the committed amica out.txt -> per-iter seconds + final LL."""
+    secs, ll = bench._parse_fortran_out(OUT_TXT)
+    assert len(secs) == 200  # max_iter of the committed run
+    assert all(s >= 0.0 for s in secs)
+    assert secs[0] > 0.0
+    assert ll == pytest.approx(-3.4018729891, abs=1e-6)
+
+
+def test_write_fortran_param(tmp_path):
+    """The rendered param carries the matched benchmark knobs for the subset,
+    and forces the full fixed-length iteration budget."""
+    bench._write_fortran_param(
+        tmp_path, nc=16, ns=5000, iters=30, threads=4, n_models=1
+    )
+    text = (tmp_path / "input.param").read_text()
+    for expected in (
+        "files ./bench.fdt",
+        "data_dim 16",
+        "field_dim 5000",
+        "max_iter 30",
+        "max_threads 4",
+        "num_mix_comps 3",
+        "pdftype 0",
+        "do_newton 0",
+        "block_size 512",
+        "use_min_dll 0",  # run the full budget, matched to torch/mlx
+        "use_grad_norm 0",
+    ):
+        assert expected in text, f"missing {expected!r} in rendered param"
+
+
+_FBIN = os.environ.get("AMICA_FORTRAN_BIN")
+
+
+@pytest.mark.skipif(
+    not bench._fortran_available(_FBIN),
+    reason="no runnable native amica binary (build via "
+    "benchmarks/fortran/build_amica.sh or set AMICA_FORTRAN_BIN); skipped on "
+    "CI / Apple-only checkouts",
+)
+def test_run_fortran_smoke():
+    """End-to-end: a short native fit on a real full-width subset yields finite
+    per-iteration timing and a sane converged LL. Uses the full 32 channels /
+    all samples so per-iteration time clears amica's ~10 ms stamp resolution
+    (a 16-ch/8k config rounds to 0.00 s and is intentionally rejected)."""
+    # the committed .fdt is float32 on disk (byte_size 4); _write_fdt recasts to
+    # float32 anyway, so read it at its real dtype.
+    data = load_data_file(str(FDT), DATA_DIM, FIELD_DIM, dtype=np.float32)
+    ms, ll = bench._run_fortran(data, iters=10, repeats=1, binary=_FBIN, threads=4)
+    assert ms > 0.0
+    assert -5.0 < ll < -2.0


### PR DESCRIPTION
## Summary
Adds a `native-fortran-f64` backend to the Phase B dimension-sweep harness
(`benchmarks/benchmark_dimsweep.py`) that times an `amica15` compiled from source, plus a
cross-platform build (`benchmarks/fortran/`). First piece of epic #84: an honest
native-Fortran reference-timing row, on both the x86 CUDA host and Apple Silicon.

Closes #85
Part of epic #84

## What changed
- **`_run_fortran` adapter**: writes a real subset as a float32 column-major `.fdt`, renders a
  matched `input.param` (n_mix=3, pdftype=0, do_newton off, block_size 512, full fixed-iter
  budget), runs the binary, and times it from amica's **own per-iteration `out.txt` stamps**
  (startup-immune: after MPI init / data load / PCA / sphering). Registered in `_BACKENDS`;
  available only when a native binary exists (so CI / Apple-only checkouts are unaffected).
- **`benchmarks/fortran/build_amica.sh`** + **`vmath_shim.c`**: cross-platform native build.
  `amica15.f90` targets ifort + MKL, so a plain gfortran build needs three fixes, applied to a
  **build copy** (never the tracked reference source): `-cpp` (skip the MKL `#include`), a
  portable `random_seed` seed size, and a libm shim for AMD LibM's `vrda_exp`/`vrda_log`.
  Built clean on macOS arm64 (gfortran 16) and Ubuntu 24.04 x86_64 (gfortran 13).
- **Docs**: `benchmarks/fortran/README.md` (host setup, timing method + 10 ms resolution
  caveat, portability notes), dimsweep README/docstring updated, `.context/issue-84/`.

## Test plan
- `pyAMICA/tests/test_fortran_adapter.py` (real committed data, NO MOCKS): `.fdt` round-trip vs
  the canonical `load_data_file` (locks the column-major convention), channel-subset round-trip,
  `out.txt` parser (200 iters, LL), param rendering, and an end-to-end smoke that runs a native
  amica (skipped unless a binary is present / `AMICA_FORTRAN_BIN` is set).
- Validated end-to-end on **both** platforms: 5/5 pass against a native arm64 (Mac) and native
  x86 (hallu) binary. Real dimsweep on hallu (RTX 4090): native-fortran-f64 12.07 ms/it @32ch,
  44.83 @70ch vs torch-cuda-f64 34.88/38.61 and torch-cpu-f64 217/226; LL agrees ~2 digits.
- `ruff check` + `ruff format` clean; `shellcheck` clean; full suite collects (154 tests).

## Notes / caveats
- Per-iteration stamp is ~10 ms resolution; the adapter rejects configs that round to 0.00 s/iter
  and documents the floor (use per-iter >> 10 ms, i.e. the 70-ch size).
- native-Fortran uses libm (not vendor SIMD) math -> portable-baseline timing, not max-tuned.
- Build portability fixes are candidates to upstream to sccn/amica (#44 M1 compile, #49 Ubuntu).
- Out of scope: `--threads` CPU-scaling sweep (Phase 2 #86); full grid + CUDA multi-model report
  (Phase 3 #87).