### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,8 +29,8 @@ authors:
     affiliation:
       name: "Swartz Center for Computational Neuroscience"
       ror: "https://ror.org/01bt2qm76"
-version: 0.1.0
-date-released: "2026-07-11"
+version: 0.1.1
+date-released: "2026-07-13"
 license: BSD-3-Clause
 repository-code: "https://github.com/sccn/pyAMICA"
 url: "https://eeglab.org/pyAMICA/"

--- a/pyAMICA/version.py
+++ b/pyAMICA/version.py
@@ -3,7 +3,7 @@ from os.path import join as pjoin
 # Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"
 _version_major = 0
 _version_minor = 1
-_version_micro = "0"  # use '' for first of series, number for 1 and above
+_version_micro = "1"  # use '' for first of series, number for 1 and above
 _version_extra = ""  # '' for full releases; 'dev' for development
 
 # Construct full version string from these.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyAMICA"
-version = "0.1.0"
+version = "0.1.1"
 description = "pyAMICA: Python implementation of the Adaptive Mixture ICA algorithm"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1267,7 +1267,7 @@ wheels = [
 
 [[package]]
 name = "pyamica"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "json5" },


### PR DESCRIPTION
Version bump for the 0.1.1 patch release, covering the changes since v0.1.0:
type-safety fixes in \`validate_implementations.py\` (#118), the multi-model
permutation-test fix (#115), the funding/float32-claim correction (#114), and
the Amari-distance metric + Fortran/Apple-CPU performance rows (#120).

Updates \`pyproject.toml\`, \`pyAMICA/version.py\`, \`CITATION.cff\`
(version + date-released), and \`uv.lock\`.