### PR TITLE
docs: add MLX backend API reference page

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -19,3 +19,6 @@ the default import surface:
 ```python
 from pyAMICA.mlx_impl import AMICAMLXNG  # requires the `mlx` extra
 ```
+
+- **[`AMICAMLXNG`](mlx-backend.md)** — the optional Apple-GPU (MLX) backend; the
+  fastest option on Apple Silicon (float32).

--- a/docs/api/mlx-backend.md
+++ b/docs/api/mlx-backend.md
@@ -1,0 +1,21 @@
+# MLX backend (AMICAMLXNG)
+
+The optional Apple-Silicon GPU backend. It runs the natural-gradient EM E/M-step
+on the Apple GPU in float32 (Apple GPUs have no float64), with the small
+per-iteration linear algebra on MLX's CPU stream. It supports single- and
+multi-model generalized-Gaussian (`pdftype=0`) natural-gradient AMICA and is the
+fastest option on Apple hardware; see [Backends & Devices](../guides/backends.md)
+for the performance comparison.
+
+MLX is an optional dependency (Apple Silicon only), so it is imported separately
+and is not part of the default `import pyAMICA` surface:
+
+```python
+from pyAMICA.mlx_impl import AMICAMLXNG  # requires the `mlx` extra
+```
+
+Install it with `uv pip install mlx` or the `mlx` extra (`pip install pyAMICA[mlx]`).
+Because it computes in float32, use the [PyTorch backend](torch-backend.md) on
+CUDA/CPU for float64 Fortran-parity runs.
+
+::: pyAMICA.mlx_impl.AMICAMLXNG

--- a/docs/guides/backends.md
+++ b/docs/guides/backends.md
@@ -8,7 +8,7 @@ interface, plus an optional Apple-GPU backend and a legacy NumPy reference.
 | Backend | Class | Role |
 |---|---|---|
 | PyTorch natural-gradient EM | [`AMICATorchNG`](../api/torch-backend.md) | **Default.** Fortran-parity backend; CUDA / CPU, and float32 on MPS. |
-| MLX (Apple GPU) | `AMICAMLXNG` (`pyAMICA.mlx_impl`) | Optional Apple-Silicon GPU backend; float32 only. |
+| MLX (Apple GPU) | [`AMICAMLXNG`](../api/mlx-backend.md) (`pyAMICA.mlx_impl`) | Optional Apple-Silicon GPU backend; float32 only. |
 | NumPy reference | [`AMICA_NumPy`](../api/numpy-backend.md) | Legacy oracle + CLI; carries the same parity fixes. |
 
 The `AMICA` wrapper uses `AMICATorchNG`. The MLX backend is imported separately

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
       - Overview: api/index.md
       - AMICA: api/amica.md
       - PyTorch backend: api/torch-backend.md
+      - MLX backend: api/mlx-backend.md
       - NumPy backend: api/numpy-backend.md
   - Development:
       - Contributing: development/contributing.md


### PR DESCRIPTION
Closes #106.

Adds an API Reference page for the MLX (Apple-GPU) backend `AMICAMLXNG`, so all three backends (PyTorch, MLX, NumPy) have a page. Previously only PyTorch and NumPy did, even though MLX is documented in the Backends & Devices guide and is the performance winner on Apple Silicon.

## Changes
- **`docs/api/mlx-backend.md`** (new): prose intro (what it is, float32-only, optional `mlx` extra, separate import) plus `::: pyAMICA.mlx_impl.AMICAMLXNG` (mkdocstrings), mirroring `torch-backend.md`/`numpy-backend.md`.
- **`mkdocs.yml`**: added the page to the API Reference nav between the PyTorch and NumPy backends.
- **`docs/api/index.md`**: added a bullet linking the MLX backend.
- **`docs/guides/backends.md`**: linked the `AMICAMLXNG` table cell to the new page.

## Build compatibility (the reason this page didn't exist before)
The docs CI runner has no `mlx` installed (Apple Silicon only), so the page cannot import the module. mkdocstrings/griffe documents it via **static source analysis** instead, so no import is needed. Verified locally with `mlx` absent from the venv:

```
uv sync --extra docs && uv run mkdocs build --strict   # exit 0
```

The rendered page shows the class docstring and both public methods (`fit`, `transform`). `--strict` also validates the new internal links.