### PR TITLE
Add funding + correct stale float32 speedup claim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,11 +47,14 @@ computes in float64 for Fortran parity, which MPS cannot represent, so parity ru
 **Performance (#63, `.context/issue-63/perf_findings.md`, `benchmarks/benchmark_gpu.py`):** the E-step
 pow-dedup (dropping the unused `dpdf`) is ~-35% and bit-identical; `block_size` default is 512 (was
 128, ~-18%). CUDA float64 is ~4.5x over a 16-thread CPU (RTX 4090, warmed) and agrees with the CPU LL
-to 5 sig digits (auto-selected by the wrapper). float32 is 5-19x faster and now converges on
+to 5 sig digits (auto-selected by the wrapper). float32 now converges reliably on
 full-size data across seeds (#75 guarded the one float32-only divide-by-zero: a sample rounding an
 activation to exactly 0 gave `0/0` in the mu denominator; not a summation-precision problem, so it
-needs no float64 and holds on MPS). float32 is ~7-sig-digit, not float64-parity, so use float64 for
-Fortran-parity runs. CPU intra-op threads are workload-limited (~4 was the sweet spot in the measured
+needs no float64 and holds on MPS) and is required on Apple GPUs (no float64). float32 is NOT a
+general speedup: the #63 "5-19x" estimate was superseded by #84's matched cross-platform sweep,
+which found CUDA is overhead-bound so f32==f64 (~36 ms) and the Apple-GPU win is the MLX backend,
+not float32 itself (on CPU f32 is only modestly faster and scales better across cores). float32 is
+~7-sig-digit, not float64-parity, so use float64 for Fortran-parity runs. CPU intra-op threads are workload-limited (~4 was the sweet spot in the measured
 laptop sweep; 8+ regressed).
 
 **Cross-platform benchmark (#77, `.context/issue-77/benchmark_findings.md`, `benchmarks/benchmark_dimsweep.py`,

--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ order = model.variance_order()     # EEGLAB IC order (IC1 = highest variance)
 The wrapper auto-selects a device and computes in float64 for Fortran parity.
 
 - CPU and CUDA (float64) are bit-reproducible; use them for parity runs.
-- float32 is 5-19x faster at about 7 significant digits.
+- float32 (about 7 significant digits, not parity) is required on the Apple GPUs
+  and modestly faster on CPU; it is not a general speedup, since CUDA is
+  overhead-bound (float32 is about as fast as float64).
 - On Apple Silicon the MLX backend is the fastest option; import it explicitly.
 
 ```python

--- a/docs/guides/backends.md
+++ b/docs/guides/backends.md
@@ -30,9 +30,12 @@ requires MLX.
 
 - **float64** — the default; required for Fortran-parity runs. CUDA float64
   agrees with the CPU log-likelihood to ~5 significant digits.
-- **float32** — 5-19x faster and required on MPS/MLX, but ~7-significant-digit,
-  not float64-parity. Use it for exploratory or large-scale runs where exact
-  reference parity is not required.
+- **float32** — required on the Apple GPUs (MPS/MLX have no float64) and
+  ~7-significant-digit, not float64-parity. It is not a general speedup: CUDA is
+  overhead-bound so float32 is about as fast as float64, while on CPU float32 is
+  modestly faster and scales better across cores. The Apple-GPU speed win comes
+  from the MLX backend (see below), not float32 itself. Use it for exploratory or
+  large-scale runs where exact reference parity is not required.
 
 ## Performance on real EEG
 

--- a/paper.md
+++ b/paper.md
@@ -182,6 +182,9 @@ We thank Jason Palmer and Ken Kreutz-Delgado, co-developers of AMICA, for the
 reference implementation, and the EEGLAB community for the tools and sample data
 used to validate this work. Two of the authors are original developers of the
 methods `pyAMICA` builds on: S.M. co-developed the AMICA algorithm (Palmer et al.,
-cited above) and A.D. is a lead developer of EEGLAB [@delorme2004eeglab].
+cited above) and A.D. is a lead developer of EEGLAB [@delorme2004eeglab]. This
+work was supported by The Swartz Foundation (Old Field, NY) to the Swartz Center
+for Computational Neuroscience and by National Institutes of Health grant
+R01-NS047293 (to A.D. and S.M.).
 
 # References


### PR DESCRIPTION
Final consistency polish before JOSS submission.

## paper.md
- Adds the funding acknowledgement: The Swartz Foundation (to SCCN) and NIH grant R01-NS047293 (to A.D. and S.M.). JOSS asks for a funding statement.

## Correct the stale "5-19x" float32 claim (AGENTS.md, README.md, docs/guides/backends.md)
The peer-review panel on the paper (#112) established that "float32 is 5-19x faster" (from the early issue-63 estimate) is superseded by the rigorous issue-84 cross-platform sweep: CUDA is overhead-bound so float32 ~= float64 (~36 ms), and PyTorch-MPS float32 is slower than CPU. float32 is not a general speedup; it is numerically faithful (4-5 sig digits vs float64) and *required* on the Apple GPUs (no float64), and the Apple-GPU speed win comes from the MLX backend, not float32. These docs still carried the old number, which the paper now points readers to, so they are corrected to match.

Doc/text-only; `mkdocs build --strict` passes. (Now runs only Typos + the paper PDF build, per #113.)