### PR TITLE
Add .zenodo.json and ROR-based citation metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -3,7 +3,7 @@
   "description": "pyAMICA is a Python (PyTorch) implementation of Adaptive Mixture Independent Component Analysis (AMICA) that reproduces the reference Fortran implementation within numerical tolerance, with CPU, NVIDIA GPU (CUDA), and Apple GPU (MLX) support. It targets EEG/EMG blind source separation and provides a scikit-learn-style interface and byte-identical EEGLAB (loadmodout15) output.",
   "upload_type": "software",
   "access_right": "open",
-  "license": "BSD-3-Clause",
+  "license": "bsd-3-clause",
   "creators": [
     {
       "name": "Shirazi, Seyed Yahya",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,42 @@
+{
+  "title": "pyAMICA: a Python implementation of Adaptive Mixture ICA",
+  "description": "pyAMICA is a Python (PyTorch) implementation of Adaptive Mixture Independent Component Analysis (AMICA) that reproduces the reference Fortran implementation within numerical tolerance, with CPU, NVIDIA GPU (CUDA), and Apple GPU (MLX) support. It targets EEG/EMG blind source separation and provides a scikit-learn-style interface and byte-identical EEGLAB (loadmodout15) output.",
+  "upload_type": "software",
+  "access_right": "open",
+  "license": "BSD-3-Clause",
+  "creators": [
+    {
+      "name": "Shirazi, Seyed Yahya",
+      "orcid": "0000-0001-5557-259X",
+      "affiliation": "Swartz Center for Computational Neuroscience, University of California San Diego"
+    },
+    {
+      "name": "Delorme, Arnaud",
+      "orcid": "0000-0002-0799-3557",
+      "affiliation": "Swartz Center for Computational Neuroscience, University of California San Diego; Centre de Recherche Cerveau et Cognition (CerCo), CNRS, University of Toulouse"
+    },
+    {
+      "name": "Makeig, Scott",
+      "orcid": "0000-0002-9048-8438",
+      "affiliation": "Swartz Center for Computational Neuroscience, University of California San Diego"
+    }
+  ],
+  "keywords": [
+    "AMICA",
+    "independent component analysis",
+    "blind source separation",
+    "EEG",
+    "EMG",
+    "PyTorch",
+    "MLX",
+    "EEGLAB"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://eeglab.org/pyAMICA/",
+      "relation": "isDocumentedBy",
+      "scheme": "url",
+      "resource_type": "publication-softwaredocumentation"
+    }
+  ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-cff-version: 1.2.0
+cff-version: 1.3.0
 message: "If you use this software, please cite it using the metadata below."
 title: "pyAMICA: a Python implementation of Adaptive Mixture ICA"
 abstract: >-
@@ -12,19 +12,28 @@ authors:
     given-names: Seyed Yahya
     email: shirazi@ieee.org
     orcid: "https://orcid.org/0000-0001-5557-259X"
-    affiliation: "Swartz Center for Computational Neuroscience, University of California San Diego"
+    affiliation:
+      name: "Swartz Center for Computational Neuroscience"
+      ror: "https://ror.org/01bt2qm76"
   - family-names: Delorme
     given-names: Arnaud
     orcid: "https://orcid.org/0000-0002-0799-3557"
-    affiliation: "Swartz Center for Computational Neuroscience, University of California San Diego; CNRS, University of Toulouse"
+    affiliation:
+      - name: "Swartz Center for Computational Neuroscience"
+        ror: "https://ror.org/01bt2qm76"
+      - name: "Centre de Recherche Cerveau et Cognition (CerCo), CNRS"
+        ror: "https://ror.org/04fhrs205"
   - family-names: Makeig
     given-names: Scott
     orcid: "https://orcid.org/0000-0002-9048-8438"
-    affiliation: "Swartz Center for Computational Neuroscience, University of California San Diego"
+    affiliation:
+      name: "Swartz Center for Computational Neuroscience"
+      ror: "https://ror.org/01bt2qm76"
 version: 0.1.0
+date-released: "2026-07-11"
 license: BSD-3-Clause
 repository-code: "https://github.com/sccn/pyAMICA"
-url: "https://github.com/sccn/pyAMICA"
+url: "https://eeglab.org/pyAMICA/"
 keywords:
   - AMICA
   - independent component analysis
@@ -45,3 +54,5 @@ references:
     year: 2012
     institution:
       name: Swartz Center for Computational Neuroscience, University of California San Diego
+# Concept (all-versions) DOI; always resolves to the latest release.
+doi: "10.5281/zenodo.21312148"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![CI](https://github.com/sccn/pyAMICA/actions/workflows/ci.yml/badge.svg)](https://github.com/sccn/pyAMICA/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/sccn/pyAMICA/branch/main/graph/badge.svg)](https://codecov.io/gh/sccn/pyAMICA)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21312148.svg)](https://doi.org/10.5281/zenodo.21312148)
+[![Docs](https://img.shields.io/badge/docs-eeglab.org%2FpyAMICA-blue)](https://eeglab.org/pyAMICA/)
 
 Python (PyTorch) implementation of Adaptive Mixture Independent Component Analysis
 (AMICA) that reproduces the reference Fortran implementation within numerical


### PR DESCRIPTION
Adds archival/citation metadata for the v0.1.0 release now that the repo is under `sccn/` and archived on Zenodo.

## Changes
- **`.zenodo.json`** (new): legacy-format Zenodo metadata with all three creators (ORCIDs), single-string affiliations, license, and keywords. Zenodo reads `.zenodo.json` preferentially, so future releases archive from this file rather than parsing `CITATION.cff`.
- **`CITATION.cff`**: upgraded to `cff-version: 1.3.0` so affiliations can carry ROR identifiers. Shirazi/Makeig -> SCCN (`ror.org/01bt2qm76`); Delorme -> SCCN + CerCo/CNRS (`ror.org/04fhrs205`). Added concept `doi` (`10.5281/zenodo.21312148`) and `date-released`.
- **`README.md`**: added Zenodo DOI and docs badges.

## Why two files
`cff-version: 1.3.0` (dev) is required for ROR-in-affiliation, but Zenodo's CFF parser errors on the 1.3.0-dev schema. Adding `.zenodo.json` lets Zenodo use it instead of the CFF, so the ROR-annotated `CITATION.cff` and clean Zenodo archiving coexist.

## Validation
- `.zenodo.json` parses as valid JSON; `CITATION.cff` parses as valid YAML (verified locally).
- Concept DOI `10.5281/zenodo.21312148` and version DOI `10.5281/zenodo.21312149` resolve to the v0.1.0 archive.
- ROR IDs verified against the ROR registry API.