### PR TITLE
Add JOSS draft-pdf build workflow

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -1,0 +1,36 @@
+name: Draft PDF
+
+# Builds paper.md into a JOSS-formatted PDF (Pandoc + inara, via the official
+# openjournals action) and uploads it as an artifact. This verifies the paper
+# compiles under JOSS's toolchain before submission and gives a per-push preview.
+on:
+  push:
+    paths:
+      - paper.md
+      - paper.bib
+      - .github/workflows/draft-pdf.yml
+  pull_request:
+    paths:
+      - paper.md
+      - paper.bib
+      - .github/workflows/draft-pdf.yml
+  workflow_dispatch:
+
+jobs:
+  paper:
+    runs-on: ubuntu-latest
+    name: Paper Draft
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build draft PDF
+        uses: openjournals/openjournals-draft-action@master
+        with:
+          journal: joss
+          paper-path: paper.md
+      - name: Upload PDF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: paper
+          # The action writes the compiled PDF next to the paper source.
+          path: paper.pdf


### PR DESCRIPTION
Closes #109.

Adds `.github/workflows/draft-pdf.yml`, which builds `paper.md` into a JOSS-formatted PDF using the official `openjournals/openjournals-draft-action` (Pandoc + inara) and uploads it as an artifact. Runs on changes to `paper.md`/`paper.bib`/the workflow, and on `workflow_dispatch`.

Purpose: verify the paper compiles under JOSS's own toolchain before submission (archive DOI `10.5281/zenodo.21312148`, v0.1.0) and provide a per-push PDF preview. No effect on the package or other CI.