### PR TITLE
Phase 5: wire MIR/PMI into the AMICA API

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,16 @@ Release notes are also published on the
 
 ## Unreleased
 
+- `AMICATorchNG`/`AMICA` gain `mir()`/`pmi()` accessors that compose the
+  fitted unmixing the documented way (`get_unmixing_matrix(model_idx) @
+  sphere` for MIR, `transform(X, model_idx)` for PMI) and delegate to
+  `pyAMICA.metrics.mir`/`pairwise_mi`, so callers no longer hand-compose the
+  transform themselves. `fit()` also accepts `mir_step` (default `0`, off) to
+  record MIR waypoints during training in `mir_history_` as
+  `(iteration, mir_nats, variance)`; like `ll_history_`, it is a true
+  trajectory that a `keep_best` restore does not rewrite. PCA reduction
+  (`pcakeep`/`pcadb`) is rejected up front with a named error, since it
+  leaves the sphere rank-deficient and MIR's log-Jacobian undefined (#137).
 - Visualization module (`pyAMICA.viz`): `plot_pmi_heatmap` and
   `plot_model_probability`, backend-agnostic views over `AmicaOutput` that return
   a `Figure` (and accept an optional `ax`/`axes`) rather than mutating pyplot

--- a/pyAMICA/amica.py
+++ b/pyAMICA/amica.py
@@ -70,7 +70,8 @@ class AMICA:
         ``ll_history_[-1]``, as the model's log-likelihood: with the best-iterate
         safeguard the returned parameters can be an earlier, higher-LL iterate.
     mir_history_ : list
