### PR TITLE
Fix type-safety diagnostics in validate_implementations.py

### DIFF
--- a/pyAMICA/torch_impl/utils.py
+++ b/pyAMICA/torch_impl/utils.py
@@ -4,6 +4,7 @@ Utility functions for PyTorch AMICA.
 
 import torch
 import numpy as np
+import numpy.typing as npt
 from typing import Optional, Dict, Any, Tuple
 import logging
 
@@ -237,7 +238,7 @@ def compare_with_fortran(
 
 
 def load_eeglab_data(
-    filepath: str, data_dim: int, field_dim: int, dtype: np.dtype = np.float32
+    filepath: str, data_dim: int, field_dim: int, dtype: npt.DTypeLike = np.float32
 ) -> np.ndarray:
     """
     Load EEGLAB .fdt binary data file.

--- a/pyAMICA/torch_impl/utils.py
+++ b/pyAMICA/torch_impl/utils.py
@@ -251,7 +251,7 @@ def load_eeglab_data(
         Number of channels
     field_dim : int
         Number of time points
-    dtype : np.dtype, default=np.float32
+    dtype : DTypeLike, default=np.float32
         Data type
 
     Returns

--- a/validate_implementations.py
+++ b/validate_implementations.py
@@ -8,6 +8,7 @@ from the same initialization and random seed.
 
 import numpy as np
 import json
+import os
 import subprocess
 import torch
 import inspect
@@ -103,7 +104,7 @@ def create_fortran_params(params: Dict, output_dir: Path, seed: int) -> Path:
 
 def run_fortran_amica(
     data: np.ndarray, params: Dict, output_dir: Path, seed: int
-) -> Dict:
+) -> Optional[Dict]:
     """Run Fortran AMICA binary and collect results."""
     # Use the macOS binary in sample_data directory
     binary_path = Path("pyAMICA/sample_data/amica15mac")
@@ -153,11 +154,9 @@ def run_fortran_amica(
 
     # Run Fortran binary
     print("Running Fortran AMICA...")
+    original_dir = os.getcwd()
     try:
         # Change to working directory to run
-        import os
-
-        original_dir = os.getcwd()
         os.chdir(fortran_dir)
 
         result = subprocess.run(


### PR DESCRIPTION
Closes #117.

- `run_fortran_amica` returns `None` on several early-exit paths but was typed
  `-> Dict`; retyped `-> Optional[Dict]` to match reality (callers already
  handle `Optional[Dict]` via `compare_results`).
- `os`/`original_dir` were only assigned inside the `try:` block but read in
  the `except:` branches (possibly-unbound); hoisted `import os` to the
  top-level imports and `original_dir = os.getcwd()` before the `try:`.
- `load_eeglab_data`'s `dtype: np.dtype = np.float32` default didn't match its
  own annotation (`np.float32` is a scalar type, not an `np.dtype` instance);
  widened to `npt.DTypeLike`.

Verified false positives, left as-is: the `torch`/`scipy.optimize` "could not
be resolved" diagnostics are a Pyright/IDE environment issue -- both resolve
and import fine at runtime (`uv run python -c "import torch, scipy"`).

## Test plan
- [x] `uv run ty check validate_implementations.py pyAMICA/torch_impl/utils.py` passes
- [x] `uv run ruff check` / `ruff format --check` pass
- [x] `uv run pytest pyAMICA/tests/test_fortran_adapter.py pyAMICA/tests/torch_tests/test_ng_utils.py` passes (20 passed, 3 skipped)