### PR TITLE
Fix license metadata to BSD-3-Clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,4 +144,4 @@ Results are saved in NumPy format:
 
 ## License
 
-This project is licensed under the MIT License - see the LICENSE file for details.
+This project is licensed under the BSD 3-Clause License - see the [LICENSE](LICENSE) file for details.

--- a/pyAMICA/version.py
+++ b/pyAMICA/version.py
@@ -20,7 +20,7 @@ CLASSIFIERS = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Topic :: Scientific/Engineering",
@@ -50,7 +50,7 @@ DESCRIPTION = description
 LONG_DESCRIPTION = long_description
 URL = "http://github.com/neuromechanist/pyAMICA"
 DOWNLOAD_URL = ""
-LICENSE = "MIT"
+LICENSE = "BSD-3-Clause"
 AUTHOR = "Seyed Yahya Shirazi"
 AUTHOR_EMAIL = "shirazi@ieee.org"
 PLATFORMS = "OS Independent"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,12 @@ authors = [
 maintainers = [
     {name = "Seyed Yahya Shirazi", email = "shirazi@ieee.org"},
 ]
-license = {text = "MIT"}
+license = {text = "BSD-3-Clause"}
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Topic :: Scientific/Engineering"


### PR DESCRIPTION
The `LICENSE` file is BSD 3-Clause, but `pyproject.toml`, `version.py`, and `README.md` declared **MIT**. This corrects the metadata to match the actual license (BSD 3-Clause), which matters for JOSS submission (license clarity).

## Changes
- `pyproject.toml`: `license = {text = "BSD-3-Clause"}`; classifier `License :: OSI Approved :: BSD License`.
- `pyAMICA/version.py`: `LICENSE = "BSD-3-Clause"`; classifier updated to BSD.
- `README.md`: license section now says BSD 3-Clause and links `LICENSE`.

No code changes. The `LICENSE` file itself (already BSD 3-Clause) is unchanged.