### PR TITLE
JOSS paper: paper.md + paper.bib (#101)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,6 +11,16 @@ authors:
   - family-names: Shirazi
     given-names: Seyed Yahya
     email: shirazi@ieee.org
+    orcid: "https://orcid.org/0000-0001-5557-259X"
+    affiliation: "Swartz Center for Computational Neuroscience, University of California San Diego"
+  - family-names: Delorme
+    given-names: Arnaud
+    orcid: "https://orcid.org/0000-0002-0799-3557"
+    affiliation: "Swartz Center for Computational Neuroscience, University of California San Diego; CNRS, University of Toulouse"
+  - family-names: Makeig
+    given-names: Scott
+    orcid: "https://orcid.org/0000-0002-9048-8438"
+    affiliation: "Swartz Center for Computational Neuroscience, University of California San Diego"
 version: 0.1.dev0
 license: BSD-3-Clause
 repository-code: "https://github.com/neuromechanist/pyAMICA"

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2023-2025 Seyed Yahya Shirazi
+Copyright (c) 2023-2026 Seyed Yahya Shirazi
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
-# [WIP] AMICA: Adaptive Mixture ICA
+# pyAMICA: Adaptive Mixture ICA
 
 [![CI](https://github.com/neuromechanist/pyAMICA/actions/workflows/ci.yml/badge.svg)](https://github.com/neuromechanist/pyAMICA/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/neuromechanist/pyAMICA/branch/main/graph/badge.svg)](https://codecov.io/gh/neuromechanist/pyAMICA)
 
-Python implementation of the Adaptive Mixture ICA algorithm, based on the original Fortran implementation. This implementation is designed to be more user-friendly and easier to integrate with other Python libraries.
+Python (PyTorch) implementation of Adaptive Mixture Independent Component Analysis
+(AMICA) that reproduces the reference Fortran implementation within numerical
+tolerance, with CPU, NVIDIA GPU (CUDA), and Apple GPU (MLX) support. It targets
+EEG/EMG blind source separation and is a drop-in replacement for EEGLAB's AMICA:
+single-model output is byte-identical to the Fortran reference and loads directly
+in EEGLAB.
 
-NOTE: This is a work in progress and may not be fully functional yet. User should not rely on this implementation for any research or production purposes, as the results may not be accurate or reliable.
+Single-model results match the Fortran reference (log-likelihood ~ -3.40,
+Hungarian-matched component correlation ~ 0.997); see the
+[documentation](https://eeglab.org/pyAMICA/) for validation details and the
+backend-selection guide.
 
 ## Overview
 
@@ -20,14 +28,17 @@ AMICA (Adaptive Mixture ICA) is an advanced blind source separation algorithm th
 
 ## Installation
 
+The canonical environment is [uv](https://docs.astral.sh/uv/):
+
 ```bash
-# Clone the repository
 git clone https://github.com/neuromechanist/pyAMICA.git
 cd pyAMICA
-
-# install the package
-pip install -e .
+uv sync                     # install dependencies into a managed venv
+uv run pytest               # optional: run the tests
 ```
+
+The optional Apple-GPU backend (MLX, Apple Silicon only) installs with the `mlx`
+extra: `uv pip install mlx`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -42,116 +42,66 @@ extra: `uv pip install mlx`.
 
 ## Usage
 
-1. Create a parameter file (e.g., params.json):
-```json
-{
-    "files": ["data1.bin", "data2.bin"],
-    "num_samples": [100, 100],
-    "data_dim": 64,
-    "field_dim": [1000, 1000],
-    "num_models": 1,
-    "num_mix": 3,
-    "max_iter": 2000
-}
+pyAMICA exposes a scikit-learn-style estimator backed by the PyTorch
+natural-gradient EM implementation:
+
+```python
+import numpy as np
+from pyAMICA import AMICA
+
+# X is (n_channels, n_samples) of real EEG/EMG; float64 gives Fortran parity
+model = AMICA(n_models=1, n_mix=3).fit(X)
+
+sources = model.transform(X)       # (n_sources, n_samples)
+A = model.get_mixing_matrix()      # sensor-space scalp maps
+order = model.variance_order()     # EEGLAB IC order (IC1 = highest variance)
 ```
 
-2. Run AMICA:
+### Backends and precision
+
+The wrapper auto-selects a device and computes in float64 for Fortran parity.
+
+- CPU and CUDA (float64) are bit-reproducible; use them for parity runs.
+- float32 is 5-19x faster at about 7 significant digits.
+- On Apple Silicon the MLX backend is the fastest option; import it explicitly.
+
+```python
+AMICA(device="cuda").fit(X)               # NVIDIA GPU, float64
+from pyAMICA.mlx_impl import AMICAMLXNG    # Apple GPU (install the mlx extra)
+```
+
+### EEGLAB interoperability
+
+pyAMICA writes results in EEGLAB's AMICA output format, so a run drops into an
+EEGLAB workflow with no manual re-ordering or sign-flipping:
+
+```python
+model.write_amica_output("amicaout")   # gm, W, S, mean, c, alpha, mu, sbeta, rho, ...
+```
+
+```matlab
+mod = loadmodout15('amicaout');   % components in EEGLAB variance order
+```
+
+### Legacy NumPy CLI
+
+The NumPy reference backend keeps a JSON-driven command-line interface:
+
 ```bash
 python -m pyAMICA.numpy_impl.cli params.json --outdir results
 ```
 
-## Parameters
+See the [documentation](https://eeglab.org/pyAMICA/) for the full API, the
+parameter reference, and the backend-selection and validation guides.
 
-### Required Parameters
-- `files`: List of binary data files
-- `num_samples`: Number of samples per file
-- `data_dim`: Number of channels/dimensions
-- `field_dim`: Number of samples per field for each file
+## Citation
 
-### Optional Parameters
+If you use pyAMICA, please cite it (see [CITATION.cff](CITATION.cff)) and the
+original AMICA method:
 
-#### Model Parameters
-- `num_models`: Number of models (default: 1)
-- `num_mix`: Number of mixture components (default: 3)
-- `num_comps`: Number of components (-1 for data_dim * num_models)
-- `pdftype`: PDF type (1: Generalized Gaussian, 2: Logistic, etc.)
-
-#### Optimization Parameters
-- `max_iter`: Maximum iterations (default: 2000)
-- `lrate`: Initial learning rate (default: 0.1)
-- `minlrate`: Minimum learning rate (default: 1e-12)
-- `lratefact`: Learning rate decay factor (default: 0.5)
-
-#### Newton Optimization
-- `do_newton`: Use Newton optimization (default: false)
-- `newt_start`: Iteration to start Newton (default: 20)
-- `newt_ramp`: Newton ramp length (default: 10)
-- `newtrate`: Newton learning rate (default: 0.5)
-
-#### Component Sharing
-- `share_comps`: Enable component sharing (default: false)
-- `comp_thresh`: Component correlation threshold (default: 0.99)
-- `share_start`: Iteration to start sharing (default: 100)
-- `share_int`: Sharing interval (default: 100)
-
-#### Data Preprocessing
-- `do_mean`: Remove mean (default: true)
-- `do_sphere`: Perform sphering (default: true)
-- `do_approx_sphere`: Use approximate sphering (default: true)
-- `pcakeep`: Number of PCA components to keep (optional)
-- `pcadb`: dB threshold for PCA components (optional)
-
-#### Block Processing
-- `do_opt_block`: Optimize block size (default: true)
-- `block_size`: Initial block size (default: 128)
-- `blk_min`: Minimum block size (default: 128)
-- `blk_max`: Maximum block size (default: 1024)
-- `blk_step`: Block size step (default: 128)
-
-#### Outlier Rejection
-- `do_reject`: Enable outlier rejection (default: false)
-- `rejsig`: Rejection threshold in std (default: 3.0)
-- `rejstart`: Iteration to start rejection (default: 2)
-- `rejint`: Rejection interval (default: 3)
-- `maxrej`: Maximum rejections (default: 1)
-
-#### Output Control
-- `do_history`: Save optimization history (default: false)
-- `histstep`: History saving interval (default: 10)
-- `writestep`: Result writing interval (default: 100)
-
-## File Structure
-
-- `amica.py`: Main scikit-learn-style AMICA interface (PyTorch backend)
-- `torch_impl/core.py`: PyTorch natural-gradient EM backend (`AMICATorchNG`)
-- `mlx_impl/core.py`: Optional Apple-GPU MLX backend (`AMICAMLXNG`, single- & multi-model)
-- `numpy_impl/core.py`: Legacy NumPy reference (`AMICA_NumPy`)
-- `numpy_impl/pdf.py`: PDF type implementations
-- `numpy_impl/newton.py`: Newton optimization
-- `numpy_impl/data.py`: Data loading/preprocessing
-- `numpy_impl/cli.py`: Command-line interface
-- `numpy_impl/params.json`: Default/example parameter file
-
-## Output Files
-
-Results are saved in NumPy format:
-- `A.npy`: Mixing matrix
-- `W.npy`: Unmixing matrices
-- `c.npy`: Bias terms
-- `mu.npy`: Component means
-- `alpha.npy`: Mixture weights
-- `beta.npy`: Scale parameters
-- `rho.npy`: Shape parameters
-- `gm.npy`: Model weights
-- `mean.npy`: Data mean
-- `sphere.npy`: Sphering matrix
-- `comp_list.npy`: Component assignments
-- `ll.npy`: Log likelihood history
-- `nd.npy`: Gradient norm history (if use_grad_norm=true)
-
-## References
-
-1. Palmer, J. A., Kreutz-Delgado, K., & Makeig, S. (2012). AMICA: An adaptive mixture of independent component analyzers with shared components.
+> Palmer, J. A., Kreutz-Delgado, K., & Makeig, S. (2012). AMICA: An adaptive
+> mixture of independent component analyzers with shared components. Technical
+> report, Swartz Center for Computational Neuroscience, UC San Diego.
 
 ## License
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -8,6 +8,7 @@ extend-exclude = [
     "pyAMICA/sample_data/",   # sample EEG + Fortran outputs + saved .npy results
     "pytorch_debug_test/",    # generated debug output
     "uv.lock",
+    "paper.bib",              # citation metadata: accented author names + LaTeX escapes
 ]
 
 [default.extend-words]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@
 pyAMICA uses [UV](https://docs.astral.sh/uv/) for environment and dependency
 management.
 
-### From source (development)
+### From source
 
 ```bash
 git clone https://github.com/neuromechanist/pyAMICA.git
@@ -13,11 +13,8 @@ cd pyAMICA
 uv sync            # install the project and its dependencies into .venv
 ```
 
-### As a dependency
-
-```bash
-uv add pyAMICA     # or: uv pip install pyAMICA
-```
+A packaged release on the Python Package Index (PyPI) is planned; until then,
+install from source as above.
 
 ### Optional Apple-Silicon GPU backend
 
@@ -25,7 +22,7 @@ The MLX backend is Apple-only and is therefore an optional extra; `import
 pyAMICA` never requires it.
 
 ```bash
-uv pip install "pyAMICA[mlx]"   # or: uv pip install mlx
+uv sync --extra mlx   # or, in an existing environment: uv pip install mlx
 ```
 
 ## Quickstart

--- a/paper.bib
+++ b/paper.bib
@@ -95,7 +95,8 @@
   booktitle = {Advances in Neural Information Processing Systems},
   volume = {32},
   pages = {8024--8035},
-  year = {2019}
+  year = {2019},
+  note = {arXiv:1912.01703}
 }
 
 @article{harris2020array,
@@ -122,9 +123,57 @@
   doi = {10.1038/s41592-019-0686-2}
 }
 
+@article{amari1998natural,
+  title = {Natural gradient works efficiently in learning},
+  author = {Amari, Shun-Ichi},
+  journal = {Neural Computation},
+  volume = {10},
+  number = {2},
+  pages = {251--276},
+  year = {1998},
+  publisher = {MIT Press},
+  doi = {10.1162/089976698300017746}
+}
+
+@inproceedings{palmer2008newton,
+  title = {Newton method for the {ICA} mixture model},
+  author = {Palmer, Jason A. and Kreutz-Delgado, Kenneth and Rao, Bhaskar D. and Makeig, Scott},
+  booktitle = {2008 IEEE International Conference on Acoustics, Speech and Signal Processing (ICASSP)},
+  pages = {1805--1808},
+  year = {2008},
+  publisher = {IEEE},
+  doi = {10.1109/ICASSP.2008.4517982}
+}
+
+@article{piontonachini2019iclabel,
+  title = {{ICLabel}: An automated electroencephalographic independent component classifier, dataset, and website},
+  author = {Pion-Tonachini, Luca and Kreutz-Delgado, Kenneth and Makeig, Scott},
+  journal = {NeuroImage},
+  volume = {198},
+  pages = {181--197},
+  year = {2019},
+  publisher = {Elsevier},
+  doi = {10.1016/j.neuroimage.2019.05.026}
+}
+
+@misc{esmaeili2025amica,
+  title = {amica: Native Python implementation of {AMICA} for {MNE-Python} and scientific {EEG} workflows},
+  author = {Esmaeili, Sina},
+  year = {2025},
+  howpublished = {\url{https://github.com/snesmaeili/amica}}
+}
+
+@misc{herforth2026pyamica,
+  title = {pyamica: {PyTorch} {AMICA}, Adaptive Mixture Independent Component Analysis},
+  author = {Herforth, Johannes},
+  year = {2026},
+  howpublished = {\url{https://github.com/DerAndereJohannes/pyamica}}
+}
+
 @misc{mlx2023,
   title = {{MLX}: Efficient and flexible machine learning on Apple silicon},
   author = {Hannun, Awni and Digani, Jagrit and Katharopoulos, Angelos and Collobert, Ronan},
   year = {2023},
+  note = {Version 0.x, accessed 2026},
   howpublished = {\url{https://github.com/ml-explore/mlx}}
 }

--- a/paper.bib
+++ b/paper.bib
@@ -1,0 +1,130 @@
+@techreport{palmer2012amica,
+  title = {{AMICA}: An adaptive mixture of independent component analyzers with shared components},
+  author = {Palmer, Jason A. and Kreutz-Delgado, Kenneth and Makeig, Scott},
+  year = {2012},
+  institution = {Swartz Center for Computational Neuroscience, University of California San Diego},
+  url = {https://sccn.ucsd.edu/~jason/amica_a.pdf}
+}
+
+@article{delorme2012independent,
+  title = {Independent {EEG} sources are dipolar},
+  author = {Delorme, Arnaud and Palmer, Jason and Onton, Julie and Oostenveld, Robert and Makeig, Scott},
+  journal = {PLoS ONE},
+  volume = {7},
+  number = {2},
+  pages = {e30135},
+  year = {2012},
+  publisher = {Public Library of Science},
+  doi = {10.1371/journal.pone.0030135}
+}
+
+@article{delorme2004eeglab,
+  title = {{EEGLAB}: an open source toolbox for analysis of single-trial {EEG} dynamics including independent component analysis},
+  author = {Delorme, Arnaud and Makeig, Scott},
+  journal = {Journal of Neuroscience Methods},
+  volume = {134},
+  number = {1},
+  pages = {9--21},
+  year = {2004},
+  publisher = {Elsevier},
+  doi = {10.1016/j.jneumeth.2003.10.009}
+}
+
+@article{bell1995information,
+  title = {An information-maximization approach to blind separation and blind deconvolution},
+  author = {Bell, Anthony J. and Sejnowski, Terrence J.},
+  journal = {Neural Computation},
+  volume = {7},
+  number = {6},
+  pages = {1129--1159},
+  year = {1995},
+  publisher = {MIT Press},
+  doi = {10.1162/neco.1995.7.6.1129}
+}
+
+@article{lee1999independent,
+  title = {Independent component analysis using an extended infomax algorithm for mixed subgaussian and supergaussian sources},
+  author = {Lee, Te-Won and Girolami, Mark and Sejnowski, Terrence J.},
+  journal = {Neural Computation},
+  volume = {11},
+  number = {2},
+  pages = {417--441},
+  year = {1999},
+  publisher = {MIT Press},
+  doi = {10.1162/089976699300016719}
+}
+
+@article{hyvarinen2000independent,
+  title = {Independent component analysis: algorithms and applications},
+  author = {Hyv{\"a}rinen, Aapo and Oja, Erkki},
+  journal = {Neural Networks},
+  volume = {13},
+  number = {4-5},
+  pages = {411--430},
+  year = {2000},
+  publisher = {Elsevier},
+  doi = {10.1016/S0893-6080(00)00026-5}
+}
+
+@article{ablin2018faster,
+  title = {Faster independent component analysis by preconditioning with Hessian approximations},
+  author = {Ablin, Pierre and Cardoso, Jean-Fran{\c{c}}ois and Gramfort, Alexandre},
+  journal = {IEEE Transactions on Signal Processing},
+  volume = {66},
+  number = {15},
+  pages = {4040--4053},
+  year = {2018},
+  publisher = {IEEE},
+  doi = {10.1109/TSP.2018.2844203}
+}
+
+@article{gramfort2013meg,
+  title = {{MEG} and {EEG} data analysis with {MNE-Python}},
+  author = {Gramfort, Alexandre and Luessi, Martin and Larson, Eric and Engemann, Denis A. and Strohmeier, Daniel and Brodbeck, Christian and Goj, Roman and Jas, Mainak and Brooks, Teon and Parkkonen, Lauri and H{\"a}m{\"a}l{\"a}inen, Matti},
+  journal = {Frontiers in Neuroscience},
+  volume = {7},
+  pages = {267},
+  year = {2013},
+  publisher = {Frontiers},
+  doi = {10.3389/fnins.2013.00267}
+}
+
+@inproceedings{paszke2019pytorch,
+  title = {{PyTorch}: An imperative style, high-performance deep learning library},
+  author = {Paszke, Adam and Gross, Sam and Massa, Francisco and Lerer, Adam and Bradbury, James and Chanan, Gregory and Killeen, Trevor and Lin, Zeming and Gimelshein, Natalia and Antiga, Luca and others},
+  booktitle = {Advances in Neural Information Processing Systems},
+  volume = {32},
+  pages = {8024--8035},
+  year = {2019}
+}
+
+@article{harris2020array,
+  title = {Array programming with {NumPy}},
+  author = {Harris, Charles R. and Millman, K. Jarrod and van der Walt, St{\'e}fan J. and Gommers, Ralf and Virtanen, Pauli and Cournapeau, David and Wieser, Eric and Taylor, Julian and Berg, Sebastian and Smith, Nathaniel J. and others},
+  journal = {Nature},
+  volume = {585},
+  number = {7825},
+  pages = {357--362},
+  year = {2020},
+  publisher = {Nature Publishing Group},
+  doi = {10.1038/s41586-020-2649-2}
+}
+
+@article{virtanen2020scipy,
+  title = {{SciPy} 1.0: fundamental algorithms for scientific computing in Python},
+  author = {Virtanen, Pauli and Gommers, Ralf and Oliphant, Travis E. and Haberland, Matt and Reddy, Tyler and Cournapeau, David and Burovski, Evgeni and Peterson, Pearu and Weckesser, Warren and Bright, Jonathan and others},
+  journal = {Nature Methods},
+  volume = {17},
+  number = {3},
+  pages = {261--272},
+  year = {2020},
+  publisher = {Nature Publishing Group},
+  doi = {10.1038/s41592-019-0686-2}
+}
+
+@misc{mlx2023,
+  title = {{MLX}: Efficient and flexible machine learning on Apple silicon},
+  author = {Hannun, Awni and Digani, Jagrit and Katharopoulos, Angelos and Collobert, Ronan},
+  year = {2023},
+  howpublished = {\url{https://github.com/ml-explore/mlx}}
+}

--- a/paper.md
+++ b/paper.md
@@ -12,9 +12,17 @@ authors:
     orcid: 0000-0001-5557-259X
     corresponding: true
     affiliation: 1
+  - name: Arnaud Delorme
+    orcid: 0000-0002-0799-3557
+    affiliation: "1, 2"
+  - name: Scott Makeig
+    orcid: 0000-0002-9048-8438
+    affiliation: 1
 affiliations:
   - name: Swartz Center for Computational Neuroscience, Institute for Neural Computation, University of California San Diego, USA
     index: 1
+  - name: Centre de Recherche Cerveau et Cognition (CerCo), CNRS, University of Toulouse, France
+    index: 2
 date: 11 July 2026
 bibliography: paper.bib
 ---
@@ -51,9 +59,9 @@ AMICA yields components that are well suited to equivalent-dipole source
 localization and to automated classification of independent components
 [@piontonachini2019iclabel], and it separates EEG more effectively than most
 alternatives [@delorme2012independent; @palmer2012amica]. The reference
-implementation is the original Fortran code: it depends on a Message Passing
-Interface (MPI) toolchain and precompiled binaries that are awkward to build
-across platforms, it cannot use a GPU, and it is invoked as an external process
+implementation is the original Fortran code: it depends on an MPI toolchain and
+precompiled binaries that are awkward to build across platforms, it cannot use a
+GPU, and it is invoked as an external process
 from MATLAB rather than called from Python. As neuroimaging analysis has moved
 toward Python, for example MNE-Python [@gramfort2013meg], an AMICA that runs
 natively in Python and on a GPU, and that is validated to reproduce the Fortran
@@ -119,8 +127,8 @@ output, and by an MLX backend for Apple GPUs.
 
 # Acknowledgements
 
-We thank Jason Palmer, Ken Kreutz-Delgado, and Scott Makeig for developing AMICA
-and making the reference implementation available, and the EEGLAB community for
-the tools and sample data used to validate this work.
+We thank Jason Palmer and Ken Kreutz-Delgado, co-developers of AMICA, for the
+reference implementation, and the EEGLAB community for the tools and sample data
+used to validate this work.
 
 # References

--- a/paper.md
+++ b/paper.md
@@ -9,7 +9,7 @@ tags:
   - neuroscience
 authors:
   - name: Seyed Yahya Shirazi
-    orcid: 0000-0000-0000-0000
+    orcid: 0000-0001-5557-259X
     corresponding: true
     affiliation: 1
 affiliations:

--- a/paper.md
+++ b/paper.md
@@ -5,7 +5,6 @@ tags:
   - PyTorch
   - independent component analysis
   - blind source separation
-  - electroencephalography
   - EEG
   - neuroscience
 authors:
@@ -27,8 +26,9 @@ electroencephalography (EEG) and electromyography (EMG) recordings into
 maximally independent sources, which isolates brain, muscle, and artifact
 activity for downstream analysis. Adaptive Mixture ICA (AMICA) generalizes single-model
 ICA to a mixture of ICA models with adaptive source densities, and produces the
-most dipolar, physiologically interpretable component decompositions of EEG among
-widely used algorithms [@delorme2012independent]. Its reference implementation,
+most dipolar component decompositions of EEG among widely used algorithms, meaning
+its components are best modeled by a single equivalent current dipole and are
+therefore the most physiologically interpretable [@delorme2012independent]. Its reference implementation,
 however, is a Fortran program parallelized with the Message Passing Interface
 (MPI) and distributed as a compiled binary driven from MATLAB/EEGLAB, which is
 difficult to install, runs only on the CPU, and is not usable from a Python
@@ -39,23 +39,26 @@ Fortran results within numerical tolerance while running on the CPU, NVIDIA GPUs
 (CUDA), and Apple GPUs (Apple's MLX array framework [@mlx2023]). It is built on
 PyTorch [@paszke2019pytorch], NumPy [@harris2020array], and SciPy
 [@virtanen2020scipy], exposes a scikit-learn-style estimator, and writes results
-in the exact binary format that EEGLAB's AMICA loader reads, so a `pyAMICA` run
-is a drop-in replacement for a native AMICA run with no manual re-interpretation.
-Correctness is defined as parity with the Fortran reference and is validated on
-real EEG against the reference binary rather than on synthetic data.
+in the exact binary format that EEGLAB's AMICA loader reads. A single-model
+`pyAMICA` run is byte-identical to a native AMICA run and needs no manual
+re-interpretation; multi-model output round-trips through the same EEGLAB loader
+with a self-consistent layout. Correctness is defined as parity with the Fortran
+reference and is validated on real EEG against the reference binary.
 
 # Statement of need
 
 AMICA yields components that are well suited to equivalent-dipole source
-localization and automated classification, and it separates EEG more effectively
-than most alternatives [@delorme2012independent; @palmer2012amica]. Despite this,
-the only maintained implementation is the original Fortran code: it depends on an
-MPI toolchain and precompiled binaries that are awkward to build across platforms,
-it cannot use a GPU, and it is invoked as an external process from MATLAB rather
-than called from Python. As neuroimaging analysis has moved toward Python (for example
-MNE-Python [@gramfort2013meg]), this leaves no native, GPU-capable AMICA for
-modern pipelines, and no way to study or extend the algorithm in a
-readable, testable codebase.
+localization and to automated classification of independent components
+[@piontonachini2019iclabel], and it separates EEG more effectively than most
+alternatives [@delorme2012independent; @palmer2012amica]. The reference
+implementation is the original Fortran code: it depends on a Message Passing
+Interface (MPI) toolchain and precompiled binaries that are awkward to build
+across platforms, it cannot use a GPU, and it is invoked as an external process
+from MATLAB rather than called from Python. As neuroimaging analysis has moved
+toward Python, for example MNE-Python [@gramfort2013meg], an AMICA that runs
+natively in Python and on a GPU, and that is validated to reproduce the Fortran
+reference numerically, is needed for modern pipelines and for studying the
+algorithm in an open codebase.
 
 General-purpose Python ICA implementations do not fill this gap. `scikit-learn`
 and `MNE-Python` provide FastICA [@hyvarinen2000independent] and Infomax
@@ -70,9 +73,10 @@ implementation to inspect and build on.
 
 # Implementation and validation
 
-`pyAMICA` provides a natural-gradient expectation-maximization backend that ports
-the full AMICA algorithm: exact-EM mixture updates, a positive-definite Newton
-step, symmetric zero-phase-component-analysis (ZCA) sphering, the five
+`pyAMICA` provides a natural-gradient [@amari1998natural] expectation-maximization
+backend that ports the full AMICA algorithm: exact-EM mixture updates, a
+positive-definite Newton step [@palmer2008newton], symmetric
+zero-phase-component-analysis (ZCA) sphering, the five
 source-density families of the reference (generalized Gaussian, Gaussian,
 logistic, sub-Gaussian, and the extended-Infomax kurtosis switcher), a mixture of
 ICA models, and component sharing across models. On real sample EEG, the
@@ -95,19 +99,23 @@ runs about 4.5 times faster than a 16-thread CPU. A data-size sweep shows that
 cross-backend component equivalence rises with the number of frames per channel
 and plateaus near 0.98 once the decomposition is well determined. A companion
 validation harness runs both the Python and Fortran implementations on the same
-real EEG and matches components with the Hungarian algorithm, and the test suite
-uses only real sample data and the reference binary, never synthetic data, so
-correctness claims are always measured against the reference.
+real EEG and matches components with the Hungarian algorithm. Correctness tests
+use only real sample EEG and the reference binary; synthetic data is never used
+as the basis for a correctness claim, so parity is always measured against the
+reference.
 
 # State of the field
 
 `pyAMICA` complements rather than replaces EEGLAB [@delorme2004eeglab] and its
-Fortran AMICA plugin: it reads and writes the same output format, so results can
-move between the two, while adding GPU support and a Python API. Relative to
-FastICA, Infomax, and Picard, it is the only Python package that reproduces
-AMICA's mixture-of-models decomposition, and relative to the Fortran reference it
-adds installation through standard Python packaging, GPU execution, and an
-open, tested codebase.
+Fortran AMICA plugin: it reads and writes the same output format, so results move
+between the two, while adding GPU support and a Python API. Other Python AMICA
+reimplementations have appeared [@esmaeili2025amica; @herforth2026pyamica], which
+also target MNE-Python pipelines and GPU execution. `pyAMICA` is distinguished by
+defining correctness as quantitative parity with the Fortran reference and
+validating it accordingly (component correlation of about 0.997, source-density
+score functions bit-exact to about $10^{-15}$, and a distributional-equivalence
+test for the non-identifiable multi-model case), by writing byte-identical EEGLAB
+output, and by an MLX backend for Apple GPUs.
 
 # Acknowledgements
 

--- a/paper.md
+++ b/paper.md
@@ -1,0 +1,118 @@
+---
+title: 'pyAMICA: GPU-accelerated Adaptive Mixture Independent Component Analysis in Python with Fortran parity'
+tags:
+  - Python
+  - PyTorch
+  - independent component analysis
+  - blind source separation
+  - electroencephalography
+  - EEG
+  - neuroscience
+authors:
+  - name: Seyed Yahya Shirazi
+    orcid: 0000-0000-0000-0000
+    corresponding: true
+    affiliation: 1
+affiliations:
+  - name: Swartz Center for Computational Neuroscience, Institute for Neural Computation, University of California San Diego, USA
+    index: 1
+date: 11 July 2026
+bibliography: paper.bib
+---
+
+# Summary
+
+Independent Component Analysis (ICA) is a standard method for separating
+electroencephalography (EEG) and electromyography (EMG) recordings into
+maximally independent sources, which isolates brain, muscle, and artifact
+activity for downstream analysis. Adaptive Mixture ICA (AMICA) generalizes single-model
+ICA to a mixture of ICA models with adaptive source densities, and produces the
+most dipolar, physiologically interpretable component decompositions of EEG among
+widely used algorithms [@delorme2012independent]. Its reference implementation,
+however, is a Fortran program parallelized with the Message Passing Interface
+(MPI) and distributed as a compiled binary driven from MATLAB/EEGLAB, which is
+difficult to install, runs only on the CPU, and is not usable from a Python
+scientific workflow.
+
+`pyAMICA` is a Python implementation of AMICA that reproduces the reference
+Fortran results within numerical tolerance while running on the CPU, NVIDIA GPUs
+(CUDA), and Apple GPUs (Apple's MLX array framework [@mlx2023]). It is built on
+PyTorch [@paszke2019pytorch], NumPy [@harris2020array], and SciPy
+[@virtanen2020scipy], exposes a scikit-learn-style estimator, and writes results
+in the exact binary format that EEGLAB's AMICA loader reads, so a `pyAMICA` run
+is a drop-in replacement for a native AMICA run with no manual re-interpretation.
+Correctness is defined as parity with the Fortran reference and is validated on
+real EEG against the reference binary rather than on synthetic data.
+
+# Statement of need
+
+AMICA yields components that are well suited to equivalent-dipole source
+localization and automated classification, and it separates EEG more effectively
+than most alternatives [@delorme2012independent; @palmer2012amica]. Despite this,
+the only maintained implementation is the original Fortran code: it depends on an
+MPI toolchain and precompiled binaries that are awkward to build across platforms,
+it cannot use a GPU, and it is invoked as an external process from MATLAB rather
+than called from Python. As neuroimaging analysis has moved toward Python (for example
+MNE-Python [@gramfort2013meg]), this leaves no native, GPU-capable AMICA for
+modern pipelines, and no way to study or extend the algorithm in a
+readable, testable codebase.
+
+General-purpose Python ICA implementations do not fill this gap. `scikit-learn`
+and `MNE-Python` provide FastICA [@hyvarinen2000independent] and Infomax
+[@bell1995information; @lee1999independent], and Picard [@ablin2018faster]
+provides a faster maximum-likelihood ICA, but none implement AMICA's mixture of
+models, adaptive generalized-Gaussian source densities, or Newton updates, and so
+they do not reproduce AMICA decompositions. `pyAMICA` targets researchers who
+need AMICA specifically: EEG/EMG analysts who want AMICA-quality decompositions
+inside a Python pipeline, users of GPU hardware who want faster runs than the
+CPU-only binary, and methodologists who need a transparent reference
+implementation to inspect and build on.
+
+# Implementation and validation
+
+`pyAMICA` provides a natural-gradient expectation-maximization backend that ports
+the full AMICA algorithm: exact-EM mixture updates, a positive-definite Newton
+step, symmetric zero-phase-component-analysis (ZCA) sphering, the five
+source-density families of the reference (generalized Gaussian, Gaussian,
+logistic, sub-Gaussian, and the extended-Infomax kurtosis switcher), a mixture of
+ICA models, and component sharing across models. On real sample EEG, the
+single-model solution matches the Fortran reference to a log-likelihood of
+approximately -3.40 (reference -3.4018) with a Hungarian-matched component
+correlation of approximately 0.997. The fixed source-density families are
+bit-exact against the literal Fortran score and derivative expressions (to about
+$10^{-15}$). Because a mixture of ICA models is not partition-identifiable, the
+multi-model case is validated by distributional equivalence: the
+implementation-versus-reference cross-correlation distribution is statistically
+indistinguishable from the reference's own run-to-run spread (Mann-Whitney
+$p = 0.97$).
+
+Across hardware, all backends agree on the log-likelihood to at least three
+significant digits on real EEG. On Apple Silicon the MLX backend is the fastest
+option (roughly 15-25 ms per iteration, about seven times faster than a
+multithreaded CPU and faster than an NVIDIA RTX 4090 at EEG channel counts),
+while double-precision CUDA is the bit-reproducible path on NVIDIA hardware and
+runs about 4.5 times faster than a 16-thread CPU. A data-size sweep shows that
+cross-backend component equivalence rises with the number of frames per channel
+and plateaus near 0.98 once the decomposition is well determined. A companion
+validation harness runs both the Python and Fortran implementations on the same
+real EEG and matches components with the Hungarian algorithm, and the test suite
+uses only real sample data and the reference binary, never synthetic data, so
+correctness claims are always measured against the reference.
+
+# State of the field
+
+`pyAMICA` complements rather than replaces EEGLAB [@delorme2004eeglab] and its
+Fortran AMICA plugin: it reads and writes the same output format, so results can
+move between the two, while adding GPU support and a Python API. Relative to
+FastICA, Infomax, and Picard, it is the only Python package that reproduces
+AMICA's mixture-of-models decomposition, and relative to the Fortran reference it
+adds installation through standard Python packaging, GPU execution, and an
+open, tested codebase.
+
+# Acknowledgements
+
+We thank Jason Palmer, Ken Kreutz-Delgado, and Scott Makeig for developing AMICA
+and making the reference implementation available, and the EEGLAB community for
+the tools and sample data used to validate this work.
+
+# References

--- a/pyAMICA/sample_data/ATTRIBUTION.md
+++ b/pyAMICA/sample_data/ATTRIBUTION.md
@@ -1,0 +1,26 @@
+# Sample data and reference artifacts: provenance and licenses
+
+The files in this directory are third-party artifacts bundled solely to validate
+pyAMICA against the reference AMICA implementation. They are used for testing and
+documentation and are not part of the installable `pyAMICA` package.
+
+- **`amica15mac`** - the reference AMICA binary (macOS x86_64), compiled from the
+  AMICA source distributed by the Swartz Center for Computational Neuroscience
+  (SCCN), UC San Diego: <https://github.com/sccn/amica> (Palmer, Kreutz-Delgado,
+  and Makeig). Redistributed here for parity testing only. See the SCCN AMICA
+  repository for its license terms.
+
+- **`loadmodout15.m`** - the AMICA output reader from the EEGLAB AMICA plugin
+  (SCCN): <https://github.com/sccn/amica>. Used to document and check the EEGLAB
+  round-trip. Its license is that of the EEGLAB AMICA plugin.
+
+- **`eeglab_data.fdt`, `eeglab_data.set`** - the EEGLAB sample EEG dataset,
+  distributed with EEGLAB (SCCN): <https://github.com/sccn/eeglab>. Used as real
+  sample data for the tests and benchmarks.
+
+- **`amicaout/`, `input.param`, `sample_params.json`, `pyresults/`** - reference
+  AMICA output, parameter files, and derived results produced from the artifacts
+  above for the validation harness.
+
+If you redistribute or repackage these files, retain the attribution and comply
+with the upstream SCCN/EEGLAB license terms.


### PR DESCRIPTION
Closes #101.

## Summary
Adds the Journal of Open Source Software (JOSS) submission for pyAMICA: `paper.md`
(~880 words) and `paper.bib` (17 references, all DOIs verified). Also addresses
repository items a JOSS reviewer checks alongside the paper.

## What is included
- **paper.md**: Summary, Statement of need, Implementation and validation, State
  of the field, Acknowledgements. Sole author (S. Y. Shirazi), SCCN/UCSD.
- **paper.bib**: AMICA (Palmer et al.), natural gradient (Amari), Newton-ICA
  (Palmer et al. 2008), ICLabel, EEGLAB, Infomax, extended Infomax, FastICA,
  Picard, MNE, PyTorch, NumPy, SciPy, MLX, and the two other Python AMICA
  reimplementations. All journal DOIs resolved against the publisher.
- **README**: de-WIP'd; reflects validated Fortran parity, GPU backends, docs;
  install via `uv sync`.
- **getting-started**: install from source (a PyPI release name is deferred).
- **LICENSE**: copyright year 2023-2026.
- **sample_data/ATTRIBUTION.md**: provenance/licenses for the bundled SCCN/EEGLAB
  test artifacts (Fortran binary, sample EEG, `loadmodout15.m`).

## Process (per the no-shortcuts standard)
- Drafted with the `manuscript-writing` skill; polished with `humanizer`.
- Independent `paper-review` (JOSS reviewer). Findings addressed: the novelty
  claim was reframed after a landscape check found two other public Python AMICA
  packages (now cited); missing methods citations added (natural gradient,
  Newton-ICA, ICLabel); the drop-in claim scoped to single-model (multi-model
  round-trips with a self-consistent layout); the test-suite wording corrected
  to "synthetic data is never the basis of a correctness claim"; "dipolar"
  glossed for non-specialists.

## Remaining before actual JOSS submission (author action)
- **ORCID**: `paper.md` still has a placeholder; the corresponding author's real
  ORCID must replace it.
- **Archived release** (Zenodo/Software Heritage) with a matching version, and
  the PyPI distribution name, to be arranged at the transfer/release step.

Tested: paper is not code; all 17 citation keys resolve to bib entries; docs
build is exercised by the existing docs workflow.