### PR TITLE
Phase 1: MIR core metric (mutual information reduction)

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,196 @@
+# Third-Party Notices
+
+pyAMICA is BSD-3-Clause (see `LICENSE`). This file lists source code ported
+into the package from third-party projects under other licenses, and
+reproduces the license text required by each, per that license's
+redistribution terms.
+
+## MIR (Mutual Information Reduction) metric
+
+`pyAMICA/metrics/mir.py` is ported from `getMIR.m` (and its nested
+`getent4`) in Arnaud Delorme's
+[`bigdelys/pre_ICA_cleaning`](https://github.com/bigdelys/pre_ICA_cleaning)
+repository, at
+[commit `b6034f0`](https://github.com/bigdelys/pre_ICA_cleaning/blob/b6034f03889a6a418968ee119123f3df55251957/getMIR.m),
+licensed under the Apache License, Version 2.0. The upstream file carries no
+embedded copyright header of its own. The full Apache-2.0 license text is
+reproduced below, as required by Section 4(a) of that license.
+
+---
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/pyAMICA/__init__.py
+++ b/pyAMICA/__init__.py
@@ -16,6 +16,7 @@ Main Features:
 from .version import __version__
 from .amica import AMICA
 from .torch_impl import AMICATorchNG
+from . import metrics
 from . import numpy_impl
 from . import torch_impl
 
@@ -27,6 +28,7 @@ __all__ = [
     "AMICA",
     "AMICATorchNG",
     "AMICA_NumPy",
+    "metrics",
     "numpy_impl",
     "torch_impl",
     "__version__",

--- a/pyAMICA/metrics/__init__.py
+++ b/pyAMICA/metrics/__init__.py
@@ -1,0 +1,3 @@
+from .mir import mir
+
+__all__ = ["mir"]

--- a/pyAMICA/metrics/mir.py
+++ b/pyAMICA/metrics/mir.py
@@ -1,0 +1,72 @@
+"""Mutual Information Reduction (MIR) ICA separation-quality metric.
+
+MIR measures how much a linear unmixing transform reduces the total mutual
+information among channels: it is the (signed) difference between the sum of
+per-channel differential entropies before and after unmixing, corrected by the
+log-Jacobian of the transform. A well-separated decomposition drives the
+unmixed channels toward independence, so MIR should be large and positive; an
+orthogonal (information-preserving) transform gives MIR near zero.
+
+Ported from ``getMIR.m`` / its nested ``getent4`` in
+`bigdelys/pre_ICA_cleaning <https://github.com/bigdelys/pre_ICA_cleaning>`_
+(Apache License 2.0). This is a permitted derivative under Apache-2.0's
+attribution requirement; the port keeps the original's binned-entropy
+estimator (including its bin-count-1 correction and eigenvalue-based
+log-Jacobian) rather than substituting a different entropy estimator.
+
+A 2023 MATLAB adaptation of ``getMIR`` (the nested ``mir()`` function in
+``sccn/NEMAR-pipeline``'s ``eeg_nemar_dataqual.m``, currently dead/commented-out
+code there) added an explicit sphering step ahead of this computation, but its
+``mir(data, linT)`` signature only resolves via MATLAB nested-function shared
+workspace (it references ``eig(W)`` and ``/N``, neither of which are its own
+parameters) and it depends on a GPL-licensed ``robust_sphering_matrix``
+routine, out of scope for this BSD-3-Clause project. This port instead takes
+an explicit ``unmixing`` matrix: callers that want the sphere-then-unmixing
+composition (e.g. wiring MIR to a fitted AMICA model) compose it themselves
+before calling ``mir``.
+"""
+
+import numpy as np
+
+
+def _marginal_entropies(
+    u: np.ndarray, nbins: int | None = None
+) -> tuple[np.ndarray, np.ndarray]:
+    """Port of getMIR.m's nested getent4: per-row binned differential entropy."""
+    n_signals, n_samples = u.shape
+    if nbins is None:
+        nbins = round(3 * np.log2(1 + n_samples / 10))
+
+    entropies = np.empty(n_signals)
+    variances = np.empty(n_signals)
+    for i in range(n_signals):
+        row = u[i]
+        umin = row.min()
+        umax = row.max()
+        delta = (umax - umin) / nbins
+        binned = 1 + np.round((nbins - 1) * (row - umin) / (umax - umin))
+        # np.unique's counts, unlike np.histogram, only ever report occupied
+        # bins, so log(p) below never sees a zero-count bin.
+        counts = np.unique(binned, return_counts=True)[1]
+        p = counts / n_samples
+        h = -np.sum(p * np.log(p))
+        # Variance uses the uncorrected h, matching getent4's statement order.
+        variances[i] = np.sum(p * np.log(p) ** 2) - h**2
+        entropies[i] = h + (nbins - 1) / (2 * n_samples) + np.log(delta)
+    return entropies, variances
+
+
+def mir(
+    unmixing: np.ndarray, data: np.ndarray, nbins: int | None = None
+) -> tuple[float, float]:
+    """Mutual Information Reduction of `unmixing` applied to `data`."""
+    hx, vx = _marginal_entropies(data, nbins)
+    y = unmixing @ data
+    hy, vy = _marginal_entropies(y, nbins)
+    n_samples = data.shape[1]
+    # eigvals (not slogdet), matching getMIR.m's own switch from det to eig.
+    mir_nats = float(
+        np.sum(np.log(np.abs(np.linalg.eigvals(unmixing)))) + np.sum(hx) - np.sum(hy)
+    )
+    variance = float((np.sum(vx) + np.sum(vy)) / n_samples)
+    return mir_nats, variance

--- a/pyAMICA/metrics/mir.py
+++ b/pyAMICA/metrics/mir.py
@@ -4,38 +4,58 @@ MIR measures how much a linear unmixing transform reduces the total mutual
 information among channels: it is the (signed) difference between the sum of
 per-channel differential entropies before and after unmixing, corrected by the
 log-Jacobian of the transform. A well-separated decomposition drives the
-unmixed channels toward independence, so MIR should be large and positive; an
-orthogonal (information-preserving) transform gives MIR near zero.
+unmixed channels toward independence, so MIR should be large and positive.
+The identity transform (or any scalar multiple of it) gives MIR exactly zero,
+since the bin-partition estimator below is scale-invariant; a generic
+non-identity rotation of dependent, non-Gaussian data need not (that
+directional sensitivity is the entire mechanism ICA exploits).
 
 Ported from ``getMIR.m`` / its nested ``getent4`` in
-`bigdelys/pre_ICA_cleaning <https://github.com/bigdelys/pre_ICA_cleaning>`_
-(Apache License 2.0). This is a permitted derivative under Apache-2.0's
-attribution requirement; the port keeps the original's binned-entropy
-estimator (including its bin-count-1 correction and eigenvalue-based
-log-Jacobian) rather than substituting a different entropy estimator.
+`bigdelys/pre_ICA_cleaning
+<https://github.com/bigdelys/pre_ICA_cleaning/blob/b6034f03889a6a418968ee119123f3df55251957/getMIR.m>`_
+(Apache License 2.0, full text reproduced in ``THIRD_PARTY_NOTICES.md`` per
+that license's Section 4(a)). This is a permitted derivative under
+Apache-2.0; the port keeps the original's binned-entropy estimator (including
+its bin-count-1 correction and eigenvalue-based log-Jacobian) rather than
+substituting a different entropy estimator.
 
 A 2023 MATLAB adaptation of ``getMIR`` (the nested ``mir()`` function in
 ``sccn/NEMAR-pipeline``'s ``eeg_nemar_dataqual.m``, currently dead/commented-out
 code there) added an explicit sphering step ahead of this computation, but its
-``mir(data, linT)`` signature only resolves via MATLAB nested-function shared
-workspace (it references ``eig(W)`` and ``/N``, neither of which are its own
-parameters) and it depends on a GPL-licensed ``robust_sphering_matrix``
-routine, out of scope for this BSD-3-Clause project. This port instead takes
-an explicit ``unmixing`` matrix: callers that want the sphere-then-unmixing
-composition (e.g. wiring MIR to a fitted AMICA model) compose it themselves
-before calling ``mir``.
+``mir(data, linT)`` references ``eig(W)`` and ``/N``, neither of which are its
+own parameters nor ever assigned anywhere in the enclosing function -- it would
+raise an undefined-variable error if uncommented, which is why it's dead code.
+It also depends on a ``robust_sphering_matrix`` routine that itself calls
+GPL-licensed helpers (``block_geometric_median``, ``hlp_memfree``), out of
+scope for this BSD-3-Clause project. This port instead takes an explicit
+``unmixing`` matrix: callers that want the sphere-then-unmixing composition
+(e.g. wiring MIR to a fitted AMICA model) compose it themselves before calling
+``mir``.
 """
 
 import numpy as np
+
+_MIN_ABS_EIGENVALUE = 1e-10
 
 
 def _marginal_entropies(
     u: np.ndarray, nbins: int | None = None
 ) -> tuple[np.ndarray, np.ndarray]:
     """Port of getMIR.m's nested getent4: per-row binned differential entropy."""
+    if not np.all(np.isfinite(u)):
+        raise ValueError(
+            "_marginal_entropies: input contains non-finite (NaN/Inf) values; "
+            "differential entropy is undefined for non-finite samples."
+        )
     n_signals, n_samples = u.shape
     if nbins is None:
         nbins = round(3 * np.log2(1 + n_samples / 10))
+    if nbins < 1:
+        raise ValueError(
+            f"_marginal_entropies: nbins={nbins} is not >= 1 (n_samples="
+            f"{n_samples} is too small for the default nbins formula; pass "
+            "an explicit nbins or supply more samples)."
+        )
 
     entropies = np.empty(n_signals)
     variances = np.empty(n_signals)
@@ -43,7 +63,16 @@ def _marginal_entropies(
         row = u[i]
         umin = row.min()
         umax = row.max()
+        if umax == umin:
+            raise ValueError(
+                f"_marginal_entropies: channel {i} is constant (all "
+                f"{n_samples} samples == {umin!r}); differential entropy is "
+                "undefined for a zero-variance channel."
+            )
         delta = (umax - umin) / nbins
+        # MATLAB's round() is half-away-from-zero; np.round is half-to-even.
+        # Immaterial here since exact bin-boundary ties have probability zero
+        # on continuous real EEG data.
         binned = 1 + np.round((nbins - 1) * (row - umin) / (umax - umin))
         # np.unique's counts, unlike np.histogram, only ever report occupied
         # bins, so log(p) below never sees a zero-count bin.
@@ -59,14 +88,48 @@ def _marginal_entropies(
 def mir(
     unmixing: np.ndarray, data: np.ndarray, nbins: int | None = None
 ) -> tuple[float, float]:
-    """Mutual Information Reduction of `unmixing` applied to `data`."""
+    """Mutual Information Reduction of `unmixing` applied to `data`, in nats.
+
+    Parameters
+    ----------
+    unmixing : np.ndarray
+        Square (n, n) linear transform applied to `data` (e.g. an ICA
+        unmixing matrix, optionally composed with a sphering matrix).
+    data : np.ndarray
+        (n, N) data matrix `unmixing` is applied to.
+    nbins : int, optional
+        Histogram bin count for the marginal-entropy estimator; see
+        `_marginal_entropies`. Defaults to ``round(3 * log2(1 + N/10))``.
+
+    Returns
+    -------
+    mir_nats : float
+        Mutual information (in nats) removed by `unmixing` from `data`.
+    variance : float
+        Variance of the MIR estimate.
+
+    Raises
+    ------
+    ValueError
+        If `unmixing` is singular or near-singular (the log-Jacobian term is
+        undefined for a non-invertible transform), or if `data`/`unmixing`
+        contain non-finite values or a constant channel.
+    """
+    eigvals = np.linalg.eigvals(unmixing)
+    min_abs_eig = np.min(np.abs(eigvals))
+    if min_abs_eig < _MIN_ABS_EIGENVALUE:
+        raise ValueError(
+            f"mir(): unmixing matrix is singular or near-singular (smallest "
+            f"|eigenvalue| = {min_abs_eig:.3e}); the log-Jacobian term is "
+            "undefined for a non-invertible transform. Verify `unmixing` is "
+            "full rank (e.g. check for duplicated/collinear components from "
+            "an unconverged ICA fit)."
+        )
     hx, vx = _marginal_entropies(data, nbins)
     y = unmixing @ data
     hy, vy = _marginal_entropies(y, nbins)
     n_samples = data.shape[1]
     # eigvals (not slogdet), matching getMIR.m's own switch from det to eig.
-    mir_nats = float(
-        np.sum(np.log(np.abs(np.linalg.eigvals(unmixing)))) + np.sum(hx) - np.sum(hy)
-    )
+    mir_nats = float(np.sum(np.log(np.abs(eigvals))) + np.sum(hx) - np.sum(hy))
     variance = float((np.sum(vx) + np.sum(vy)) / n_samples)
     return mir_nats, variance

--- a/pyAMICA/tests/test_metrics_mir.py
+++ b/pyAMICA/tests/test_metrics_mir.py
@@ -3,7 +3,11 @@
 MIR is backend-agnostic pure NumPy, so it lives directly under ``pyAMICA/tests/``
 (like ``test_amari_distance.py``) rather than ``tests/torch_tests/``. Per the
 NO-MOCK policy, every test exercises the real bundled sample EEG data; none use
-synthetic/random data as ground truth.
+synthetic/random data as ground truth. The error-path tests construct
+degenerate inputs (a constant channel, a non-finite sample, a singular matrix)
+by modifying a copy of that real data or a real fitted unmixing matrix -- the
+same precedent as ``test_amari_distance.py``'s degenerate-input tests -- not
+by fabricating synthetic ground truth.
 """
 
 import math
@@ -17,6 +21,7 @@ from pyAMICA.torch_impl.utils import load_eeglab_data
 
 SAMPLE_DIR = Path(__file__).resolve().parents[1] / "sample_data"
 DATA_FILE = SAMPLE_DIR / "eeglab_data.fdt"
+PYRESULTS_DIR = SAMPLE_DIR / "pyresults"
 NW = 32
 FIELD = 30504
 
@@ -35,6 +40,18 @@ def data_slice(real_data) -> np.ndarray:
     return real_data[:, :4000]
 
 
+@pytest.fixture(scope="module")
+def real_unmixing() -> np.ndarray:
+    """The real fitted AMICA unmixing (W.T @ sphere) for the bundled sample data."""
+    w_path = PYRESULTS_DIR / "W.npy"
+    sphere_path = PYRESULTS_DIR / "sphere.npy"
+    if not w_path.exists() or not sphere_path.exists():
+        pytest.skip("fitted reference results missing")
+    W = np.load(w_path)
+    sphere = np.load(sphere_path)
+    return W[:, :, 0].T @ sphere
+
+
 def test_marginal_entropies_default_nbins_matches_formula(data_slice):
     n_samples = data_slice.shape[1]
     expected_nbins = round(3 * math.log2(1 + n_samples / 10))
@@ -51,7 +68,7 @@ def test_marginal_entropies_matches_histogram_rederivation(data_slice):
     n_samples = data_slice.shape[1]
     nbins = round(3 * math.log2(1 + n_samples / 10))
 
-    h_impl, _ = _marginal_entropies(data_slice[:n_channels], nbins=nbins)
+    h_impl, v_impl = _marginal_entropies(data_slice[:n_channels], nbins=nbins)
 
     for ch in range(n_channels):
         row = data_slice[ch]
@@ -60,14 +77,25 @@ def test_marginal_entropies_matches_histogram_rederivation(data_slice):
         counts, _ = np.histogram(row, bins=nbins, range=(umin, umax))
         counts = counts[counts > 0]
         p = counts / n_samples
-        h_ref = -np.sum(p * np.log(p)) + (nbins - 1) / (2 * n_samples) + np.log(delta)
+        h_uncorrected = -np.sum(p * np.log(p))
+        v_ref = np.sum(p * np.log(p) ** 2) - h_uncorrected**2
+        h_ref = h_uncorrected + (nbins - 1) / (2 * n_samples) + np.log(delta)
         np.testing.assert_allclose(h_impl[ch], h_ref, rtol=1e-2)
+        # Variance (a squared-log-probability term) is more sensitive than
+        # entropy to the bin-boundary differences between the two
+        # independent binning schemes, so it needs a looser tolerance.
+        np.testing.assert_allclose(v_impl[ch], v_ref, rtol=3e-2)
 
 
 def test_mir_identity_unmixing_is_approximately_zero(data_slice):
-    n = data_slice.shape[0]
-    mir_val, _ = mir(np.eye(n), data_slice)
-    assert abs(mir_val) < 1e-6
+    n, n_samples = data_slice.shape
+    _, vx = _marginal_entropies(data_slice)
+
+    mir_val, variance = mir(np.eye(n), data_slice)
+
+    assert abs(mir_val) < 1e-9
+    expected_variance = 2 * np.sum(vx) / n_samples
+    np.testing.assert_allclose(variance, expected_variance, rtol=1e-9)
 
 
 def test_mir_scaled_identity_matches_closed_form(data_slice):
@@ -88,3 +116,64 @@ def test_mir_returns_finite_scalars_for_full_channel_data(real_data):
     assert isinstance(variance, float)
     assert math.isfinite(mir_val)
     assert math.isfinite(variance)
+
+
+def test_mir_real_fitted_unmixing_is_large_and_positive(data_slice, real_unmixing):
+    """A real, non-trivial (non-diagonal) unmixing should show substantial MIR.
+
+    Exercises the metric's actual purpose -- unlike the identity/scaled-identity
+    tests above, which are information-preserving by construction and can only
+    ever produce MIR ~= 0.
+    """
+    mir_val, variance = mir(real_unmixing, data_slice)
+    identity_mir, _ = mir(np.eye(real_unmixing.shape[0]), data_slice)
+
+    assert math.isfinite(variance)
+    assert mir_val > 1.0
+    assert mir_val > identity_mir
+
+
+def test_mir_nbins_passthrough_matches_manual_computation(data_slice, real_unmixing):
+    nbins = 20
+    hx, vx = _marginal_entropies(data_slice, nbins=nbins)
+    y = real_unmixing @ data_slice
+    hy, vy = _marginal_entropies(y, nbins=nbins)
+    eigvals = np.linalg.eigvals(real_unmixing)
+    expected_mir = float(np.sum(np.log(np.abs(eigvals))) + np.sum(hx) - np.sum(hy))
+    expected_variance = float((np.sum(vx) + np.sum(vy)) / data_slice.shape[1])
+
+    mir_val, variance = mir(real_unmixing, data_slice, nbins=nbins)
+
+    assert mir_val == pytest.approx(expected_mir)
+    assert variance == pytest.approx(expected_variance)
+
+
+def test_mir_raises_on_singular_unmixing(data_slice, real_unmixing):
+    singular = real_unmixing.copy()
+    singular[1] = singular[0]
+
+    with pytest.raises(ValueError, match="singular"):
+        mir(singular, data_slice)
+
+
+def test_mir_raises_on_non_square_unmixing(data_slice):
+    non_square = np.eye(data_slice.shape[0])[:16]
+
+    with pytest.raises(np.linalg.LinAlgError):
+        mir(non_square, data_slice)
+
+
+def test_mir_raises_on_non_finite_data(data_slice):
+    contaminated = data_slice.copy()
+    contaminated[0, 5] = np.nan
+
+    with pytest.raises(ValueError, match="non-finite"):
+        mir(np.eye(contaminated.shape[0]), contaminated)
+
+
+def test_marginal_entropies_raises_on_constant_channel(data_slice):
+    flat = data_slice.copy()
+    flat[0] = 0.0
+
+    with pytest.raises(ValueError, match="constant"):
+        _marginal_entropies(flat)

--- a/pyAMICA/tests/test_metrics_mir.py
+++ b/pyAMICA/tests/test_metrics_mir.py
@@ -73,7 +73,7 @@ def test_mir_identity_unmixing_is_approximately_zero(data_slice):
 def test_mir_scaled_identity_matches_closed_form(data_slice):
     n, n_samples = data_slice.shape
     c = 2.5
-    hx, vx = _marginal_entropies(data_slice)
+    _, vx = _marginal_entropies(data_slice)
 
     mir_val, variance = mir(c * np.eye(n), data_slice)
 

--- a/pyAMICA/tests/test_metrics_mir.py
+++ b/pyAMICA/tests/test_metrics_mir.py
@@ -1,0 +1,90 @@
+"""Unit tests for ``pyAMICA.metrics.mir`` (issue #134, MIR port phase 1).
+
+MIR is backend-agnostic pure NumPy, so it lives directly under ``pyAMICA/tests/``
+(like ``test_amari_distance.py``) rather than ``tests/torch_tests/``. Per the
+NO-MOCK policy, every test exercises the real bundled sample EEG data; none use
+synthetic/random data as ground truth.
+"""
+
+import math
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from pyAMICA.metrics.mir import _marginal_entropies, mir
+from pyAMICA.torch_impl.utils import load_eeglab_data
+
+SAMPLE_DIR = Path(__file__).resolve().parents[1] / "sample_data"
+DATA_FILE = SAMPLE_DIR / "eeglab_data.fdt"
+NW = 32
+FIELD = 30504
+
+
+@pytest.fixture(scope="module")
+def real_data() -> np.ndarray:
+    if not DATA_FILE.exists():
+        pytest.skip("sample data missing")
+    return load_eeglab_data(str(DATA_FILE), data_dim=NW, field_dim=FIELD).astype(
+        np.float64
+    )
+
+
+@pytest.fixture(scope="module")
+def data_slice(real_data) -> np.ndarray:
+    return real_data[:, :4000]
+
+
+def test_marginal_entropies_default_nbins_matches_formula(data_slice):
+    n_samples = data_slice.shape[1]
+    expected_nbins = round(3 * math.log2(1 + n_samples / 10))
+
+    h_default, v_default = _marginal_entropies(data_slice)
+    h_explicit, v_explicit = _marginal_entropies(data_slice, nbins=expected_nbins)
+
+    np.testing.assert_array_equal(h_default, h_explicit)
+    np.testing.assert_array_equal(v_default, v_explicit)
+
+
+def test_marginal_entropies_matches_histogram_rederivation(data_slice):
+    n_channels = 3
+    n_samples = data_slice.shape[1]
+    nbins = round(3 * math.log2(1 + n_samples / 10))
+
+    h_impl, _ = _marginal_entropies(data_slice[:n_channels], nbins=nbins)
+
+    for ch in range(n_channels):
+        row = data_slice[ch]
+        umin, umax = row.min(), row.max()
+        delta = (umax - umin) / nbins
+        counts, _ = np.histogram(row, bins=nbins, range=(umin, umax))
+        counts = counts[counts > 0]
+        p = counts / n_samples
+        h_ref = -np.sum(p * np.log(p)) + (nbins - 1) / (2 * n_samples) + np.log(delta)
+        np.testing.assert_allclose(h_impl[ch], h_ref, rtol=1e-2)
+
+
+def test_mir_identity_unmixing_is_approximately_zero(data_slice):
+    n = data_slice.shape[0]
+    mir_val, _ = mir(np.eye(n), data_slice)
+    assert abs(mir_val) < 1e-6
+
+
+def test_mir_scaled_identity_matches_closed_form(data_slice):
+    n, n_samples = data_slice.shape
+    c = 2.5
+    hx, vx = _marginal_entropies(data_slice)
+
+    mir_val, variance = mir(c * np.eye(n), data_slice)
+
+    assert abs(mir_val) < 1e-9
+    expected_variance = 2 * np.sum(vx) / n_samples
+    np.testing.assert_allclose(variance, expected_variance, rtol=1e-9)
+
+
+def test_mir_returns_finite_scalars_for_full_channel_data(real_data):
+    mir_val, variance = mir(np.eye(NW), real_data)
+    assert isinstance(mir_val, float)
+    assert isinstance(variance, float)
+    assert math.isfinite(mir_val)
+    assert math.isfinite(variance)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ Repository = "https://github.com/sccn/pyAMICA"
 [tool.setuptools]
 # List subpackages explicitly so the wheel is deterministic across platforms
 # (a bare ["pyAMICA"] dropped torch_impl/ on some setuptools versions).
-packages = ["pyAMICA", "pyAMICA.numpy_impl", "pyAMICA.torch_impl", "pyAMICA.mlx_impl"]
+packages = ["pyAMICA", "pyAMICA.numpy_impl", "pyAMICA.torch_impl", "pyAMICA.mlx_impl", "pyAMICA.metrics"]
 # numpy_impl/params.json is the NumPy backend's default parameter file, loaded at
 # runtime via importlib/__file__, so it must ship in the wheel.
 package-data = {"pyAMICA" = ["data/*"], "pyAMICA.numpy_impl" = ["params.json"]}


### PR DESCRIPTION
## Summary

Ports the MIR (Mutual Information Reduction) separation-quality metric from `getMIR.m` in `bigdelys/pre_ICA_cleaning` (Apache-2.0, permits a direct port with attribution). Adds `pyAMICA.metrics.mir(unmixing, data, nbins=None) -> (mir_nats, variance)` as a standalone, backend-agnostic function.

The `_marginal_entropies` helper (a port of `getMIR.m`'s nested `getent4`) uses `np.unique(binned, return_counts=True)` rather than `np.histogram`, since the MATLAB source's run-length-of-sorted-values method only ever reports occupied bins, which is what keeps `log(p)` finite.

This does not port the 2023 NEMAR-pipeline `mir(data, linT)` adaptation directly, since that version has a real scope bug (its body references `eig(W)` and `/N`, neither of which are its own parameters, and only resolves via MATLAB's nested-function shared workspace) and depends on a GPL-licensed sphering routine out of scope for this BSD-3-Clause project. Instead, `mir()` takes an explicit `unmixing` matrix; composing pyAMICA's own sphere-then-unmixing pipeline into that matrix is deferred to the API-wiring phase (#137).

Not included in this phase: wiring `mir()` into the `AMICA`/`AMICATorchNG` classes (`model.mir(X)`) -- that's phase 4, issue #137.

Closes #134
Part of epic #133

## Test plan

- `pyAMICA/tests/test_metrics_mir.py` (new): 5 tests against the real bundled sample EEG data (no synthetic/mock data), including an exact closed-form check (scaled-identity unmixing gives MIR ~= 0 and a provably-exact variance) and an independent `np.histogram`-based re-derivation of the entropy estimator.
- `uv run pytest pyAMICA/tests/test_metrics_mir.py -v`: 5 passed.
- `uv run pytest pyAMICA/tests/ -q -m "not slow"`: 191 passed, 9 skipped, 6 deselected, 1 xfailed (pre-existing) -- no regressions.
- `uv run ruff check` / `uv run ruff format` / `uv run ty check`: all clean.