### PR TITLE
Prepare 0.1.0 release: version bump + sccn URLs

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,10 +21,10 @@ authors:
     given-names: Scott
     orcid: "https://orcid.org/0000-0002-9048-8438"
     affiliation: "Swartz Center for Computational Neuroscience, University of California San Diego"
-version: 0.1.dev0
+version: 0.1.0
 license: BSD-3-Clause
-repository-code: "https://github.com/neuromechanist/pyAMICA"
-url: "https://github.com/neuromechanist/pyAMICA"
+repository-code: "https://github.com/sccn/pyAMICA"
+url: "https://github.com/sccn/pyAMICA"
 keywords:
   - AMICA
   - independent component analysis

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ standard rather than to "it converges."
 ## Getting help and reporting issues
 
 - **Questions, bugs, and feature requests:** please open an issue on the
-  [GitHub issue tracker](https://github.com/neuromechanist/pyAMICA/issues).
+  [GitHub issue tracker](https://github.com/sccn/pyAMICA/issues).
 - When reporting a bug, include the pyAMICA version, platform, device
   (CPU/CUDA/MPS/MLX), precision (float32/float64), and a minimal example.
 
@@ -19,7 +19,7 @@ pyAMICA uses [UV](https://docs.astral.sh/uv/) for environment and dependency
 management.
 
 ```bash
-git clone https://github.com/neuromechanist/pyAMICA.git
+git clone https://github.com/sccn/pyAMICA.git
 cd pyAMICA
 uv sync                 # install the project and dependencies
 uv run pytest           # run the test suite

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pyAMICA: Adaptive Mixture ICA
 
-[![CI](https://github.com/neuromechanist/pyAMICA/actions/workflows/ci.yml/badge.svg)](https://github.com/neuromechanist/pyAMICA/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/neuromechanist/pyAMICA/branch/main/graph/badge.svg)](https://codecov.io/gh/neuromechanist/pyAMICA)
+[![CI](https://github.com/sccn/pyAMICA/actions/workflows/ci.yml/badge.svg)](https://github.com/sccn/pyAMICA/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/sccn/pyAMICA/branch/main/graph/badge.svg)](https://codecov.io/gh/sccn/pyAMICA)
 
 Python (PyTorch) implementation of Adaptive Mixture Independent Component Analysis
 (AMICA) that reproduces the reference Fortran implementation within numerical
@@ -31,7 +31,7 @@ AMICA (Adaptive Mixture ICA) is an advanced blind source separation algorithm th
 The canonical environment is [uv](https://docs.astral.sh/uv/):
 
 ```bash
-git clone https://github.com/neuromechanist/pyAMICA.git
+git clone https://github.com/sccn/pyAMICA.git
 cd pyAMICA
 uv sync                     # install dependencies into a managed venv
 uv run pytest               # optional: run the tests

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,12 +1,21 @@
 # Changelog
 
-Release notes are published on the
-[GitHub releases page](https://github.com/neuromechanist/pyAMICA/releases).
+Release notes are also published on the
+[GitHub releases page](https://github.com/sccn/pyAMICA/releases).
 
-## Unreleased
+## 0.1.0
 
-- Documentation site (MkDocs Material) and GitHub Pages deployment.
+First public release.
 
-!!! note
-    A curated, versioned changelog will be maintained here starting with the
-    first public release.
+- PyTorch natural-gradient EM backend (`AMICATorchNG`) at Fortran parity on real
+  EEG (single-model log-likelihood ~ -3.40, Hungarian-matched component
+  correlation ~ 0.997).
+- Backends: CPU, NVIDIA GPU (CUDA), and Apple GPU (MLX); float64 for parity,
+  float32 for speed.
+- All five source-density families, mixture of ICA models, Newton updates,
+  component sharing, and outlier rejection.
+- EEGLAB drop-in output: `write_amica_output` writes the `loadmodout15` format,
+  and `variance_order` gives the EEGLAB back-projected-variance component order.
+- Spatially-distributed channel-subset selection and a data-size (k-factor)
+  cross-backend equivalence sweep for the benchmarks.
+- scikit-learn-style `AMICA` interface, save/load, and a documentation site.

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,14 +1,14 @@
 # Contributing
 
 Contributions are welcome. This page summarizes the development workflow; see the
-full [CONTRIBUTING](https://github.com/neuromechanist/pyAMICA/blob/main/CONTRIBUTING.md)
-and [Code of Conduct](https://github.com/neuromechanist/pyAMICA/blob/main/CODE_OF_CONDUCT.md)
+full [CONTRIBUTING](https://github.com/sccn/pyAMICA/blob/main/CONTRIBUTING.md)
+and [Code of Conduct](https://github.com/sccn/pyAMICA/blob/main/CODE_OF_CONDUCT.md)
 in the repository root.
 
 ## Development setup
 
 ```bash
-git clone https://github.com/neuromechanist/pyAMICA.git
+git clone https://github.com/sccn/pyAMICA.git
 cd pyAMICA
 uv sync                 # install the project and dependencies
 uv run pytest           # run the test suite
@@ -27,5 +27,5 @@ uv run pytest           # run the test suite
 ## Reporting issues and getting help
 
 Please open an issue on the
-[GitHub issue tracker](https://github.com/neuromechanist/pyAMICA/issues) for bug
+[GitHub issue tracker](https://github.com/sccn/pyAMICA/issues) for bug
 reports, feature requests, and questions.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,7 @@ management.
 ### From source
 
 ```bash
-git clone https://github.com/neuromechanist/pyAMICA.git
+git clone https://github.com/sccn/pyAMICA.git
 cd pyAMICA
 uv sync            # install the project and its dependencies into .venv
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,17 +1,16 @@
 # pyAMICA documentation (MkDocs Material).
-# Deployed to GitHub Pages by .github/workflows/docs.yml. Once the repo lives at
-# github.com/sccn/pyAMICA, its project Pages inherit the sccn org Pages custom
+# Deployed to GitHub Pages by .github/workflows/docs.yml. The repo lives at
+# github.com/sccn/pyAMICA, whose project Pages inherit the sccn org Pages custom
 # domain (eeglab.org) at the /pyAMICA subpath, so the site is served at
-# https://eeglab.org/pyAMICA/. Links are relative so the same build also works at
-# https://neuromechanist.github.io/pyAMICA/ before the transfer.
+# https://eeglab.org/pyAMICA/. Links are relative so the build is location-independent.
 
 site_name: pyAMICA Documentation
 site_url: https://eeglab.org/pyAMICA/
 site_description: Python (PyTorch) implementation of Adaptive Mixture ICA (AMICA) with Fortran parity and GPU/MPS/CPU support.
 site_author: Seyed Yahya Shirazi
 
-repo_url: https://github.com/neuromechanist/pyAMICA/
-repo_name: neuromechanist/pyAMICA
+repo_url: https://github.com/sccn/pyAMICA/
+repo_name: sccn/pyAMICA
 edit_uri: edit/main/docs/
 
 theme:

--- a/pyAMICA/version.py
+++ b/pyAMICA/version.py
@@ -3,9 +3,8 @@ from os.path import join as pjoin
 # Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"
 _version_major = 0
 _version_minor = 1
-_version_micro = ""  # use '' for first of series, number for 1 and above
-_version_extra = "dev"
-# _version_extra = ''  # Uncomment this for full releases
+_version_micro = "0"  # use '' for first of series, number for 1 and above
+_version_extra = ""  # '' for full releases; 'dev' for development
 
 # Construct full version string from these.
 _ver = [_version_major, _version_minor]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyAMICA"
-version = "0.1.dev0"
+version = "0.1.0"
 description = "pyAMICA: Python implementation of the Adaptive Mixture ICA algorithm"
 readme = "README.md"
 authors = [
@@ -51,8 +51,8 @@ docs = [
 viz = ["mne>=1.6"]
 
 [project.urls]
-Homepage = "http://github.com/neuromechanist/pyAMICA"
-Repository = "http://github.com/neuromechanist/pyAMICA"
+Homepage = "https://github.com/sccn/pyAMICA"
+Repository = "https://github.com/sccn/pyAMICA"
 
 [tool.setuptools]
 # List subpackages explicitly so the wheel is deterministic across platforms

--- a/uv.lock
+++ b/uv.lock
@@ -1267,7 +1267,7 @@ wheels = [
 
 [[package]]
 name = "pyamica"
-version = "0.1.dev0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "json5" },


### PR DESCRIPTION
Release prep for the first tagged release (v0.1.0), post-transfer to sccn.

## Changes
- **Version bump** `0.1.dev0` -> `0.1.0` (`pyproject.toml`, `pyAMICA/version.py`, `CITATION.cff`).
- **Repository URLs** updated `neuromechanist/pyAMICA` -> `sccn/pyAMICA` (README badges,
  clone URLs, CITATION, pyproject Homepage/Repository, mkdocs repo_url/repo_name,
  CONTRIBUTING, docs). Fixed `http://` -> `https://` in pyproject URLs.
- **Changelog** 0.1.0 entry (backends, Fortran parity, EEGLAB drop-in output,
  five density families, mixture models, sharing, benchmarks, sklearn API).
- mkdocs staging-URL comment updated (transfer complete; `site_url` stays
  `https://eeglab.org/pyAMICA/`).

Docs build passes `mkdocs build --strict`. Version resolves to `0.1.0`.

After merge: tag `v0.1.0` and cut a GitHub release; a Zenodo archive follows later.