### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,8 +29,8 @@ authors:
     affiliation:
       name: "Swartz Center for Computational Neuroscience"
       ror: "https://ror.org/01bt2qm76"
-version: 0.1.1
-date-released: "2026-07-13"
+version: 0.1.2
+date-released: "2026-07-14"
 license: BSD-3-Clause
 repository-code: "https://github.com/sccn/pyAMICA"
 url: "https://eeglab.org/pyAMICA/"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,44 @@
 Release notes are also published on the
 [GitHub releases page](https://github.com/sccn/pyAMICA/releases).
 
+## 0.1.2
+
+Outlier-rejection parity in the NumPy backend, repo-wide type-checking, and the
+full validation-evidence documentation.
+
+- NumPy backend outlier rejection: the Fortran `do_reject` outlier-rejection path
+  is ported to `AMICA_NumPy` via the same `good_idx` mechanism as the PyTorch
+  backend, so the NumPy reference now drops per-sample outliers on the
+  `rejstart`/`rejint`/`maxrej` schedule (#123).
+- Rejection robustness: a non-finite log-likelihood is now distinguished from an
+  over-aggressive `rejsig`, so an over-tight rejection threshold fails with a
+  clear message instead of a silent non-finite result (#127).
+- Type checking enforced: repo-wide `ty` diagnostics fixed (496 to 0) and `ty`
+  added to CI alongside a pre-commit config (ruff + ty) (#124, #125).
+- Documentation: the validation guide is expanded into a full evidence page,
+  source-density bit-exactness, cross-platform device/precision invariance
+  (cross-backend equivalence matrix and IC topomaps), the EEGLAB drop-in
+  round-trip, and the other validated behaviors (#108).
+
+## 0.1.1
+
+Validation-methodology and correctness fixes since 0.1.0.
+
+- Amari distance: a second, permutation- and scale-invariant unmixing-matrix
+  comparison metric (Amari, Cichocki & Yang 1996) alongside Hungarian-matched
+  correlation, used throughout the Fortran-parity validation (#120).
+- Multi-model equivalence test: switched to a valid run-level permutation test
+  that respects the dependence among the 40 runs' pairwise correlations, instead
+  of a pseudoreplicated Mann-Whitney/TOST (#115).
+- Parity and performance tables added to the paper, with the full results,
+  native-Fortran CPU core-scaling rows, and per-run detail in the docs (#112).
+- Type-safety fixes in `validate_implementations.py` (`run_fortran_amica`
+  return type, `load_eeglab_data` dtype annotation) (#118).
+- JOSS draft-PDF build workflow, `.zenodo.json` with ROR-based citation
+  metadata, and an MLX backend API reference page (#110, #105, #107).
+- Corrected a stale float32-speedup claim and added a funding acknowledgement
+  (#114).
+
 ## 0.1.0
 
 First public release.

--- a/pyAMICA/version.py
+++ b/pyAMICA/version.py
@@ -3,7 +3,7 @@ from os.path import join as pjoin
 # Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"
 _version_major = 0
 _version_minor = 1
-_version_micro = "1"  # use '' for first of series, number for 1 and above
+_version_micro = "2"  # use '' for first of series, number for 1 and above
 _version_extra = ""  # '' for full releases; 'dev' for development
 
 # Construct full version string from these.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyAMICA"
-version = "0.1.1"
+version = "0.1.2"
 description = "pyAMICA: Python implementation of the Adaptive Mixture ICA algorithm"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1319,7 +1319,7 @@ wheels = [
 
 [[package]]
 name = "pyamica"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "json5" },


### PR DESCRIPTION
Cut release **0.1.2**. Everything landed since v0.1.1 (5 PRs).

## Version bump
`0.1.1` -> `0.1.2` across `pyAMICA/version.py`, `pyproject.toml`, `uv.lock`, and `CITATION.cff` (date-released 2026-07-14).

## Changelog
Adds a 0.1.2 entry and **backfills the missing 0.1.1 entry** (the changelog had stopped at 0.1.0).

### 0.1.2 highlights
- **NumPy `do_reject` outlier rejection** ported via `good_idx` (#123), plus a robustness fix distinguishing a non-finite LL from an over-aggressive `rejsig` (#127).
- **Repo-wide `ty` type-checking**: 496 -> 0 diagnostics, enforced in CI with a ruff+ty pre-commit config (#124, #125).
- **Comprehensive validation docs**: source-density bit-exactness, cross-platform device/precision invariance (equivalence matrix + IC topomaps), EEGLAB drop-in round-trip, other validated behaviors (#108).

## Verification
- [x] `uv run python -c "import pyAMICA.version"` resolves to 0.1.2
- [x] `uv lock --check` passes (lock in sync)
- [x] pre-commit (ruff check/format + ty) green
- No code changed; version/metadata/docs only.

After merge: tag `v0.1.2` and publish the GitHub release.