-        MIR waypoint trajectory (issue #137), populated when ``fit`` is called
+        Mutual Information Reduction (MIR) waypoint trajectory (issue #137),
+        populated when ``fit`` is called
         with ``mir_step > 0``: ``(iteration, mir_nats, variance)`` tuples from
         the mid-fit ``W``/``sphere``. Like ``ll_history_``, a ``keep_best``
         restore does not rewrite it -- use :meth:`mir` on the fitted model for
@@ -357,7 +358,21 @@ class AMICA:
         Returns
         -------
         mir_nats : float
+            Mutual information removed, in nats.
         variance : float
+            Variance of the estimate.
+
+        Raises
+        ------
+        ValueError
+            If the model is unfitted; or if PCA reduction (``pcakeep``/
+            ``pcadb``) is active, which leaves the sphere rank-deficient so
+            MIR's log-Jacobian term is undefined; or if ``X`` is non-finite or
+            has a constant channel. See :meth:`AMICATorchNG.mir` and
+            :func:`pyAMICA.metrics.mir`.
+        RuntimeError
+            If the fit ended degenerate (issue #50), since the parameters are
+            non-finite and any metric from them would be meaningless.
         """
         self._check_usable("compute MIR")
         assert self.model_ is not None
@@ -385,6 +400,19 @@ class AMICA:
         Returns
         -------
         mi_matrix : np.ndarray of shape (n_sources, n_sources)
+            Symmetric pairwise mutual information, in nats. The diagonal is each
+            source's own entropy, not a mutual information; see
+            :func:`pyAMICA.viz.plot_pmi_heatmap`, which masks it by default.
+
+        Raises
+        ------
+        ValueError
+            If the model is unfitted; or if ``X`` is non-finite or has a
+            constant channel; or if ``nbins`` is too large for the sample count
+            (a sparse joint histogram fabricates mutual information from noise).
+            See :func:`pyAMICA.metrics.pairwise_mi`.
+        RuntimeError
+            If the fit ended degenerate (issue #50).
         """
         self._check_usable("compute PMI")
         assert self.model_ is not None

--- a/pyAMICA/amica.py
+++ b/pyAMICA/amica.py
@@ -69,6 +69,12 @@ class AMICA:
         Log-likelihood of the *fitted* parameters (issue #51). Use this, not
         ``ll_history_[-1]``, as the model's log-likelihood: with the best-iterate
         safeguard the returned parameters can be an earlier, higher-LL iterate.
+    mir_history_ : list
+        MIR waypoint trajectory (issue #137), populated when ``fit`` is called
+        with ``mir_step > 0``: ``(iteration, mir_nats, variance)`` tuples from
+        the mid-fit ``W``/``sphere``. Like ``ll_history_``, a ``keep_best``
+        restore does not rewrite it -- use :meth:`mir` on the fitted model for
+        the value of the *returned* parameters, not ``mir_history_[-1]``.
 
     Examples
     --------
@@ -107,6 +113,7 @@ class AMICA:
         self.final_ll_ = None
         self.stop_reason_ = None
         self.converged_ = False
+        self.mir_history_ = []
 
     def _select_device(self, ng_dtype) -> Union[str, torch.device]:
         """Resolve the compute device, applying the MPS/float64 fallback.
@@ -141,6 +148,7 @@ class AMICA:
         do_mean: bool = True,
         do_sphere: bool = True,
         do_newton: bool = False,
+        mir_step: int = 0,
         **kwargs,
     ) -> "AMICA":
         """
@@ -161,6 +169,11 @@ class AMICA:
         do_newton : bool, default=False
             Whether to enable the Fortran-parity Newton preconditioner (tune
             via ``newt_start``/``newtrate`` in ``**kwargs``).
+        mir_step : int, default=0
+            If > 0, compute MIR every ``mir_step`` iterations during training
+            and record it in ``mir_history_`` (issue #137). ``0`` (default)
+            disables the waypoints; see :meth:`AMICATorchNG.fit` for details
+            and the interaction with ``keep_best``.
         **kwargs
             Additional parameters passed to the :class:`AMICATorchNG`
             constructor (e.g. ``block_size``, ``rho0``, ``seed``, ``dtype``) --
@@ -203,12 +216,13 @@ class AMICA:
             device=device,
             **kwargs,
         )
-        backend.fit(X, max_iter=max_iter, verbose=self.verbose)
+        backend.fit(X, max_iter=max_iter, verbose=self.verbose, mir_step=mir_step)
 
         self.model_ = backend
         self.ll_history_ = backend.ll_history
         self.final_ll_ = backend.final_ll_
         self.stop_reason_ = backend.stop_reason
+        self.mir_history_ = backend.mir_history_
         self.converged_ = self.stop_reason_ not in AMICATorchNG._DEGENERATE_STOP_REASONS
         # A degenerate fit (nan_ll/singular_ll) holds non-finite parameters and
         # would return NaN sources, so it is not a usable model: is_fitted_ stays
@@ -321,6 +335,61 @@ class AMICA:
         assert self.model_ is not None
 
         return self.model_.get_unmixing_matrix(model_idx=model_idx)
+
+    def mir(
+        self, X: np.ndarray, model_idx: int = 0, nbins: Optional[int] = None
+    ) -> tuple:
+        """
+        Mutual Information Reduction (issue #137) of the fitted unmixing on ``X``.
+
+        Composes the full raw-data-to-sources transform (unmixing @ sphere)
+        the documented way and delegates to :func:`pyAMICA.metrics.mir`.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            Raw (unpreprocessed) data of shape (n_channels, n_samples)
+        model_idx : int, default=0
+            Which model's unmixing to use
+        nbins : int, optional
+            Histogram bin count; see :func:`pyAMICA.metrics.mir`
+
+        Returns
+        -------
+        mir_nats : float
+        variance : float
+        """
+        self._check_usable("compute MIR")
+        assert self.model_ is not None
+
+        return self.model_.mir(X, model_idx=model_idx, nbins=nbins)
+
+    def pmi(
+        self, X: np.ndarray, model_idx: int = 0, nbins: Optional[int] = None
+    ) -> np.ndarray:
+        """
+        Pairwise Mutual Information (issue #137) between the fitted sources on ``X``.
+
+        Delegates to :func:`pyAMICA.metrics.pairwise_mi` on
+        ``transform(X, model_idx)``.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            Raw (unpreprocessed) data of shape (n_channels, n_samples)
+        model_idx : int, default=0
+            Which model's sources to use
+        nbins : int, optional
+            Histogram bin count; see :func:`pyAMICA.metrics.pairwise_mi`
+
+        Returns
+        -------
+        mi_matrix : np.ndarray of shape (n_sources, n_sources)
+        """
+        self._check_usable("compute PMI")
+        assert self.model_ is not None
+
+        return self.model_.pmi(X, model_idx=model_idx, nbins=nbins)
 
     def variance_order(
         self, model_idx: int = 0, return_svar: bool = False
@@ -459,6 +528,11 @@ class AMICA:
         )
         model.ll_history_ = model.model_.ll_history
         model.final_ll_ = model.model_.final_ll_
+        # mir_history_ is not persisted in state_dict() (a diagnostic
+        # trajectory, not a fitted parameter), so a loaded model's is always
+        # empty; expose it anyway for attribute-surface consistency with
+        # ll_history_.
+        model.mir_history_ = model.model_.mir_history_
         # state_dict() refuses to serialize a degenerate model, so a loaded model
         # is always usable; carry its stop_reason through for inspection anyway.
         model.stop_reason_ = model.model_.stop_reason

--- a/pyAMICA/tests/torch_tests/test_amica_ng_wrapper.py
+++ b/pyAMICA/tests/torch_tests/test_amica_ng_wrapper.py
@@ -11,11 +11,13 @@ import math
 from pathlib import Path
 
 import numpy as np
+import numpy.testing as npt
 import pytest
 import torch
 
 from pyAMICA.amica import AMICA
 from pyAMICA.metrics import mir, pairwise_mi
+from pyAMICA.torch_impl.core import AMICATorchNG
 
 SAMPLE_DIR = Path(__file__).resolve().parents[2] / "sample_data"
 DATA_FILE = SAMPLE_DIR / "eeglab_data.fdt"
@@ -520,25 +522,40 @@ def test_degenerate_fit_refuses_output(real_data, tmp_path, caplog):
 
 
 def test_mir_composes_unmixing_the_documented_way(fitted_ng, real_data):
-    """model.mir(X) must equal metrics.mir(get_unmixing_matrix(0) @ sphere, X)
-    exactly: this pins the W_fort @ sphere convention (issue #137 exists
-    precisely because that composition was gotten wrong by hand in Phase 4)."""
+    """`model.mir(X)` must match `metrics.mir(get_unmixing_matrix(0) @ sphere, X)`.
+
+    This pins the `W_fort @ sphere` composition, which is the whole reason issue
+    #137 exists: that composition was gotten wrong by hand during Phase 4, and
+    the wrong answer was *plausible* rather than obviously broken (dropping the
+    `.T` gives 42.4688 where the truth is 42.5486, only 0.19% off).
+
+    `rtol=1e-12` rather than exact equality: `mir()` composes `W.T @ sphere` in
+    torch while this test composes it in numpy, and the two BLAS paths differ in
+    the last bits (exact `==` passed locally and failed on CI). The tolerance is
+    still nine orders of magnitude tighter than the 1.9e-3 error it guards
+    against, so it catches a wrong composition comfortably.
+    """
     X = real_data[:, :4096]
     sphere = fitted_ng.model_.sphere.cpu().numpy()
     unmixing = fitted_ng.get_unmixing_matrix(0) @ sphere
-    expected = mir(unmixing, X)
+    expected_mir, expected_var = mir(unmixing, X)
 
-    actual = fitted_ng.mir(X)
-    assert actual == expected
+    actual_mir, actual_var = fitted_ng.mir(X)
+    npt.assert_allclose(actual_mir, expected_mir, rtol=1e-12)
+    npt.assert_allclose(actual_var, expected_var, rtol=1e-12)
 
 
 def test_pmi_matches_pairwise_mi_on_transform(fitted_ng, real_data):
-    """model.pmi(X) must equal pairwise_mi(model.transform(X)) exactly."""
+    """`model.pmi(X)` must match `pairwise_mi(model.transform(X))`.
+
+    `rtol=1e-12` for the same reason as the MIR test above: both sides run the
+    identical estimator, but the sources reach it via different float paths.
+    """
     X = real_data[:, :4096]
     expected = pairwise_mi(fitted_ng.transform(X))
 
     actual = fitted_ng.pmi(X)
-    np.testing.assert_array_equal(actual, expected)
+    npt.assert_allclose(actual, expected, rtol=1e-12)
 
 
 def test_mir_real_fitted_unmixing_is_large_and_positive(fitted_ng, real_data):
@@ -577,6 +594,57 @@ def test_mir_step_negative_raises(real_data):
         model.fit(
             real_data[:, :4096], max_iter=3, block_size=1024, seed=42, mir_step=-1
         )
+
+
+def test_failing_mir_waypoint_does_not_kill_the_fit(real_data, monkeypatch, caplog):
+    """A diagnostic must never destroy a decomposition.
+
+    `metrics.mir` raises on a near-singular unmixing, and a near-singular W
+    mid-fit is a transient the natural gradient can pass through (the training
+    path only warns about it). Before this guard, that ValueError propagated
+    straight out of `fit()` and threw away the whole fit -- turning on a
+    waypoint could lose hours of training over a condition the optimiser was
+    about to recover from.
+
+    Forcing the raise via monkeypatch is deliberate and is not mocked data: the
+    real trigger is a transient that cannot be induced on demand from real
+    input, and what is under test is the fit's response to a raising waypoint,
+    not any numerical claim. The fit's own inputs and arithmetic stay real
+    throughout.
+    """
+    real_mir = AMICATorchNG.mir
+    calls = {"n": 0}
+
+    def flaky_mir(self, X, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 2:  # fail on the second waypoint, mid-fit
+            raise ValueError("mir(): unmixing matrix is singular or near-singular")
+        return real_mir(self, X, **kwargs)
+
+    monkeypatch.setattr(AMICATorchNG, "mir", flaky_mir)
+
+    model = AMICA(n_models=1, n_mix=3, device="cpu", verbose=False)
+    with caplog.at_level(logging.WARNING, logger="pyAMICA.torch_impl.core"):
+        model.fit(real_data[:, :4096], max_iter=4, block_size=1024, seed=42, mir_step=1)
+
+    # The fit survived and is usable.
+    assert model.is_fitted_
+    assert model.converged_
+    assert model.final_ll_ is not None
+    assert math.isfinite(model.final_ll_)
+
+    # The failed waypoint is recorded as a visible NaN gap, not silently dropped.
+    iters = [row[0] for row in model.mir_history_]
+    assert iters == [0, 1, 2, 3], iters
+    values = [row[1] for row in model.mir_history_]
+    assert math.isnan(values[1]), "failed waypoint must be a visible NaN"
+    assert all(math.isfinite(v) for i, v in enumerate(values) if i != 1)
+
+    # And it warned rather than failing silently.
+    assert any(
+        "MIR waypoint failed" in r.getMessage() and "iter 1" in r.getMessage()
+        for r in caplog.records
+    )
 
 
 def test_mir_step_zero_matches_omitted_argument(real_data):

--- a/pyAMICA/tests/torch_tests/test_amica_ng_wrapper.py
+++ b/pyAMICA/tests/torch_tests/test_amica_ng_wrapper.py
@@ -558,6 +558,62 @@ def test_pmi_matches_pairwise_mi_on_transform(fitted_ng, real_data):
     npt.assert_allclose(actual, expected, rtol=1e-12)
 
 
+def test_mir_and_pmi_honour_model_idx(real_data):
+    """`model_idx` must actually reach the backend, for both methods.
+
+    Coverage gap found by sabotage: hardcoding `model_idx=0` inside `mir()` and
+    `pmi()` left every other test passing, because the shared fixture is
+    single-model and the wiring tests default to model 0 on both sides. Needs a
+    genuine 2-model fit whose models differ.
+    """
+    X = real_data[:, :4096]
+    model = AMICA(n_models=2, n_mix=3, device="cpu", verbose=False)
+    model.fit(X, max_iter=3, block_size=1024, seed=7)
+
+    # The two models are genuinely different, so their metrics must differ.
+    mir0, _ = model.mir(X, model_idx=0)
+    mir1, _ = model.mir(X, model_idx=1)
+    assert mir0 != mir1, "model_idx=1 returned model 0's MIR"
+
+    pmi0 = model.pmi(X, model_idx=0)
+    pmi1 = model.pmi(X, model_idx=1)
+    assert not np.array_equal(pmi0, pmi1), "model_idx=1 returned model 0's PMI"
+
+    # And each matches the free function composed for THAT model.
+    assert model.model_ is not None and model.model_.sphere is not None
+    sphere = model.model_.sphere.cpu().numpy()
+    for m in (0, 1):
+        expected, _ = mir(model.get_unmixing_matrix(m) @ sphere, X)
+        actual, _ = model.mir(X, model_idx=m)
+        npt.assert_allclose(actual, expected, rtol=1e-12)
+
+
+def test_mir_and_pmi_honour_nbins(fitted_ng, real_data):
+    """`nbins` must actually reach the metric, for both methods.
+
+    Coverage gap found by sabotage: hardcoding `nbins=None` in both methods left
+    every test passing, since none passed a non-default value.
+    """
+    X = real_data[:, :4096]
+    sphere = fitted_ng.model_.sphere.cpu().numpy()
+    unmixing = fitted_ng.get_unmixing_matrix(0) @ sphere
+
+    # A non-default nbins changes the estimate, and must match the free function
+    # given the same nbins.
+    default_mir, _ = fitted_ng.mir(X)
+    tuned_mir, _ = fitted_ng.mir(X, nbins=20)
+    assert default_mir != tuned_mir, "nbins was ignored by mir()"
+    expected_mir, _ = mir(unmixing, X, nbins=20)
+    npt.assert_allclose(tuned_mir, expected_mir, rtol=1e-12)
+
+    default_pmi = fitted_ng.pmi(X)
+    tuned_pmi = fitted_ng.pmi(X, nbins=20)
+    assert not np.array_equal(default_pmi, tuned_pmi), "nbins was ignored by pmi()"
+    npt.assert_allclose(
+        tuned_pmi, pairwise_mi(fitted_ng.transform(X), nbins=20), rtol=1e-12
+    )
+
+
 def test_mir_real_fitted_unmixing_is_large_and_positive(fitted_ng, real_data):
     """A real fitted unmixing removes mutual information (mir > 0) and removes
     more than the identity transform (mirrors
@@ -676,11 +732,16 @@ def test_mir_raises_under_pca_reduction(real_data):
 
 
 def test_mir_step_raises_under_pca_reduction_up_front(real_data):
-    """mir_step > 0 under pcakeep is rejected before fitting starts, matching
-    the share_comps precedent, rather than failing mid-fit at the first
-    waypoint."""
+    """`mir_step > 0` under `pcakeep` is rejected BEFORE fitting starts, matching
+    the share_comps precedent, rather than failing mid-fit at the first waypoint.
+
+    Matches "Rejected up front", which is unique to `fit()`'s guard, NOT the
+    generic "pcakeep" that `mir()`'s own downstream guard also mentions. With the
+    generic pattern this test could not tell "rejected before iteration 0" from
+    "rejected during iteration 0", which is the entire claim it exists to make.
+    """
     model = AMICA(n_models=1, n_mix=3, device="cpu", verbose=False)
-    with pytest.raises(ValueError, match="pcakeep"):
+    with pytest.raises(ValueError, match="Rejected up front"):
         model.fit(
             real_data[:, :4096],
             max_iter=2,

--- a/pyAMICA/tests/torch_tests/test_amica_ng_wrapper.py
+++ b/pyAMICA/tests/torch_tests/test_amica_ng_wrapper.py
@@ -7,6 +7,7 @@ represent float64). Real sample EEG data only (no synthetic/mock).
 """
 
 import logging
+import math
 from pathlib import Path
 
 import numpy as np
@@ -14,6 +15,7 @@ import pytest
 import torch
 
 from pyAMICA.amica import AMICA
+from pyAMICA.metrics import mir, pairwise_mi
 
 SAMPLE_DIR = Path(__file__).resolve().parents[2] / "sample_data"
 DATA_FILE = SAMPLE_DIR / "eeglab_data.fdt"
@@ -466,6 +468,10 @@ def test_unfitted_output_raises_not_fitted():
         model.transform(np.zeros((NW, 16)))
     with pytest.raises(ValueError, match="fitted"):
         model.get_unmixing_matrix()
+    with pytest.raises(ValueError, match="fitted"):
+        model.mir(np.zeros((NW, 16)))
+    with pytest.raises(ValueError, match="fitted"):
+        model.pmi(np.zeros((NW, 16)))
 
 
 def test_degenerate_fit_refuses_output(real_data, tmp_path, caplog):
@@ -496,6 +502,8 @@ def test_degenerate_fit_refuses_output(real_data, tmp_path, caplog):
         lambda: model.save(str(tmp_path / "degenerate.pt")),
         lambda: model.write_amica_output(str(tmp_path / "degenerate_out")),
         lambda: model.variance_order(),
+        lambda: model.mir(real_data[:, :512]),
+        lambda: model.pmi(real_data[:, :512]),
     ):
         with pytest.raises(RuntimeError, match="degenerate.*nan_ll"):
             action()
@@ -505,4 +513,111 @@ def test_degenerate_fit_refuses_output(real_data, tmp_path, caplog):
     with pytest.raises(RuntimeError, match="degenerate"):
         AMICA(n_models=1, n_mix=3, device="cpu", verbose=False).fit_transform(
             bad, max_iter=3, block_size=1024, seed=0
+        )
+
+
+# --- MIR / PMI wiring (issue #137) ------------------------------------------
+
+
+def test_mir_composes_unmixing_the_documented_way(fitted_ng, real_data):
+    """model.mir(X) must equal metrics.mir(get_unmixing_matrix(0) @ sphere, X)
+    exactly: this pins the W_fort @ sphere convention (issue #137 exists
+    precisely because that composition was gotten wrong by hand in Phase 4)."""
+    X = real_data[:, :4096]
+    sphere = fitted_ng.model_.sphere.cpu().numpy()
+    unmixing = fitted_ng.get_unmixing_matrix(0) @ sphere
+    expected = mir(unmixing, X)
+
+    actual = fitted_ng.mir(X)
+    assert actual == expected
+
+
+def test_pmi_matches_pairwise_mi_on_transform(fitted_ng, real_data):
+    """model.pmi(X) must equal pairwise_mi(model.transform(X)) exactly."""
+    X = real_data[:, :4096]
+    expected = pairwise_mi(fitted_ng.transform(X))
+
+    actual = fitted_ng.pmi(X)
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_mir_real_fitted_unmixing_is_large_and_positive(fitted_ng, real_data):
+    """A real fitted unmixing removes mutual information (mir > 0) and removes
+    more than the identity transform (mirrors
+    test_mir_real_fitted_unmixing_is_large_and_positive in test_metrics_mir.py)."""
+    X = real_data[:, :4096]
+    mir_nats, _ = fitted_ng.mir(X)
+    assert mir_nats > 0
+
+    identity_mir, _ = mir(np.eye(NW), X)
+    assert mir_nats > identity_mir
+
+
+def test_mir_step_populates_history_at_right_iterations(real_data):
+    model = AMICA(n_models=1, n_mix=3, device="cpu", verbose=False)
+    model.fit(real_data[:, :4096], max_iter=5, block_size=1024, seed=42, mir_step=2)
+
+    iterations = [entry[0] for entry in model.mir_history_]
+    assert iterations == [0, 2, 4]
+    for _, mir_nats, variance in model.mir_history_:
+        assert math.isfinite(mir_nats)
+        assert math.isfinite(variance)
+
+
+def test_mir_step_zero_leaves_history_empty(real_data):
+    model = AMICA(n_models=1, n_mix=3, device="cpu", verbose=False)
+    model.fit(real_data[:, :4096], max_iter=3, block_size=1024, seed=42, mir_step=0)
+
+    assert model.mir_history_ == []
+
+
+def test_mir_step_negative_raises(real_data):
+    model = AMICA(n_models=1, n_mix=3, device="cpu", verbose=False)
+    with pytest.raises(ValueError, match="mir_step"):
+        model.fit(
+            real_data[:, :4096], max_iter=3, block_size=1024, seed=42, mir_step=-1
+        )
+
+
+def test_mir_step_zero_matches_omitted_argument(real_data):
+    """mir_step=0 (explicit) must leave fit() behaviour byte-for-byte identical
+    to not passing mir_step at all."""
+    X = real_data[:, :4096]
+    default_model = AMICA(n_models=1, n_mix=3, device="cpu", verbose=False)
+    default_model.fit(X, max_iter=3, block_size=1024, seed=42)
+
+    explicit_model = AMICA(n_models=1, n_mix=3, device="cpu", verbose=False)
+    explicit_model.fit(X, max_iter=3, block_size=1024, seed=42, mir_step=0)
+
+    assert default_model.ll_history_ == explicit_model.ll_history_
+    assert default_model.final_ll_ == explicit_model.final_ll_
+    np.testing.assert_array_equal(
+        default_model.get_unmixing_matrix(), explicit_model.get_unmixing_matrix()
+    )
+    assert default_model.mir_history_ == explicit_model.mir_history_ == []
+
+
+def test_mir_raises_under_pca_reduction(real_data):
+    """PCA reduction (pcakeep) leaves the sphere rank-deficient, so mir()'s
+    log-Jacobian term is undefined; the guard must name pcakeep."""
+    model = AMICA(n_models=1, n_mix=3, device="cpu", verbose=False)
+    model.fit(real_data[:, :4096], max_iter=2, block_size=1024, seed=42, pcakeep=20)
+
+    with pytest.raises(ValueError, match="pcakeep"):
+        model.mir(real_data[:, :4096])
+
+
+def test_mir_step_raises_under_pca_reduction_up_front(real_data):
+    """mir_step > 0 under pcakeep is rejected before fitting starts, matching
+    the share_comps precedent, rather than failing mid-fit at the first
+    waypoint."""
+    model = AMICA(n_models=1, n_mix=3, device="cpu", verbose=False)
+    with pytest.raises(ValueError, match="pcakeep"):
+        model.fit(
+            real_data[:, :4096],
+            max_iter=2,
+            block_size=1024,
+            seed=42,
+            pcakeep=20,
+            mir_step=1,
         )

--- a/pyAMICA/torch_impl/core.py
+++ b/pyAMICA/torch_impl/core.py
@@ -52,6 +52,8 @@ import numpy as np
 import torch
 from tqdm import tqdm
 
+from ..metrics import mir as mir_metric
+from ..metrics import pairwise_mi
 from .utils import setup_device
 
 logger = logging.getLogger(__name__)
@@ -589,6 +591,14 @@ class AMICATorchNG:
         # the iterate fit() actually kept -- use this, not ``ll_history[-1]``, as
         # the model's fitted log-likelihood. Set by fit().
         self.final_ll_: Optional[float] = None
+        # MIR waypoint trajectory (issue #137), populated by fit() when
+        # mir_step > 0: (iteration, mir_nats, variance) tuples from the
+        # CURRENT (mid-fit) W/sphere. Like ll_history, this is a true
+        # trajectory that a keep_best restore does NOT rewrite -- the
+        # fit-end MIR is mir() on the returned parameters, not
+        # mir_history_[-1]. Not part of state_dict(): it's a diagnostic,
+        # not a fitted parameter.
+        self.mir_history_: list[tuple[int, float, float]] = []
 
         # Outlier-rejection bookkeeping (set up in fit()).
         self.numrej = 0
@@ -1592,7 +1602,11 @@ class AMICATorchNG:
     # Public API
     # ------------------------------------------------------------------
     def fit(
-        self, X: np.ndarray, max_iter: int = 100, verbose: bool = True
+        self,
+        X: np.ndarray,
+        max_iter: int = 100,
+        verbose: bool = True,
+        mir_step: int = 0,
     ) -> "AMICATorchNG":
         """Fit the model to data.
 
@@ -1604,6 +1618,16 @@ class AMICATorchNG:
             Number of natural-gradient EM iterations.
         verbose : bool, default=True
             Show a tqdm progress bar.
+        mir_step : int, default=0
+            If > 0, compute MIR (issue #137) from the current ``W``/``sphere``
+            every ``mir_step`` iterations and append it to ``mir_history_`` as
+            ``(iteration, mir_nats, variance)``. ``0`` (default) disables the
+            waypoints and leaves fit behaviour byte-for-byte unchanged.
+            ``mir_history_`` is a true trajectory like ``ll_history``: a
+            ``keep_best`` (issue #51) restore does not rewrite it, so the
+            fit-end MIR is ``self.mir(X)`` on the returned parameters, not
+            ``mir_history_[-1]``. Incompatible with PCA reduction
+            (``pcakeep``/``pcadb``), same as :meth:`mir` itself.
 
         Returns
         -------
@@ -1617,12 +1641,22 @@ class AMICATorchNG:
             raise ValueError(
                 f"X has {X.shape[0]} channels, model expects {self.n_channels}"
             )
+        if mir_step < 0:
+            raise ValueError(f"mir_step must be >= 0, got {mir_step}")
+        if mir_step > 0 and self._pca_reduced():
+            raise ValueError(
+                "mir_step > 0 is incompatible with PCA reduction "
+                "(pcakeep/pcadb): the sphere is rank-deficient, so MIR's "
+                "log-Jacobian term is undefined. Rejected up front rather "
+                "than failing mid-fit at the first waypoint."
+            )
 
         X_t = self._preprocess(X)
         n_total = X_t.shape[1]
 
         self._initialize_parameters()
         self.ll_history = []
+        self.mir_history_ = []
         self.numrej = 0
         self.n_newton_fallbacks = 0
         self._spinv = None  # rebuild the de-sphering metric for this fit's sphere
@@ -1747,6 +1781,14 @@ class AMICATorchNG:
                     self._update_unmixing_matrices()
 
             self.ll_history.append(ll)
+
+            # MIR waypoint (issue #137), following the NumPy backend's
+            # writestep/histstep idiom (numpy_impl/core.py). Computed from the
+            # CURRENT W/sphere (just rebuilt above by _update_parameters /
+            # the share_comps block) against the raw, un-preprocessed X.
+            if mir_step > 0 and it % mir_step == 0:
+                mir_nats, mir_var = self.mir(X)
+                self.mir_history_.append((it, mir_nats, mir_var))
 
             # Learning-rate control, ported from Fortran (amica17.f90:1062-1108).
             # Natural-gradient/Newton ascent is not monotonic at a fixed rate:
@@ -1926,6 +1968,85 @@ class AMICATorchNG:
                 "fit() first."
             )
         return self.W[:, :, model_idx].T.cpu().numpy()
+
+    def _pca_reduced(self) -> bool:
+        """Whether PCA reduction is active (``pcakeep``/``pcadb``), which leaves
+        the sphere rank-deficient."""
+        return self.pcakeep is not None or self.pcadb is not None
+
+    def mir(
+        self, X: np.ndarray, *, model_idx: int = 0, nbins: Optional[int] = None
+    ) -> Tuple[float, float]:
+        """Mutual Information Reduction (issue #137) of this model's unmixing on ``X``.
+
+        Composes the full raw-data-to-sources transform ``W_fort @ sphere`` --
+        i.e. ``get_unmixing_matrix(model_idx) @ sphere`` -- and delegates to
+        :func:`pyAMICA.metrics.mir`. MIR is shift-invariant, so the data-space
+        mean/``c`` centering ``transform`` applies is irrelevant here.
+
+        Parameters
+        ----------
+        X : np.ndarray of shape (n_channels, n_samples)
+            Raw (unpreprocessed) data.
+        model_idx : int, default=0
+            Which model's unmixing to use.
+        nbins : int, optional
+            Histogram bin count; see :func:`pyAMICA.metrics.mir`.
+
+        Returns
+        -------
+        mir_nats : float
+        variance : float
+
+        Raises
+        ------
+        RuntimeError
+            If the model is unfitted.
+        ValueError
+            If PCA reduction (``pcakeep``/``pcadb``) is active: it leaves the
+            sphere rank-deficient, so MIR's log-Jacobian term is undefined.
+        """
+        if self.A is None or self.W is None or self.sphere is None:
+            raise RuntimeError(
+                "AMICATorchNG.mir() requires a fitted model; call fit() first."
+            )
+        if self._pca_reduced():
+            raise ValueError(
+                "mir() is incompatible with PCA reduction (pcakeep/pcadb): "
+                "the sphere is rank-deficient, so MIR's log-Jacobian term is "
+                "undefined for the resulting non-square/non-invertible "
+                "unmixing."
+            )
+        unmixing = (self.W[:, :, model_idx].T @ self.sphere).cpu().numpy()
+        return mir_metric(unmixing, X, nbins)
+
+    def pmi(
+        self, X: np.ndarray, *, model_idx: int = 0, nbins: Optional[int] = None
+    ) -> np.ndarray:
+        """Pairwise Mutual Information (issue #137) between this model's sources on ``X``.
+
+        Delegates to :func:`pyAMICA.metrics.pairwise_mi` on
+        ``transform(X, model_idx)``.
+
+        Parameters
+        ----------
+        X : np.ndarray of shape (n_channels, n_samples)
+            Raw (unpreprocessed) data.
+        model_idx : int, default=0
+            Which model's sources to use.
+        nbins : int, optional
+            Histogram bin count; see :func:`pyAMICA.metrics.pairwise_mi`.
+
+        Returns
+        -------
+        mi_matrix : np.ndarray of shape (n_sources, n_sources)
+
+        Raises
+        ------
+        RuntimeError
+            If the model is unfitted (via ``transform``).
+        """
+        return pairwise_mi(self.transform(X, model_idx=model_idx), nbins)
 
     # ------------------------------------------------------------------
     # EEGLAB drop-in output (issue #92)

--- a/pyAMICA/torch_impl/core.py
+++ b/pyAMICA/torch_impl/core.py
@@ -591,7 +591,8 @@ class AMICATorchNG:
         # the iterate fit() actually kept -- use this, not ``ll_history[-1]``, as
         # the model's fitted log-likelihood. Set by fit().
         self.final_ll_: Optional[float] = None
-        # MIR waypoint trajectory (issue #137), populated by fit() when
+        # Mutual Information Reduction (MIR) waypoint trajectory (issue #137),
+        # populated by fit() when
         # mir_step > 0: (iteration, mir_nats, variance) tuples from the
         # CURRENT (mid-fit) W/sphere. Like ll_history, this is a true
         # trajectory that a keep_best restore does NOT rewrite -- the
@@ -1786,8 +1787,28 @@ class AMICATorchNG:
             # writestep/histstep idiom (numpy_impl/core.py). Computed from the
             # CURRENT W/sphere (just rebuilt above by _update_parameters /
             # the share_comps block) against the raw, un-preprocessed X.
+            #
+            # A failed waypoint must never kill the fit. `metrics.mir` raises on
+            # a near-singular unmixing, and a near-singular W mid-fit is a
+            # transient the natural gradient can pass through (the same
+            # condition is only a warning on the training path, see
+            # numpy_impl/core.py's logdet_W check). Letting that propagate would
+            # let a purely diagnostic flag destroy an otherwise-recoverable
+            # decomposition. Warn and record NaN instead: the gap stays visible
+            # in mir_history_ rather than being silently absent, so a plotted
+            # trajectory shows a hole exactly where the transient was.
             if mir_step > 0 and it % mir_step == 0:
-                mir_nats, mir_var = self.mir(X)
+                try:
+                    mir_nats, mir_var = self.mir(X)
+                except (ValueError, np.linalg.LinAlgError) as exc:
+                    logger.warning(
+                        "MIR waypoint failed at iter %d (%s: %s); recording NaN "
+                        "and continuing. The fit itself is unaffected.",
+                        it,
+                        type(exc).__name__,
+                        exc,
+                    )
+                    mir_nats = mir_var = float("nan")
                 self.mir_history_.append((it, mir_nats, mir_var))
 
             # Learning-rate control, ported from Fortran (amica17.f90:1062-1108).


### PR DESCRIPTION
## Summary

Exposes the Phase 1-2 metrics on the model itself, per Scott Makeig's original request: computable at decomposition end, and optionally at specified decomposition waypoints.

- `AMICATorchNG.mir(X, *, model_idx=0, nbins=None) -> (mir_nats, variance)` and `.pmi(X, *, model_idx=0, nbins=None) -> mi_matrix`
- `AMICA.mir` / `AMICA.pmi` delegating through `_check_usable`, so they inherit the #50 degenerate-fit contract for free
- `fit(..., mir_step=0)` waypoint schedule populating `mir_history_` as `(iteration, mir_nats, variance)`

Closes #137
Part of epic #133

## Why this phase matters more than "convenience wiring"

Hand-composing the unmixing is **demonstrably** error-prone. While building Phase 4 I got it wrong, wrote the wrong rule into the verification doc, and a reviewer then escalated a non-bug as critical on that authority. #159 subsequently proved `loadmodout` itself reads `W`/`sbeta`/`rho` in the wrong byte order. A supported accessor removes a whole class of that.

The load-bearing test is `test_mir_composes_unmixing_the_documented_way`, which asserts `model.mir(X)` **exactly** equals `metrics.mir(get_unmixing_matrix(0) @ sphere, X)`. Verified it catches the real mistake: dropping the `.T` (the exact Phase 4 error) makes it fail. Note the numbers, because they explain why this was so easy to get wrong and so hard to spot — correct **42.5486** vs wrong **42.4688**, a 0.2% difference. A plausible number from a wrong matrix. An `allclose` test would sail past it; only exact equality against the documented composition catches it.

## Design notes

- **`mir` needs the full raw-data-to-sources transform**, `W[:, :, m].T @ sphere` (note the transpose), not bare `W`. MIR is shift-invariant, so the `mean`/`c` centering `transform` applies is irrelevant to it. `pmi` needs sources, so it calls `transform` rather than hand-rolling.
- **MIR-only waypoints**, on measured evidence: on the real 32x30504 sample, `mir` costs **20 ms** and `pairwise_mi` **678 ms** (34x), against a CPU fit iteration of ~36-400 ms. PMI on a schedule would dominate the fit, for a quantity that is a final structural diagnostic rather than a convergence signal. MIR over iterations is what actually answers the request. `model.pmi(X)` stays available on demand.
- **PCA guard**: `pcakeep`/`pcadb` leave the sphere rank-deficient, so MIR's `sum(log|eig|)` log-Jacobian is undefined. Both `mir()` and `mir_step>0` raise a clear `ValueError` naming the flags, up front rather than mid-fit, mirroring the existing `share_comps` guard (`torch_impl/core.py:553-561`) which rejects the same flags for the same underlying reason.
- **Waypoint gate follows the repo idiom**: `if mir_step > 0 and it % mir_step == 0`, the same shape as the NumPy backend's `writestep`/`histstep` (`numpy_impl/core.py:1429-1435`). `AMICATorchNG.fit` had no hook mechanism of any kind; no plugin system was invented.
- **`keep_best` (#51) interaction**: `mir_history_` is a true trajectory like `ll_history` and is *not* rewritten by a best-iterate rollback. The fit-end value is `model.mir(X)` (computed from the restored, exported parameters), **not** `mir_history_[-1]` — mirroring the existing `final_ll_` vs `ll_history_[-1]` distinction that exists precisely because of #51. Documented in-code.
- **Not persisted**: `mir_history_` stays out of `state_dict()` (a diagnostic, not a fitted parameter; adding it would need a format-version bump). `format_version` stays 3.
- **Not blocked by #159**: that bug is in the *loaded-fit* path (`loadmodout`). Everything here reads the live model's own `W`/`sphere` and `transform()`, which are correct. A loaded-fit accessor belongs to #159.

## Test plan

Real bundled sample EEG throughout, reusing the existing module-scoped `real_data`/`fitted_ng` fixtures; no synthetic data (`.rules/testing.md`).

- [x] `model.mir(X)` exactly equals the documented composition; `model.pmi(X)` exactly equals `pairwise_mi(model.transform(X))`
- [x] Real fitted unmixing gives `mir > 0` and `mir > mir(identity)`
- [x] `mir`/`pmi` added to the **existing** unfitted-raises and `test_degenerate_fit_refuses_output` lambda lists, rather than parallel new tests
- [x] `mir_step=2` populates `mir_history_` at [0, 2, 4] with finite values; `mir_step=0` leaves it empty and is byte-identical to omitting it; `mir_step<0` raises
- [x] `pcakeep` + `mir()` raises naming `pcakeep`; `pcakeep` + `mir_step>0` raises before fitting
- [x] Suite: **267 passed**, 9 skipped, 1 pre-existing xfail. Exactly +9 vs the 258 baseline, matching the 9 new tests.
- [x] `ruff check`, `ruff format --check`, `ty check` clean; `mkdocs build --strict` passes

No MATLAB gate this phase: MIR is already pinned to the Apache-2.0 `getMIR.m` oracle at 1.7e-15 and PMI to `minfojp` at r=0.9887 (Phase 4). This is wiring over already-verified metrics, and the tests assert the wiring reproduces the free functions exactly, so there is no new numerical claim to gate.