### PR TITLE
CI: skip Python jobs for text/metadata-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,30 @@
 name: CI
 
-# Python jobs (lint/test/build) skip when a change touches only prose --
-# Markdown or docs (incl. a future mkdocs site). Spell-checking lives in the
-# separate typos.yml, which has no such filter so docs are always checked.
+# Python jobs (lint/test/build) skip when a change touches only prose or
+# metadata -- Markdown, the docs site, the JOSS paper (paper.md/paper.bib), and
+# citation/archive metadata (CITATION.cff, .zenodo.json, LICENSE) -- none of
+# which affect the package. Spell-checking (typos.yml) and the paper PDF build
+# (draft-pdf.yml) have their own triggers, so prose is still checked.
 on:
   push:
     branches: [main]
     paths-ignore:
       - "**.md"
+      - "**.bib"
       - "docs/**"
       - "mkdocs.yml"
+      - "CITATION.cff"
+      - ".zenodo.json"
+      - "LICENSE"
   pull_request:
     paths-ignore:
       - "**.md"
+      - "**.bib"
       - "docs/**"
       - "mkdocs.yml"
+      - "CITATION.cff"
+      - ".zenodo.json"
+      - "LICENSE"
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The CI Python jobs (lint/build/test, ~10 min) already skip for `**.md`, `docs/**`, and `mkdocs.yml`, but non-Markdown text/metadata files still trigger the full suite pointlessly, e.g. PR #105 (`.zenodo.json`, `CITATION.cff`) and PR #112 (`paper.bib`) each ran the whole test matrix for a prose/metadata-only change.

Adds `**.bib`, `CITATION.cff`, `.zenodo.json`, and `LICENSE` to `paths-ignore` (both `push` and `pull_request`). These files have no effect on the package.

Spell-checking (`typos.yml`) and the JOSS paper PDF build (`draft-pdf.yml`) have their own triggers, so prose is still validated. A change that touches any code file alongside these still runs the full suite (paths-ignore only skips when *all* changed files match).