### PR TITLE
Phase 3: posterior-probability (LLt) output parity with Fortran

### DIFF
--- a/pyAMICA/amica.py
+++ b/pyAMICA/amica.py
@@ -362,6 +362,11 @@ class AMICA:
         sign-flipping is needed. Single-model output is byte-compatible with the
         Fortran reference (issue #92).
 
+        Also writes ``LLt`` (the per-sample/per-model log-likelihood, issue
+        #155) for a model that was just fit in this process; a model restored
+        via :meth:`load` has no training data to recompute it from, so
+        ``LLt`` is omitted for it (a warning is logged).
+
         Parameters
         ----------
         outdir : str

--- a/pyAMICA/numpy_impl/core.py
+++ b/pyAMICA/numpy_impl/core.py
@@ -953,6 +953,86 @@ class AMICA:
 
         return updates
 
+    def _compute_full_posterior_ll(
+        self, data: Optional[np.ndarray] = None
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Recompute the per-model/per-sample log-likelihood over every sample
+        of ``data`` (default ``self.data``), for the Fortran ``LLt`` output
+        (issue #155).
+
+        Duplicates the ``b``/``z``/``logV`` forward pass in
+        ``_get_block_updates`` (same definitions, Fortran amica17.f90:1280-1372)
+        rather than sharing it, so this read-only computation cannot affect
+        that method's training-path behavior. Computed fresh from ``self``'s
+        current parameters, not stashed mid-training-loop values, so it is
+        correct even after a keep-best rollback (issue #51).
+
+        Returns
+        -------
+        Lht : ndarray of shape (num_models, n_samples)
+            Per-model log-likelihood, Fortran's ``modloglik``.
+        Lt : ndarray of shape (n_samples,)
+            Total log-likelihood, Fortran's ``loglik``.
+        """
+        assert (
+            self.data_dim is not None
+            and self.W is not None
+            and self.c is not None
+            and self.comp_list is not None
+            and self.beta is not None
+            and self.mu is not None
+            and self.rho is not None
+            and self.alpha is not None
+            and self.gm is not None
+        )
+        if data is None:
+            assert self.data is not None
+            data = self.data
+        n_samples = data.shape[1]
+        Lht = np.zeros((self.num_models, n_samples))
+        Lt = np.zeros(n_samples)
+
+        for start in range(0, n_samples, self.block_size):
+            end = min(start + self.block_size, n_samples)
+            X = data[:, start:end]
+            batch_size = X.shape[1]
+
+            b = np.zeros((batch_size, self.data_dim, self.num_models))
+            for h in range(self.num_models):
+                b[:, :, h] = np.dot((X - self.c[:, h][:, None]).T, self.W[:, :, h])
+
+            z = np.zeros((batch_size, self.data_dim, self.num_mix, self.num_models))
+            for h in range(self.num_models):
+                for i in range(self.data_dim):
+                    k = self.comp_list[i, h]
+                    for j in range(self.num_mix):
+                        y = self.beta[j, k] * (b[:, i, h] - self.mu[j, k])
+                        log_pdf, _ = self._compute_log_pdf(y, self.rho[j, k])
+                        z[:, i, j, h] = (
+                            np.log(self.alpha[j, k]) + np.log(self.beta[j, k]) + log_pdf
+                        )
+
+            z0max = np.max(z, axis=2, keepdims=True)
+            ll_src = z0max[:, :, 0, :] + np.log(np.sum(np.exp(z - z0max), axis=2))
+            logV = np.zeros((batch_size, self.num_models))
+            for h in range(self.num_models):
+                with np.errstate(divide="ignore", over="ignore", invalid="ignore"):
+                    _, logdet_W = np.linalg.slogdet(self.W[:, :, h])
+                logV[:, h] = (
+                    np.log(self.gm[h])
+                    + logdet_W
+                    + self.sldet
+                    + np.sum(ll_src[:, :, h], axis=1)
+                )
+
+            Vmax = np.max(logV, axis=1, keepdims=True)
+            ll_samples = Vmax[:, 0] + np.log(np.sum(np.exp(logV - Vmax), axis=1))
+
+            Lht[:, start:end] = logV.T
+            Lt[start:end] = ll_samples
+
+        return Lht, Lt
+
     def _update_parameters(self, updates: Dict):
         """
         Update model parameters using computed updates.
@@ -1521,6 +1601,8 @@ class AMICA:
         # (loadmodout treats 'nd' as optional).
         from .load import write_amicaout
 
+        Lht, Lt = self._compute_full_posterior_ll()
+
         write_amicaout(
             self.outdir,
             gm=self.gm,
@@ -1535,6 +1617,8 @@ class AMICA:
             comp_list=self.comp_list,
             ll=np.asarray(self.ll),
             A=self.A,
+            Lht=Lht,
+            Lt=Lt,
         )
 
     def _write_history(self):

--- a/pyAMICA/numpy_impl/core.py
+++ b/pyAMICA/numpy_impl/core.py
@@ -748,19 +748,31 @@ class AMICA:
 
         return updates
 
-    def _get_block_updates(self, X: np.ndarray) -> Dict:
-        """
-        Compute parameter updates for a data block.
+    def _forward_block(self, X: np.ndarray):
+        """Shared E-step forward pass for one data block (Fortran
+        amica17.f90:1280-1372): activations ``b``, the raw (unnormalized)
+        mixture log-probabilities ``z``, their per-source max ``z0max``, the
+        per-model log-likelihood ``logV`` (with the log|det W| + sldet
+        Jacobian), and the per-sample total log-likelihood (``Vmax``/
+        ``ll_samples``, log-sum-exp over models).
 
-        Parameters
-        ----------
-        X : ndarray
-            Data block to process
+        Shared by ``_get_block_updates`` (the training-path M-step, which
+        normalizes ``z``/``logV`` into responsibilities) and
+        ``_compute_full_posterior_ll`` (the LLt write path, which only needs
+        ``logV``/``ll_samples``) so a single copy carries any future fix to
+        this forward pass -- this codebase has had one-sided forward-pass bugs
+        before (issue #24's fp-vs-dpdf sign bug), and a duplicated copy could
+        silently drift (issue #155).
 
         Returns
         -------
-        updates : dict
-            Parameter updates for this block
+        b : ndarray of shape (batch, data_dim, num_models)
+        z : ndarray of shape (batch, data_dim, num_mix, num_models)
+            Raw (unnormalized) mixture log-probabilities.
+        z0max : ndarray of shape (batch, data_dim, 1, num_models)
+        logV : ndarray of shape (batch, num_models)
+        Vmax : ndarray of shape (batch, 1)
+        ll_samples : ndarray of shape (batch,)
         """
         assert (
             self.data_dim is not None
@@ -774,28 +786,6 @@ class AMICA:
             and self.gm is not None
         )
         batch_size = X.shape[1]
-        tiny = np.finfo(np.float64).tiny
-        updates = {
-            "dgm": np.zeros(self.num_models),
-            "dalpha_n": np.zeros((self.num_mix, self.num_comps)),
-            "dmu_n": np.zeros((self.num_mix, self.num_comps)),
-            "dmu_d": np.zeros((self.num_mix, self.num_comps)),
-            "dbeta_n": np.zeros((self.num_mix, self.num_comps)),
-            "dbeta_d": np.zeros((self.num_mix, self.num_comps)),
-            "drho_n": np.zeros((self.num_mix, self.num_comps)),
-            "dWtmp": np.zeros((self.data_dim, self.data_dim, self.num_models)),
-            "dc_numer": np.zeros((self.data_dim, self.num_models)),
-            "ll": 0.0,
-        }
-
-        if self.do_newton:
-            updates.update(
-                {
-                    "dsigma2": np.zeros((self.data_dim, self.num_models)),
-                    "dlambda": np.zeros((self.data_dim, self.num_models)),
-                    "dkappa": np.zeros((self.data_dim, self.num_models)),
-                }
-            )
 
         # Compute activations for each model. c is the per-model data-space
         # center: b = W(x - c). Fortran subtracts wc in the E-step
@@ -861,6 +851,60 @@ class AMICA:
         # Block log-likelihood = sum_t logsumexp_h logV (Fortran :1372).
         Vmax = np.max(logV, axis=1, keepdims=True)
         ll_samples = Vmax[:, 0] + np.log(np.sum(np.exp(logV - Vmax), axis=1))
+
+        return b, z, z0max, logV, Vmax, ll_samples
+
+    def _get_block_updates(self, X: np.ndarray) -> Dict:
+        """
+        Compute parameter updates for a data block.
+
+        Parameters
+        ----------
+        X : ndarray
+            Data block to process
+
+        Returns
+        -------
+        updates : dict
+            Parameter updates for this block
+        """
+        assert (
+            self.data_dim is not None
+            and self.c is not None
+            and self.W is not None
+            and self.comp_list is not None
+            and self.beta is not None
+            and self.mu is not None
+            and self.rho is not None
+            and self.alpha is not None
+            and self.gm is not None
+        )
+        batch_size = X.shape[1]
+        tiny = np.finfo(np.float64).tiny
+        updates = {
+            "dgm": np.zeros(self.num_models),
+            "dalpha_n": np.zeros((self.num_mix, self.num_comps)),
+            "dmu_n": np.zeros((self.num_mix, self.num_comps)),
+            "dmu_d": np.zeros((self.num_mix, self.num_comps)),
+            "dbeta_n": np.zeros((self.num_mix, self.num_comps)),
+            "dbeta_d": np.zeros((self.num_mix, self.num_comps)),
+            "drho_n": np.zeros((self.num_mix, self.num_comps)),
+            "dWtmp": np.zeros((self.data_dim, self.data_dim, self.num_models)),
+            "dc_numer": np.zeros((self.data_dim, self.num_models)),
+            "ll": 0.0,
+        }
+
+        if self.do_newton:
+            updates.update(
+                {
+                    "dsigma2": np.zeros((self.data_dim, self.num_models)),
+                    "dlambda": np.zeros((self.data_dim, self.num_models)),
+                    "dkappa": np.zeros((self.data_dim, self.num_models)),
+                }
+            )
+
+        b, z, z0max, logV, Vmax, ll_samples = self._forward_block(X)
+
         updates["ll"] = np.sum(ll_samples)
         # Expose the per-sample vector for outlier rejection (issue #123); only
         # under do_reject, so the default path is unchanged.
@@ -953,29 +997,56 @@ class AMICA:
 
         return updates
 
-    def _compute_full_posterior_ll(
-        self, data: Optional[np.ndarray] = None
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    def _compute_full_posterior_ll(self) -> Tuple[np.ndarray, np.ndarray]:
         """Recompute the per-model/per-sample log-likelihood over every sample
-        of ``data`` (default ``self.data``), for the Fortran ``LLt`` output
-        (issue #155).
+        of ``self.data``, for the Fortran ``LLt`` output (issue #155).
 
-        Duplicates the ``b``/``z``/``logV`` forward pass in
-        ``_get_block_updates`` (same definitions, Fortran amica17.f90:1280-1372)
-        rather than sharing it, so this read-only computation cannot affect
-        that method's training-path behavior. Computed fresh from ``self``'s
-        current parameters, not stashed mid-training-loop values, so it is
-        correct even after a keep-best rollback (issue #51).
+        Shares the ``_forward_block`` forward pass with ``_get_block_updates``
+        (only ``logV``/``ll_samples`` are needed here), so this read-only
+        computation cannot silently drift from the training path's E-step.
+        Computed fresh from ``self``'s current parameters, not stashed
+        mid-training-loop values, so it is correct even after a keep-best
+        rollback (issue #51).
+
+        Deliberate divergence from Fortran: Fortran's ``modloglik`` is filled
+        during iteration i's E-step, the M-step then updates the parameters,
+        and ``write_output`` writes both -- so Fortran's on-disk LLt is stale
+        by one M-step relative to the parameters written alongside it. This
+        method recomputes from the POST-update parameters, so pyAMICA's LLt is
+        self-consistent with the written W/A (better-behaved, not "fixed
+        toward Fortran" -- do not change this to match Fortran's staleness).
+
+        Cost note: called at every ``writestep`` checkpoint during training
+        (see ``_write_results``), not just once at the end, so each
+        checkpoint now pays a full O(n_samples) forward pass it did not pay
+        before this method existed. Bounded and small at the default
+        ``writestep`` (100; the bundled sample config uses 20); accepted for
+        now since this is the legacy backend. A cheaper design (stash the
+        per-sample ``logV`` computed during the training E-step instead of
+        recomputing, as Fortran does by keeping ``modloglik`` permanently
+        allocated) is tracked as a follow-up rather than done here.
+
+        Under ``do_reject``, only the good set (``self.good_idx``) is scored
+        -- Fortran zeroes a rejected sample's ``modloglik``/``loglik`` on write
+        (amica15.f90:2211-2216) and ``load_rej`` uses that exact zero as the
+        rejection sentinel (``sum(modloglik(:,i)) == 0.0``, amica15.f90:
+        887-896), so rejected columns of ``Lht``/``Lt`` are left at their
+        zero-initialized value rather than computed and discarded -- this also
+        avoids running rejected outliers through the model for the first time
+        at write time.
 
         Returns
         -------
         Lht : ndarray of shape (num_models, n_samples)
-            Per-model log-likelihood, Fortran's ``modloglik``.
+            Per-model log-likelihood, Fortran's ``modloglik``. Zero for
+            rejected samples under ``do_reject``.
         Lt : ndarray of shape (n_samples,)
-            Total log-likelihood, Fortran's ``loglik``.
+            Total log-likelihood, Fortran's ``loglik``. Zero for rejected
+            samples under ``do_reject``.
         """
         assert (
             self.data_dim is not None
+            and self.data is not None
             and self.W is not None
             and self.c is not None
             and self.comp_list is not None
@@ -985,51 +1056,28 @@ class AMICA:
             and self.alpha is not None
             and self.gm is not None
         )
-        if data is None:
-            assert self.data is not None
-            data = self.data
+        data = self.data
         n_samples = data.shape[1]
         Lht = np.zeros((self.num_models, n_samples))
         Lt = np.zeros(n_samples)
 
-        for start in range(0, n_samples, self.block_size):
-            end = min(start + self.block_size, n_samples)
-            X = data[:, start:end]
-            batch_size = X.shape[1]
+        if self.do_reject:
+            assert self.good_idx is not None
+            idx = self.good_idx
+            data_use = data[:, idx]
+        else:
+            idx = np.arange(n_samples)
+            data_use = data
+        n_use = data_use.shape[1]
 
-            b = np.zeros((batch_size, self.data_dim, self.num_models))
-            for h in range(self.num_models):
-                b[:, :, h] = np.dot((X - self.c[:, h][:, None]).T, self.W[:, :, h])
+        for start in range(0, n_use, self.block_size):
+            end = min(start + self.block_size, n_use)
+            X = data_use[:, start:end]
+            _, _, _, logV, _, ll_samples = self._forward_block(X)
 
-            z = np.zeros((batch_size, self.data_dim, self.num_mix, self.num_models))
-            for h in range(self.num_models):
-                for i in range(self.data_dim):
-                    k = self.comp_list[i, h]
-                    for j in range(self.num_mix):
-                        y = self.beta[j, k] * (b[:, i, h] - self.mu[j, k])
-                        log_pdf, _ = self._compute_log_pdf(y, self.rho[j, k])
-                        z[:, i, j, h] = (
-                            np.log(self.alpha[j, k]) + np.log(self.beta[j, k]) + log_pdf
-                        )
-
-            z0max = np.max(z, axis=2, keepdims=True)
-            ll_src = z0max[:, :, 0, :] + np.log(np.sum(np.exp(z - z0max), axis=2))
-            logV = np.zeros((batch_size, self.num_models))
-            for h in range(self.num_models):
-                with np.errstate(divide="ignore", over="ignore", invalid="ignore"):
-                    _, logdet_W = np.linalg.slogdet(self.W[:, :, h])
-                logV[:, h] = (
-                    np.log(self.gm[h])
-                    + logdet_W
-                    + self.sldet
-                    + np.sum(ll_src[:, :, h], axis=1)
-                )
-
-            Vmax = np.max(logV, axis=1, keepdims=True)
-            ll_samples = Vmax[:, 0] + np.log(np.sum(np.exp(logV - Vmax), axis=1))
-
-            Lht[:, start:end] = logV.T
-            Lt[start:end] = ll_samples
+            cols = idx[start:end]
+            Lht[:, cols] = logV.T
+            Lt[cols] = ll_samples
 
         return Lht, Lt
 
@@ -1593,6 +1641,14 @@ class AMICA:
         losslessly, matching ``loadmodout``'s own C-order model-axis convention),
         but is not byte-identical to multi-model Fortran output. Multi-model
         Fortran interop is out of scope here (see #27).
+
+        Also writes ``LLt`` (issue #155) via ``_compute_full_posterior_ll``,
+        which is called on every ``_write_results`` call -- including every
+        mid-training ``writestep`` checkpoint, not just the final write -- so
+        each checkpoint now pays a full O(n_samples) forward pass over the
+        whole dataset. See ``_compute_full_posterior_ll``'s docstring for the
+        cost/tradeoff note and the cheaper stash-during-E-step design tracked
+        as a follow-up.
         """
         # A is written (Fortran output omits it; loadmodout derives A from W and
         # S) only so load_results can restore it directly for the viz helpers.

--- a/pyAMICA/numpy_impl/load.py
+++ b/pyAMICA/numpy_impl/load.py
@@ -132,6 +132,12 @@ def write_amicaout(
     # comp_list is 1-based on disk (loadmodout subtracts 1 when indexing).
     _w("comp_list", np.asarray(comp_list) + 1, dtype=np.int32, order="F")
     _w("LL", np.asarray(ll))
+    if (Lht is None) != (Lt is None):
+        raise ValueError(
+            "write_amicaout: Lht and Lt must be given together (both None to "
+            f"omit LLt, or both arrays to write it); got Lht={Lht!r}, "
+            f"Lt={Lt!r}."
+        )
     if Lht is not None and Lt is not None:
         # Fortran writes, per timepoint, each model's log-likelihood then the
         # total (write_output, amica15.f90:2308-2333) -- a column-major

--- a/pyAMICA/numpy_impl/load.py
+++ b/pyAMICA/numpy_impl/load.py
@@ -63,14 +63,16 @@ def write_amicaout(
     comp_list,
     ll,
     A=None,
+    Lht=None,
+    Lt=None,
 ):
     """Write a fitted AMICA model as the Fortran/EEGLAB binary output directory.
 
     Emits the raw little-endian files that :func:`loadmodout` and EEGLAB's
     ``loadmodout15.m`` read: ``gm``, ``W``, ``S``, ``mean``, ``c``, ``alpha``,
-    ``mu``, ``sbeta``, ``rho``, ``comp_list`` (1-based ``int32``) and ``LL``.
-    This is the write counterpart of :func:`loadmodout`, so a pyAMICA fit (either
-    backend) drops into an EEGLAB workflow (issue #92).
+    ``mu``, ``sbeta``, ``rho``, ``comp_list`` (1-based ``int32``), ``LL`` and
+    (when given) ``LLt``. This is the write counterpart of :func:`loadmodout`,
+    so a pyAMICA fit (either backend) drops into an EEGLAB workflow (issue #92).
 
     Both backends store these arrays in the same convention, so for a single
     model the bytes are identical to the Fortran reference's ``amicaout`` files;
@@ -93,6 +95,12 @@ def write_amicaout(
         Mixing matrix. ``loadmodout15`` derives ``A`` from ``W`` and ``S`` and
         ignores this file; it is written (when given) only so pyAMICA's own
         ``load_results`` can restore ``A`` directly for the viz helpers.
+    Lht : array-like of shape (num_models, n_samples), optional
+        Per-model per-sample log-likelihood (Fortran ``modloglik``). Written
+        together with ``Lt`` as the ``LLt`` file (issue #155); omitted (as
+        before) when either is ``None``.
+    Lt : array-like of shape (n_samples,), optional
+        Total per-sample log-likelihood (Fortran ``loglik``).
     """
     outdir = Path(outdir)
     outdir.mkdir(parents=True, exist_ok=True)
@@ -124,6 +132,12 @@ def write_amicaout(
     # comp_list is 1-based on disk (loadmodout subtracts 1 when indexing).
     _w("comp_list", np.asarray(comp_list) + 1, dtype=np.int32, order="F")
     _w("LL", np.asarray(ll))
+    if Lht is not None and Lt is not None:
+        # Fortran writes, per timepoint, each model's log-likelihood then the
+        # total (write_output, amica15.f90:2308-2333) -- a column-major
+        # (num_models+1, n_samples) matrix. Stacking Lt as the last row and
+        # flattening order="F" reproduces that per-timepoint sequence exactly.
+        _w("LLt", np.vstack([np.atleast_2d(Lht), np.atleast_2d(Lt)]), order="F")
 
 
 def loadmodout(outdir: Union[str, Path]) -> AmicaOutput:
@@ -195,10 +209,12 @@ def loadmodout(outdir: Union[str, Path]) -> AmicaOutput:
                 f"be corrupt or from an incompatible run."
             )
 
-    # Read log likelihoods
+    # Read log likelihoods. Stored column-major (Fortran writes, per timepoint,
+    # each model's log-likelihood then the total), so reshape order="F" (matches
+    # loadmodout15.m's `reshape(LLt, num_models+1, N)` and write_amicaout below).
     LLt = read_binary_file(outdir / "LLt")
     if LLt is not None:
-        LLt = LLt.reshape(num_models + 1, -1)
+        LLt = LLt.reshape(num_models + 1, -1, order="F")
         Lht = LLt[:num_models]
         Lt = LLt[num_models]
     else:

--- a/pyAMICA/tests/test_sample_data.py
+++ b/pyAMICA/tests/test_sample_data.py
@@ -17,6 +17,32 @@ eeglab_data_file = op.join(sample_data_path, "eeglab_data.fdt")
 amicaout_dir = op.join(sample_data_path, "amicaout")
 
 
+def test_loadmodout_llt_reshape_order():
+    """``loadmodout`` reads the bundled Fortran-produced ``LLt`` file with the
+    correct column-major reshape (issue #155 regression).
+
+    The reference binary writes, per timepoint, each model's log-likelihood
+    then the total (Fortran ``write_output``, amica15.f90:2308-2333) -- a
+    column-major ``(num_models+1, N)`` layout (matching EEGLAB's
+    ``loadmodout15.m``, which does ``reshape(LLt, num_models+1, N)`` under
+    MATLAB's column-major default). A C-order reshape scrambles this. The
+    bundled fixture is single-model, so ``Lht[0]`` must equal ``Lt`` exactly --
+    a C-order bug would break both this equality and the mean check below.
+    """
+    out = loadmodout(amicaout_dir)
+    assert out.num_models == 1
+    assert out.Lht is not None and out.Lt is not None
+    assert out.Lht.shape == (1, out.Lt.shape[0])
+    np.testing.assert_array_equal(out.Lht[0], out.Lt)
+
+    # Fortran's bundled "LL" file already reports the per-sample-per-channel
+    # normalized log-likelihood (~-3.40), so nw * final_ll recovers the LLt
+    # convention's per-sample total (summed over channels), Lt.mean().
+    nw = out.W.shape[0]
+    final_ll = out.LL[-1]
+    np.testing.assert_allclose(out.Lt.mean(), nw * final_ll, rtol=1e-3)
+
+
 @pytest.mark.slow
 @pytest.mark.xfail(
     reason="uses a per-row corrcoef of the internal W (= Fortran W^T, so rows are "
@@ -294,6 +320,45 @@ def test_cli_output_format_roundtrip(tmp_path):
     # mixing-vector-only path.
     viz.plot_components(str(outdir), data=data, max_comps=3)
     viz.plot_pdf_fits(str(outdir), data, max_comps=2)
+
+
+@pytest.mark.skipif(not op.exists(eeglab_data_file), reason="sample data missing")
+def test_numpy_llt_roundtrip(tmp_path):
+    """A real (short but genuine) single-model NumPy fit writes an ``LLt`` file
+    that round-trips through ``loadmodout`` (issue #155).
+
+    ``Lht[0]`` must equal ``Lt`` exactly for a single model (both are read from
+    the same on-disk sequence). ``Lt.mean()`` (the per-sample total log-density,
+    summed over channels) should be close to ``model.ll[-1] / model.num_samples``
+    -- ``self.ll`` is this backend's raw (unnormalized) per-iteration sum of the
+    same per-sample quantity, so dividing by the sample count recovers the same
+    convention as ``Lt.mean()``. They are not bit-identical: ``self.ll[-1]`` is
+    the pre-update E-step likelihood of the last iteration, while the written
+    LLt is recomputed post-update, so a loose tolerance is used.
+    """
+    data = load_data_file(eeglab_data_file, 32, 30504, dtype=np.float32).astype(
+        np.float64
+    )[:, :4096]
+    outdir = tmp_path / "out"
+    model = AMICA(
+        use_tqdm=False,
+        num_models=1,
+        num_mix=3,
+        seed=1,
+        max_iter=30,
+        writestep=10000,
+        do_opt_block=False,
+        outdir=str(outdir),
+    )
+    model.fit(data)
+
+    out = loadmodout(outdir)
+    assert out.Lht is not None and out.Lt is not None
+    assert out.Lht.shape == (1, model.num_samples)
+    np.testing.assert_array_equal(out.Lht[0], out.Lt)
+
+    expected = model.ll[-1] / model.num_samples
+    np.testing.assert_allclose(out.Lt.mean(), expected, rtol=1e-2)
 
 
 @pytest.mark.skipif(not op.exists(eeglab_data_file), reason="sample data missing")

--- a/pyAMICA/tests/test_sample_data.py
+++ b/pyAMICA/tests/test_sample_data.py
@@ -362,6 +362,118 @@ def test_numpy_llt_roundtrip(tmp_path):
 
 
 @pytest.mark.skipif(not op.exists(eeglab_data_file), reason="sample data missing")
+def test_numpy_llt_reject_zeroes_rejected_samples(tmp_path):
+    """Under ``do_reject``, rejected samples must be exactly zero in the
+    written ``LLt`` (issue #155 Fix 1): Fortran zeroes a rejected sample's
+    ``modloglik``/``loglik`` on write (amica15.f90:2211-2216) and its
+    ``load_rej`` reader reconstructs the rejection mask from that exact zero
+    sentinel (``sum(modloglik(:,i)) == 0.0``, amica15.f90:887-896). Good
+    samples must stay non-zero and finite.
+    """
+    data = load_data_file(eeglab_data_file, 32, 30504, dtype=np.float32).astype(
+        np.float64
+    )[:, :4096]
+    outdir = tmp_path / "out"
+    model = AMICA(
+        use_tqdm=False,
+        num_models=1,
+        num_mix=3,
+        seed=1,
+        max_iter=15,
+        writestep=10000,
+        do_opt_block=False,
+        do_reject=True,
+        rejstart=2,
+        rejint=3,
+        maxrej=3,
+        rejsig=2.0,
+        outdir=str(outdir),
+    )
+    model.fit(data)
+    good_idx = model.good_idx
+    num_samples = model.num_samples
+    assert good_idx is not None and num_samples is not None
+    assert good_idx.size < num_samples, "fixture must reject something"
+
+    out = loadmodout(outdir)
+    assert out.Lht is not None and out.Lt is not None
+    good = np.zeros(num_samples, dtype=bool)
+    good[good_idx] = True
+
+    np.testing.assert_array_equal(out.Lht[:, ~good], 0.0)
+    np.testing.assert_array_equal(out.Lt[~good], 0.0)
+    assert np.all(out.Lht[:, good] != 0.0)
+    assert np.all(np.isfinite(out.Lht[:, good]))
+    assert np.all(out.Lt[good] != 0.0)
+    assert np.all(np.isfinite(out.Lt[good]))
+
+
+@pytest.mark.skipif(not op.exists(eeglab_data_file), reason="sample data missing")
+def test_numpy_llt_multimodel_roundtrip(tmp_path):
+    """A small real 2-model NumPy fit's ``LLt`` satisfies its definitional
+    relationship: the total per-sample log-likelihood is the log-sum-exp of
+    the per-model log-likelihoods (issue #155). Only the torch backend had a
+    multi-model LLt round-trip test; the two ``_compute_full_posterior_ll``
+    are separate implementations, so this exercises the numpy one too. Few
+    iterations -- this is a code-path smoke test, not a convergence check.
+    """
+    from scipy.special import logsumexp
+
+    data = load_data_file(eeglab_data_file, 32, 30504, dtype=np.float32).astype(
+        np.float64
+    )[:, :4096]
+    outdir = tmp_path / "out"
+    model = AMICA(
+        use_tqdm=False,
+        num_models=2,
+        num_mix=3,
+        seed=7,
+        max_iter=5,
+        writestep=10000,
+        do_opt_block=False,
+        outdir=str(outdir),
+    )
+    model.fit(data)
+
+    out = loadmodout(outdir)
+    assert out.Lht is not None and out.Lt is not None
+    assert out.Lht.shape == (2, model.num_samples)
+    np.testing.assert_allclose(out.Lt, logsumexp(out.Lht, axis=0), rtol=1e-10)
+
+
+@pytest.mark.skipif(not op.exists(eeglab_data_file), reason="sample data missing")
+def test_numpy_llt_partial_final_block(tmp_path):
+    """The block loop's remainder branch (``end = min(start + block_size,
+    n_samples)``) is exercised by a sample count NOT evenly divisible by
+    ``block_size`` (issue #155 Fix 6d -- the existing LLt tests all used
+    exactly-divisible counts, e.g. 4096/128, so this branch was untested).
+    """
+    data = load_data_file(eeglab_data_file, 32, 30504, dtype=np.float32).astype(
+        np.float64
+    )[:, :4100]
+    assert data.shape[1] % 1024 != 0, "fixture must not be block_size-divisible"
+    outdir = tmp_path / "out"
+    model = AMICA(
+        use_tqdm=False,
+        num_models=1,
+        num_mix=3,
+        seed=1,
+        max_iter=5,
+        writestep=10000,
+        do_opt_block=False,
+        block_size=1024,
+        outdir=str(outdir),
+    )
+    model.fit(data)
+
+    out = loadmodout(outdir)
+    assert out.Lht is not None and out.Lt is not None
+    assert out.Lht.shape == (1, model.num_samples)
+    np.testing.assert_array_equal(out.Lht[0], out.Lt)
+    assert np.all(np.isfinite(out.Lt))
+
+
+@pytest.mark.skipif(not op.exists(eeglab_data_file), reason="sample data missing")
 def test_restart_on_early_nan_recovers(tmp_path):
     """An early non-finite LL triggers reinitialize-and-restart (Fortran
     restartiter path, #39); the fit recovers and finishes with a finite LL.

--- a/pyAMICA/tests/torch_tests/test_amica_ng_wrapper.py
+++ b/pyAMICA/tests/torch_tests/test_amica_ng_wrapper.py
@@ -301,6 +301,136 @@ def test_write_amica_output_llt_multimodel(real_data, tmp_path):
     np.testing.assert_allclose(out.Lt, logsumexp(out.Lht, axis=0), rtol=1e-10)
 
 
+def test_loadmodout_llt_gm_reorder_alignment(real_data, tmp_path):
+    """``loadmodout`` must permute ``Lht`` by the SAME ``gm_ord`` it applies to
+    ``W``/``mod_prob``/``comp_list``/etc, not leave it in on-disk order (issue
+    #155 review Addition B).
+
+    ``test_write_amica_output_llt_multimodel``'s ``Lt == logsumexp(Lht,
+    axis=0)`` check is permutation-invariant over the model axis, so it
+    cannot detect a model-axis misalignment between ``Lht`` and ``W``/``gm``.
+    This test instead reads the raw on-disk ``gm``/``LLt`` bytes directly,
+    computes the permutation by hand, and checks ``loadmodout``'s ``Lht``
+    against it.
+
+    Requires a genuinely non-identity ``gm_ord`` (model 1 outweighing model
+    0), or this degenerates into a tautology that passes regardless of
+    whether the permutation is applied; seed=4 gives exactly that on real
+    sample EEG.
+    """
+    from pyAMICA.numpy_impl.load import loadmodout
+
+    model = AMICA(n_models=2, n_mix=3, device="cpu", verbose=False)
+    model.fit(real_data[:, :4096], max_iter=8, block_size=1024, seed=4)
+
+    outdir = tmp_path / "amicaout"
+    model.write_amica_output(str(outdir))
+
+    gm_raw = np.fromfile(outdir / "gm", dtype=np.float64)
+    num_models = gm_raw.size
+    gm_ord = np.argsort(gm_raw)[::-1]
+    assert not np.array_equal(gm_ord, np.arange(num_models)), (
+        "fixture must give a non-identity gm ordering, or this test is a tautology"
+    )
+
+    LLt_raw = np.fromfile(outdir / "LLt", dtype=np.float64)
+    n_samples = LLt_raw.size // (num_models + 1)
+    LLt_raw = LLt_raw.reshape(num_models + 1, n_samples, order="F")
+    Lht_raw = LLt_raw[:num_models]
+
+    out = loadmodout(outdir)
+    assert out.Lht is not None
+    np.testing.assert_array_equal(out.Lht, Lht_raw[gm_ord])
+    assert not np.array_equal(out.Lht, Lht_raw), (
+        "Lht must actually be permuted by gm_ord, not left in on-disk order"
+    )
+
+
+def test_write_amica_output_llt_reject_zeroes_rejected_samples(real_data, tmp_path):
+    """Under ``do_reject``, rejected samples must be exactly zero in the
+    written ``LLt`` (issue #155 Fix 1): Fortran zeroes a rejected sample's
+    ``modloglik``/``loglik`` on write (amica15.f90:2211-2216) and its
+    ``load_rej`` reader reconstructs the rejection mask from that exact zero
+    sentinel (``sum(modloglik(:,i)) == 0.0``, amica15.f90:887-896). Good
+    samples must stay non-zero and finite.
+    """
+    from pyAMICA.numpy_impl.load import loadmodout
+
+    model = AMICA(n_models=1, n_mix=3, device="cpu", verbose=False)
+    model.fit(
+        real_data[:, :4096],
+        max_iter=15,
+        block_size=1024,
+        seed=1,
+        do_reject=True,
+        rejstart=2,
+        rejint=3,
+        maxrej=3,
+        rejsig=2.0,
+    )
+    ng = model.model_
+    assert ng is not None and ng.good_idx is not None
+    assert ng.good_idx.numel() < 4096, "fixture must reject something"
+
+    outdir = tmp_path / "amicaout"
+    model.write_amica_output(str(outdir))
+    out = loadmodout(outdir)
+    assert out.Lht is not None and out.Lt is not None
+
+    good = np.zeros(4096, dtype=bool)
+    good[ng.good_idx.detach().cpu().numpy()] = True
+
+    np.testing.assert_array_equal(out.Lht[:, ~good], 0.0)
+    np.testing.assert_array_equal(out.Lt[~good], 0.0)
+    assert np.all(out.Lht[:, good] != 0.0)
+    assert np.all(np.isfinite(out.Lht[:, good]))
+    assert np.all(out.Lt[good] != 0.0)
+    assert np.all(np.isfinite(out.Lt[good]))
+
+
+def test_write_amica_output_llt_partial_final_block(real_data, tmp_path):
+    """The block loop's remainder branch (``end = min(start + block_size,
+    n_samples)``) is exercised by a sample count NOT evenly divisible by
+    ``block_size`` (issue #155 Fix 6d -- the existing LLt tests all used
+    exactly-divisible counts, e.g. 4096/1024, so this branch was untested).
+    """
+    from pyAMICA.numpy_impl.load import loadmodout
+
+    n = 4100
+    assert n % 1024 != 0, "fixture must not be block_size-divisible"
+    model = AMICA(n_models=1, n_mix=3, device="cpu", verbose=False)
+    model.fit(real_data[:, :n], max_iter=5, block_size=1024, seed=1)
+
+    outdir = tmp_path / "amicaout"
+    model.write_amica_output(str(outdir))
+    out = loadmodout(outdir)
+    assert out.Lht is not None and out.Lt is not None
+    assert out.Lht.shape == (1, n)
+    np.testing.assert_array_equal(out.Lht[0], out.Lt)
+    assert np.all(np.isfinite(out.Lt))
+
+
+def test_from_state_dict_write_amica_output_omits_llt(fitted_ng, tmp_path, caplog):
+    """A model restored via ``from_state_dict`` (the ``AMICA.load`` path) has
+    no training data to recompute ``LLt`` from (issue #155 Fix 2/3): a warning
+    must fire and no ``LLt`` file must be written, while the rest of the
+    output is unaffected."""
+    path = str(tmp_path / "model.pt")
+    fitted_ng.save(path)
+    loaded = AMICA.load(path, device="cpu")
+
+    outdir = tmp_path / "amicaout"
+    with caplog.at_level(logging.WARNING, logger="pyAMICA.torch_impl.core"):
+        loaded.write_amica_output(str(outdir))
+
+    assert not (outdir / "LLt").exists()
+    assert (outdir / "W").exists()  # the rest of the output is unaffected
+    assert any(
+        "LLt" in r.getMessage() and "restored" in r.getMessage().lower()
+        for r in caplog.records
+    )
+
+
 def test_ng_wrapper_fit_transform_real_data(fitted_ng, real_data):
     assert fitted_ng.is_fitted_
     assert len(fitted_ng.ll_history_) >= 1

--- a/pyAMICA/tests/torch_tests/test_amica_ng_wrapper.py
+++ b/pyAMICA/tests/torch_tests/test_amica_ng_wrapper.py
@@ -255,6 +255,52 @@ def test_write_amica_output_ll_matches_kept_iterate(real_data, tmp_path):
     assert len(ll) < len(ng.ll_history)  # the later overshoot is dropped
 
 
+def test_write_amica_output_llt_roundtrip(fitted_ng, tmp_path):
+    """A real (short but genuine) single-model NG fit writes an ``LLt`` file
+    that round-trips through ``loadmodout`` (issue #155).
+
+    ``Lht[0]`` must equal ``Lt`` exactly for a single model. ``Lt.mean()`` (the
+    per-sample total log-density, summed over channels) should be close to
+    ``nw * final_ll_`` -- the NG backend's ``final_ll_`` is already the
+    per-sample-per-channel normalized log-likelihood, matching the Fortran
+    ``LL`` file convention directly.
+    """
+    from pyAMICA.numpy_impl.load import loadmodout
+
+    outdir = tmp_path / "amicaout"
+    fitted_ng.write_amica_output(str(outdir))
+
+    out = loadmodout(outdir)
+    assert out.Lht is not None and out.Lt is not None
+    assert out.Lht.shape == (1, 4096)
+    np.testing.assert_array_equal(out.Lht[0], out.Lt)
+
+    assert fitted_ng.final_ll_ is not None
+    np.testing.assert_allclose(out.Lt.mean(), NW * fitted_ng.final_ll_, rtol=1e-2)
+
+
+def test_write_amica_output_llt_multimodel(real_data, tmp_path):
+    """A small real 2-model NG fit's ``LLt`` satisfies its definitional
+    relationship: the total per-sample log-likelihood is the log-sum-exp of
+    the per-model log-likelihoods over models (issue #155). Few iterations --
+    this exercises the multi-model LLt code path, not convergence."""
+    from pyAMICA.numpy_impl.load import loadmodout
+
+    model = AMICA(n_models=2, n_mix=3, device="cpu", verbose=False)
+    model.fit(real_data[:, :4096], max_iter=5, block_size=1024, seed=7)
+
+    outdir = tmp_path / "amicaout"
+    model.write_amica_output(str(outdir))
+
+    out = loadmodout(outdir)
+    assert out.Lht is not None and out.Lt is not None
+    assert out.Lht.shape == (2, 4096)
+
+    from scipy.special import logsumexp
+
+    np.testing.assert_allclose(out.Lt, logsumexp(out.Lht, axis=0), rtol=1e-10)
+
+
 def test_ng_wrapper_fit_transform_real_data(fitted_ng, real_data):
     assert fitted_ng.is_fitted_
     assert len(fitted_ng.ll_history_) >= 1

--- a/pyAMICA/torch_impl/core.py
+++ b/pyAMICA/torch_impl/core.py
@@ -619,12 +619,17 @@ class AMICATorchNG:
         self.sphere: Optional[torch.Tensor] = None
         self.sldet = 0.0
 
-        # Sphered training data, set by fit() (issue #155): retained so
-        # write_amica_output can recompute the full-dataset LLt from the
-        # CURRENT parameters at write time. Not a fitted parameter (absent from
-        # state_dict()/_PARAM_TENSORS): a model restored via from_state_dict()
-        # has no training data, so write_amica_output writes no LLt for it.
-        self._X_t: Optional[torch.Tensor] = None
+        # Full-dataset per-sample/per-model log-likelihood (Fortran's LLt,
+        # issue #155), computed ONCE at the end of fit() -- after any
+        # keep-best restore (issue #51), so it reflects the parameters
+        # actually exported, never a mid-training-loop value -- and stored as
+        # compact numpy arrays (not the full sphered dataset, which would pin
+        # n_channels x N x 8 bytes on the model, on GPU too). Not a fitted
+        # parameter (absent from state_dict()/_PARAM_TENSORS): a model
+        # restored via from_state_dict() has neither, so write_amica_output
+        # writes no LLt for it.
+        self._llt_lht: Optional[np.ndarray] = None
+        self._llt_lt: Optional[np.ndarray] = None
 
     # ------------------------------------------------------------------
     # Preprocessing
@@ -864,8 +869,9 @@ class AMICATorchNG:
         self, X_t: torch.Tensor
     ) -> Tuple[np.ndarray, np.ndarray]:
         """Recompute the per-model/per-sample log-likelihood over every sample
-        of ``X_t`` (the sphered training data retained by ``fit()``), for the
-        Fortran ``LLt`` output (issue #155).
+        of ``X_t`` (the sphered training data), for the Fortran ``LLt`` output
+        (issue #155). Called once from ``fit()`` (after any keep-best restore)
+        with the full dataset; not retained on ``self`` afterward.
 
         Reuses ``_forward``'s ``logV`` (Fortran's ``modloglik``: already
         includes the ``log|det W|`` + ``sldet`` Jacobian terms) rather than any
@@ -873,21 +879,51 @@ class AMICATorchNG:
         parameters -- correct even after a keep-best rollback (issue #51) to an
         earlier iterate than the training loop's last.
 
+        Deliberate divergence from Fortran: Fortran's ``modloglik`` is filled
+        during iteration i's E-step, the M-step then updates the parameters,
+        and ``write_output`` writes both -- so Fortran's on-disk LLt is stale
+        by one M-step relative to the parameters written alongside it. This
+        method recomputes from the POST-update (and, here, post-keep-best-
+        restore) parameters, so pyAMICA's LLt is self-consistent with the
+        written W/A (better-behaved, not "fixed toward Fortran" -- do not
+        change this to match Fortran's staleness).
+
+        Under ``do_reject``, only the good set (``self.good_idx``) is scored --
+        Fortran zeroes a rejected sample's ``modloglik``/``loglik`` on write
+        (amica15.f90:2211-2216) and ``load_rej`` uses that exact zero as the
+        rejection sentinel (``sum(modloglik(:,i)) == 0.0``, amica15.f90:
+        887-896), so rejected columns of the returned arrays are left at their
+        zero-initialized value rather than computed and discarded -- this also
+        avoids running rejected outliers through the model for the first time
+        at write time.
+
         Returns
         -------
-        Lht : ndarray of shape (n_models, n_samples)
-        Lt : ndarray of shape (n_samples,)
+        Lht : ndarray of shape (n_models, n_samples). Zero for rejected
+            samples under ``do_reject``.
+        Lt : ndarray of shape (n_samples,). Zero for rejected samples under
+            ``do_reject``.
         """
         n_samples = X_t.shape[1]
         Lht = np.zeros((self.n_models, n_samples))
         Lt = np.zeros(n_samples)
 
-        for start in range(0, n_samples, self.block_size):
-            end = min(start + self.block_size, n_samples)
-            logV, *_ = self._forward(X_t[:, start:end])
+        if self.do_reject:
+            assert self.good_idx is not None
+            idx = self.good_idx.detach().cpu().numpy()
+            X_use = X_t[:, self.good_idx]
+        else:
+            idx = np.arange(n_samples)
+            X_use = X_t
+        n_use = X_use.shape[1]
+
+        for start in range(0, n_use, self.block_size):
+            end = min(start + self.block_size, n_use)
+            logV, *_ = self._forward(X_use[:, start:end])
             lt_block = torch.logsumexp(logV, dim=1)
-            Lht[:, start:end] = logV.T.detach().cpu().numpy()
-            Lt[start:end] = lt_block.detach().cpu().numpy()
+            cols = idx[start:end]
+            Lht[:, cols] = logV.T.detach().cpu().numpy()
+            Lt[cols] = lt_block.detach().cpu().numpy()
 
         return Lht, Lt
 
@@ -1584,7 +1620,6 @@ class AMICATorchNG:
 
         X_t = self._preprocess(X)
         n_total = X_t.shape[1]
-        self._X_t = X_t
 
         self._initialize_parameters()
         self.ll_history = []
@@ -1786,6 +1821,13 @@ class AMICATorchNG:
             self._restore_params(best_snapshot)
             self.final_ll_ = best_ll
 
+        # LLt (Fortran's per-sample/per-model log-likelihood, issue #155):
+        # computed ONCE here, strictly after the keep-best restore above, so
+        # the stored arrays reflect the parameters actually being returned/
+        # exported by fit() -- never a mid-training-loop value. Stored as
+        # compact numpy arrays rather than retaining the full sphered dataset.
+        self._llt_lht, self._llt_lt = self._compute_full_posterior_ll(X_t)
+
         return self
 
     def _sample_ll(self, good_idx: torch.Tensor, X_t: torch.Tensor) -> torch.Tensor:
@@ -1953,11 +1995,19 @@ class AMICATorchNG:
         """Write this fitted model as the Fortran/EEGLAB AMICA output directory.
 
         Produces the raw binary files that EEGLAB's ``loadmodout15.m`` (and the
-        Python port :func:`pyAMICA.numpy_impl.load.loadmodout`) read, so a
-        PyTorch NG fit drops directly into an EEGLAB workflow (issue #92).
-        ``loadmodout15`` performs the variance-ordering and unit-norm
-        normalization on load, so the on-disk parameters are written in fit
-        order. Single-model output is byte-compatible with the Fortran reference.
+        Python port :func:`pyAMICA.numpy_impl.load.loadmodout`) read: ``gm``,
+        ``W``, ``S``, ``mean``, ``c``, ``alpha``, ``mu``, ``sbeta``, ``rho``,
+        ``comp_list``, ``LL``, so a PyTorch NG fit drops directly into an
+        EEGLAB workflow (issue #92). ``loadmodout15`` performs the
+        variance-ordering and unit-norm normalization on load, so the on-disk
+        parameters are written in fit order. Single-model output is
+        byte-compatible with the Fortran reference.
+
+        Also writes ``LLt`` (the per-sample/per-model log-likelihood, issue
+        #155) for a model that was just ``fit()`` in this process. A model
+        restored via :meth:`from_state_dict` has no training data to recompute
+        it from, so ``LLt`` is omitted for it (a warning is logged) -- the
+        rest of the output is unaffected.
 
         Parameters
         ----------
@@ -1989,13 +2039,18 @@ class AMICATorchNG:
             ll = ll[: int(np.argmax(ll)) + 1]
 
         # LLt (Fortran's per-sample/per-model log-likelihood, issue #155):
-        # recomputed fresh from the CURRENT parameters over the retained
-        # sphered training data. Only fit() sets _X_t, so a model restored via
-        # from_state_dict() (no training data) writes without LLt, same as a
-        # Fortran run with write_LLt disabled.
-        if self._X_t is not None:
-            Lht, Lt = self._compute_full_posterior_ll(self._X_t)
+        # computed once at the end of fit() (after any keep-best restore) and
+        # stored compactly on self. A model restored via from_state_dict()
+        # never ran fit() in this process, so it has neither -- warn rather
+        # than silently omitting the file (silent-failure review).
+        if self._llt_lht is not None and self._llt_lt is not None:
+            Lht, Lt = self._llt_lht, self._llt_lt
         else:
+            logger.warning(
+                "No LLt data available (model was restored via "
+                "from_state_dict(), not freshly fit()); writing output "
+                "without the LLt file."
+            )
             Lht = Lt = None
 
         write_amicaout(

--- a/pyAMICA/torch_impl/core.py
+++ b/pyAMICA/torch_impl/core.py
@@ -46,7 +46,7 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -619,6 +619,13 @@ class AMICATorchNG:
         self.sphere: Optional[torch.Tensor] = None
         self.sldet = 0.0
 
+        # Sphered training data, set by fit() (issue #155): retained so
+        # write_amica_output can recompute the full-dataset LLt from the
+        # CURRENT parameters at write time. Not a fitted parameter (absent from
+        # state_dict()/_PARAM_TENSORS): a model restored via from_state_dict()
+        # has no training data, so write_amica_output writes no LLt for it.
+        self._X_t: Optional[torch.Tensor] = None
+
     # ------------------------------------------------------------------
     # Preprocessing
     # ------------------------------------------------------------------
@@ -852,6 +859,37 @@ class AMICATorchNG:
         statistic; Fortran ``P``/``loglik``, amica17.f90:1372)."""
         logV, *_ = self._forward(X)
         return torch.logsumexp(logV, dim=1)  # (batch,)
+
+    def _compute_full_posterior_ll(
+        self, X_t: torch.Tensor
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Recompute the per-model/per-sample log-likelihood over every sample
+        of ``X_t`` (the sphered training data retained by ``fit()``), for the
+        Fortran ``LLt`` output (issue #155).
+
+        Reuses ``_forward``'s ``logV`` (Fortran's ``modloglik``: already
+        includes the ``log|det W|`` + ``sldet`` Jacobian terms) rather than any
+        value accumulated during training, so this reflects ``self``'s current
+        parameters -- correct even after a keep-best rollback (issue #51) to an
+        earlier iterate than the training loop's last.
+
+        Returns
+        -------
+        Lht : ndarray of shape (n_models, n_samples)
+        Lt : ndarray of shape (n_samples,)
+        """
+        n_samples = X_t.shape[1]
+        Lht = np.zeros((self.n_models, n_samples))
+        Lt = np.zeros(n_samples)
+
+        for start in range(0, n_samples, self.block_size):
+            end = min(start + self.block_size, n_samples)
+            logV, *_ = self._forward(X_t[:, start:end])
+            lt_block = torch.logsumexp(logV, dim=1)
+            Lht[:, start:end] = logV.T.detach().cpu().numpy()
+            Lt[start:end] = lt_block.detach().cpu().numpy()
+
+        return Lht, Lt
 
     def _get_block_updates(self, X: torch.Tensor) -> Dict[str, torch.Tensor]:
         """Compute sufficient-statistic accumulators for one data block.
@@ -1546,6 +1584,7 @@ class AMICATorchNG:
 
         X_t = self._preprocess(X)
         n_total = X_t.shape[1]
+        self._X_t = X_t
 
         self._initialize_parameters()
         self.ll_history = []
@@ -1949,6 +1988,16 @@ class AMICATorchNG:
         ):
             ll = ll[: int(np.argmax(ll)) + 1]
 
+        # LLt (Fortran's per-sample/per-model log-likelihood, issue #155):
+        # recomputed fresh from the CURRENT parameters over the retained
+        # sphered training data. Only fit() sets _X_t, so a model restored via
+        # from_state_dict() (no training data) writes without LLt, same as a
+        # Fortran run with write_LLt disabled.
+        if self._X_t is not None:
+            Lht, Lt = self._compute_full_posterior_ll(self._X_t)
+        else:
+            Lht = Lt = None
+
         write_amicaout(
             outdir,
             gm=_np(self.gm),
@@ -1963,6 +2012,8 @@ class AMICATorchNG:
             comp_list=_np(self.comp_list),
             ll=ll,
             A=_np(self.A),
+            Lht=Lht,
+            Lt=Lt,
         )
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The reference Fortran binary writes an `LLt` file on every run: the per-timepoint, per-model log-likelihood (`modloglik`) plus the total per-sample log-likelihood (`loglik`). Neither pyAMICA backend produced this file, and the reader had a separate latent bug. Since parity with the Fortran reference is this project's definition of correctness, a reference artifact we fail to reproduce is a regression, not a missing nice-to-have. This phase closes both gaps.

Two distinct bugs:

1. **Missing writer.** `write_amicaout()` emitted `gm/A/W/S/mean/c/alpha/mu/sbeta/rho/comp_list/LL` but never `LLt`, so no pyAMICA run produced the file at all.

2. **Reader reshape order (pre-existing, latent).** `loadmodout()` reshaped the raw `LLt` bytes with numpy's default `order="C"`, but Fortran's `write_output` (amica15.f90:2308-2333) writes, per timepoint, each model's log-likelihood then the total, which is a column-major `(num_models+1, N)` layout (matching EEGLAB's `loadmodout15.m`). Verified against the bundled `sample_data/amicaout/LLt` fixture: under `order="C"` the single-model `Lht` disagrees with `Lt` for 87% of samples, where they must be exactly equal; under `order="F"` they match exactly and `Lt.mean()` recovers `nw * final_ll` independently. This was latent only because nothing in the repo read `Lht`/`Lt`/`v`.

## Approach

Neither backend retains a full-dataset per-sample log-likelihood after fit; it is computed per block during the E-step and discarded once folded into sufficient statistics. Both backends therefore recompute it with a fresh full-dataset forward pass at write time, from whatever parameters are currently on the model. This is what makes the output correct after a `keep_best` rollback (#51), where the final exported parameters are an earlier iterate than the training loop's last.

`modloglik` is confirmed against the Fortran as `log|det W_h| + log(gm_h) + sldet + sum_i ll_src`, and `loglik` as its log-sum-exp over models.

Closes #155
Part of epic #133

## Test plan

All against real bundled sample EEG and the real Fortran-produced fixture; no synthetic data.

- [x] `test_loadmodout_llt_reshape_order` reads the real Fortran `amicaout/LLt` fixture and asserts single-model `Lht[0] == Lt` exactly plus `Lt.mean() ~= nw * final_ll`. This is the oracle that pins the layout to Fortran; it fails under the old `order="C"`.
- [x] `test_numpy_llt_roundtrip` and `test_write_amica_output_llt_roundtrip` fit real single-model NumPy/NG models and round-trip the written `LLt` through the fixed reader. A writer/reader order mismatch scrambles the interleave and breaks these, so they transitively pin the writer to Fortran's layout.
- [x] `test_write_amica_output_llt_multimodel` checks a real 2-model NG fit satisfies `Lt == logsumexp(Lht, axis=0)`.
- [x] Full suite green on the rebased branch: 218 passed, 9 skipped (MLX absent), 1 pre-existing xfail.
- [x] `ruff check`, `ruff format --check`, `ty check` all clean.