### PR TITLE
Reject: distinguish non-finite LL from too-aggressive rejsig (#127)

### DIFF
--- a/pyAMICA/numpy_impl/core.py
+++ b/pyAMICA/numpy_impl/core.py
@@ -1465,7 +1465,21 @@ class AMICA:
         keep = ll_vec >= (mean - self.rejsig * std)
 
         if not bool(keep.any()):
-            raise ValueError(
+            # For finite log-likelihoods the max sample is always >= mean >=
+            # mean - rejsig*std (rejsig>0 is validated at construction), so it is
+            # always kept; the only way every sample is dropped is a non-finite
+            # per-sample LL (one NaN poisons mean/std, making every comparison
+            # False). Report that accurately instead of blaming rejsig (issue
+            # #127), which a user cannot fix by tuning rejsig.
+            n_bad = int(np.count_nonzero(~np.isfinite(ll_vec)))
+            if n_bad:
+                raise ValueError(
+                    f"{n_bad} of {ll_vec.size} samples have a non-finite "
+                    "log-likelihood; this indicates numerical instability "
+                    "(singular W / overflow) upstream, not a rejsig "
+                    "miscalibration."
+                )
+            raise ValueError(  # defensive: unreachable for finite LL, rejsig>0
                 f"Outlier rejection removed all {self.good_idx.size} samples "
                 f"(rejsig={self.rejsig} too aggressive for this data)."
             )

--- a/pyAMICA/tests/test_numpy_reject.py
+++ b/pyAMICA/tests/test_numpy_reject.py
@@ -138,12 +138,15 @@ def test_multimodel_rejection_keeps_gm_and_c_finite():
     np.testing.assert_allclose(model.gm.sum(), 1.0, atol=1e-8)
 
 
-def test_rejection_degenerate_ll_raises_clear_error():
-    """A degenerate per-sample LL (e.g. all NaN from a diverged fit) makes
-    rejection raise a clear ValueError rather than silently emptying the good
-    set and crashing downstream on a zero-length normalization."""
+def test_rejection_nonfinite_ll_raises_instability_error():
+    """A non-finite per-sample LL (numerical instability upstream) makes
+    rejection raise a clear error naming the real cause, not blaming rejsig
+    (issue #127). Even a single NaN poisons mean/std and would drop every
+    sample, so the guard fires and the message must be accurate."""
     model = AMICA(do_reject=True, rejsig=3.0)
     model.good_idx = np.arange(16)
-    model._last_ll_samples = np.full(16, np.nan)
-    with pytest.raises(ValueError, match="removed all"):
+    ll = np.arange(16, dtype=np.float64)
+    ll[7] = np.nan  # one non-finite entry poisons the whole reject decision
+    model._last_ll_samples = ll
+    with pytest.raises(ValueError, match="non-finite"):
         model._reject_outliers()

--- a/pyAMICA/tests/torch_tests/test_ng_backend.py
+++ b/pyAMICA/tests/torch_tests/test_ng_backend.py
@@ -865,14 +865,16 @@ def test_multimodel_dead_model_keeps_prior_c():
 
 
 def test_rejection_degenerate_ll_raises_clear_error():
-    """If the per-sample log-likelihood is degenerate (e.g. all NaN from a
-    diverged fit), rejection raises a clear ValueError rather than silently
-    emptying the good set and crashing downstream on ``None`` accumulators."""
+    """If the per-sample log-likelihood is non-finite (numerical instability
+    upstream, e.g. a diverged fit), rejection raises a clear error naming the
+    real cause instead of blaming rejsig (issue #127) -- a single NaN poisons
+    mean/std and would otherwise silently empty the good set."""
     m = _fresh_ng(do_reject=True)
     m.good_idx = torch.arange(16)
     m.numrej = 0
-    ll = torch.full((16,), float("nan"), dtype=torch.float64)
-    with pytest.raises(ValueError, match="removed all"):
+    ll = torch.arange(16, dtype=torch.float64)
+    ll[7] = float("nan")  # one non-finite entry poisons the reject decision
+    with pytest.raises(ValueError, match="non-finite"):
         m._reject_outliers(ll)
 
 

--- a/pyAMICA/torch_impl/core.py
+++ b/pyAMICA/torch_impl/core.py
@@ -1775,7 +1775,21 @@ class AMICATorchNG:
         keep = ll_vec >= (mean - self.rejsig * std)
 
         if not bool(keep.any()):
-            raise ValueError(
+            # For finite log-likelihoods the max sample is always >= mean >=
+            # mean - rejsig*std (rejsig>0 is validated at construction), so it is
+            # always kept; the only way every sample is dropped is a non-finite
+            # per-sample LL (one NaN poisons mean/std, making every comparison
+            # False). Report that accurately instead of blaming rejsig (issue
+            # #127), which a user cannot fix by tuning rejsig.
+            n_bad = int((~torch.isfinite(ll_vec)).sum())
+            if n_bad:
+                raise ValueError(
+                    f"{n_bad} of {ll_vec.numel()} samples have a non-finite "
+                    "log-likelihood; this indicates numerical instability "
+                    "(singular W / overflow) upstream, not a rejsig "
+                    "miscalibration."
+                )
+            raise ValueError(  # defensive: unreachable for finite LL, rejsig>0
                 f"Outlier rejection removed all {good.numel()} samples "
                 f"(rejsig={self.rejsig} too aggressive for this data)."
             )


### PR DESCRIPTION
## Summary

Closes #127. Makes both backends' `_reject_outliers` report the real cause when
outlier rejection would drop every sample.

**Stacked on #126** (base is the #123 branch) so the NumPy `do_reject`
implementation it modifies is present; retarget to `main` once #126 merges.

## Problem

Both `AMICATorchNG._reject_outliers` and `AMICA_NumPy._reject_outliers` raised:

> Outlier rejection removed all N samples (rejsig=X too aggressive for this data).

whenever the keep-mask was empty. But for **finite** log-likelihoods with the
construction-validated `rejsig > 0`, the maximum sample is always `>= mean >=
mean - rejsig*std`, so it is always kept -- the good set can only empty when the
per-sample LL is **non-finite** (a single NaN poisons `mean`/`std`, making every
comparison `False`). That is upstream numerical instability (singular `W` /
overflow), which a user cannot fix by tuning `rejsig`; the old message
misdiagnosed it.

## Change

On an empty keep-mask, both backends now count the non-finite entries and raise
an accurate instability message naming the real cause. The old `rejsig` message
is kept only as a defensive backstop (now unreachable for finite LL with
`rejsig > 0`). The two backends raise the same message style, fixed together to
avoid cross-backend divergence.

## Tests

Both backends' degenerate-LL tests now inject a **single** NaN (demonstrating one
non-finite entry poisons the whole reject decision) and assert the `non-finite`
message:
- `test_numpy_reject.py::test_rejection_nonfinite_ll_raises_instability_error`
- `test_ng_backend.py::test_rejection_degenerate_ll_raises_clear_error`

## Validation

- `uv run ty check .` -> 0 diagnostics; ruff clean.
- All reject tests pass (6 NumPy + 3 torch).
