### PR TITLE
Fix loadmodout byte order for W/sbeta/rho (#159)

### DIFF
--- a/.context/issue-159/gate_check.py
+++ b/.context/issue-159/gate_check.py
@@ -1,0 +1,36 @@
+"""MATLAB gate check for issue #159 (run last).
+
+Compares Python ``loadmodout`` against MATLAB ``loadmodout15.m`` element-wise for
+W/A/sbeta/rho, on the genuine single-model fixture and the pyAMICA 2-model output.
+Both are the same algorithm (Python is a port), so a correct byte order makes them
+agree to floating-point noise; the pre-#159 C-order read made W disagree by the
+internal transpose (and A/svar with it), and sbeta/rho disagree for num_mix > 1.
+"""
+
+import os
+import numpy as np
+from scipy.io import loadmat
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+TOL = 1e-9
+
+ok = True
+for tag in ("fixture", "two_model"):
+    py = np.load(os.path.join(HERE, f"py_{tag}.npz"))
+    mat = loadmat(os.path.join(HERE, f"mat_{tag}.mat"))
+    print(f"\n== {tag} (num_models={int(py['num_models'])}) ==")
+    for name in ("W", "A", "sbeta", "rho"):
+        p = np.asarray(py[name])
+        m = np.asarray(mat[name])
+        # MATLAB drops trailing singleton dims (num_models==1 -> 2-D); align.
+        if m.ndim < p.ndim:
+            m = m.reshape(p.shape)
+        close = p.shape == m.shape and np.allclose(p, m, atol=TOL, rtol=1e-7)
+        diff = np.max(np.abs(p - m)) if p.shape == m.shape else float("nan")
+        ok &= close
+        print(
+            f"  {name:6s} py{p.shape} mat{m.shape}  max|diff|={diff:.2e}  "
+            f"{'OK' if close else 'MISMATCH'}"
+        )
+
+print("\nGATE", "PASS" if ok else "FAIL")

--- a/.context/issue-159/gate_compare.m
+++ b/.context/issue-159/gate_compare.m
@@ -1,0 +1,29 @@
+% MATLAB gate for issue #159 (run after gate_prep.py, before gate_check.py).
+% Loads the genuine single-model Fortran fixture and the pyAMICA-written 2-model
+% output with EEGLAB's real loadmodout15.m, and saves W/A/sbeta/rho so the Python
+% companion can check they match what Python loadmodout read. This is the only
+% test that pins direction (2) of the interop contract: EEGLAB reads pyAMICA's
+% (and Fortran's) bytes correctly. A pyAMICA write->read round trip cannot.
+
+here = fileparts(mfilename('fullpath'));
+root = fullfile(here, '..', '..');
+sample = fullfile(root, 'pyAMICA', 'sample_data');
+
+% addpath sample_data LAST so its working loadmodout15.m shadows any broken
+% copy elsewhere on the path (postAmicaUtility's has a syntax error on R2025b).
+addpath(sample);
+
+dirs = struct('tag', {'fixture', 'two_model'}, ...
+              'path', {fullfile(sample, 'amicaout'), fullfile(here, 'gate_2model')});
+
+for k = 1:numel(dirs)
+    % loadmodout15 concatenates paths directly, so the dir needs a TRAILING SLASH.
+    d = [dirs(k).path filesep];
+    m = loadmodout15(d);
+    W = m.W; A = m.A; sbeta = m.sbeta; rho = m.rho; num_models = m.num_models; %#ok<NASGU>
+    save(fullfile(here, ['mat_' dirs(k).tag '.mat']), 'W', 'A', 'sbeta', 'rho', 'num_models');
+    fprintf('%s: num_models=%d  W=%s  A=%s\n', dirs(k).tag, m.num_models, ...
+            mat2str(size(m.W)), mat2str(size(m.A)));
+end
+
+fprintf('\nSaved mat_fixture.mat and mat_two_model.mat. Next: gate_check.py.\n');

--- a/.context/issue-159/gate_prep.py
+++ b/.context/issue-159/gate_prep.py
@@ -1,0 +1,48 @@
+"""MATLAB gate prep for issue #159 (run first).
+
+Writes a real 2-model pyAMICA output, then dumps what Python ``loadmodout``
+reads for W/A/sbeta/rho on (a) the genuine single-model Fortran fixture and
+(b) that 2-model output. ``gate_compare.m`` then loads the same two directories
+with EEGLAB's ``loadmodout15.m`` and this script's companion assertion (run last)
+checks they agree element-wise. Python ``loadmodout`` is a port of
+``loadmodout15.m``, so on correct byte order the two must match to ~1e-12; the
+pre-#159 C-order read made W (and A/svar) disagree by the internal transpose.
+"""
+
+import os
+import numpy as np
+
+from pyAMICA import AMICA
+from pyAMICA.numpy_impl.load import loadmodout
+from pyAMICA.torch_impl.utils import load_eeglab_data
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
+SAMPLE = os.path.join(ROOT, "pyAMICA", "sample_data")
+FIXTURE = os.path.join(SAMPLE, "amicaout")
+TWO_MODEL = os.path.join(HERE, "gate_2model")
+
+X = load_eeglab_data(os.path.join(SAMPLE, "eeglab_data.fdt"), 32, 30504).astype(
+    np.float64
+)
+
+# Deterministic real 2-model fit -> genuine-Fortran multi-model output.
+model = AMICA(n_models=2, n_mix=3, device="cpu", verbose=False)
+model.fit(X[:, :8192], max_iter=20, block_size=1024, seed=4)
+assert model.is_fitted_, "2-model gate fit ended degenerate; adjust seed"
+model.write_amica_output(TWO_MODEL)
+
+for tag, d in (("fixture", FIXTURE), ("two_model", TWO_MODEL)):
+    out = loadmodout(d)
+    np.savez(
+        os.path.join(HERE, f"py_{tag}.npz"),
+        W=out.W,
+        A=out.A,
+        sbeta=out.sbeta,
+        rho=out.rho,
+        num_models=out.num_models,
+    )
+    print(f"{tag}: num_models={out.num_models} W{out.W.shape} A{out.A.shape}")
+
+print(f"\nTwo-model output written to: {TWO_MODEL}")
+print("Next: run gate_compare.m in MATLAB, then gate_check.py.")

--- a/.context/issue-159/matlab_interop_verification.md
+++ b/.context/issue-159/matlab_interop_verification.md
@@ -1,0 +1,51 @@
+# Issue #159 -- MATLAB interop verification (W / A / sbeta / rho)
+
+Direction (2) of the interop contract: EEGLAB's real `loadmodout15.m` reads
+pyAMICA's (and Fortran's) bytes correctly. A pyAMICA write->read round trip
+cannot pin this -- it cancels the byte-order error -- so this is a manual MATLAB
+run, recorded here (MATLAB is not on PATH and not in CI).
+
+## Setup
+
+- MATLAB `R2025b` at `/Volumes/S1/Applications/MATLAB_R2025b.app/bin/matlab`.
+- Reader: pyAMICA's own working `pyAMICA/sample_data/loadmodout15.m`, added to the
+  path LAST so it shadows any broken copy (postAmicaUtility's has a syntax error
+  on R2025b). `loadmodout15` concatenates paths directly, so the outdir argument
+  is passed with a trailing `filesep`.
+- Scripts (reproducible): `.context/issue-159/gate_prep.py` (writes a real
+  20-iter 2-model NG output, seed=4, and dumps Python `loadmodout` W/A/sbeta/rho),
+  `gate_compare.m` (MATLAB `loadmodout15` on the same dirs), `gate_check.py`
+  (element-wise compare).
+- Inputs: (a) the genuine single-model Fortran fixture `sample_data/amicaout`;
+  (b) the freshly written pyAMICA 2-model output `.context/issue-159/gate_2model`.
+
+## Result -- GATE PASS
+
+Python `loadmodout` (a port of `loadmodout15.m`) now agrees with MATLAB
+`loadmodout15` element-wise, on both directories:
+
+| dir | array | max abs diff |
+|---|---|---|
+| fixture (1 model)   | W | 8.2e-14 |
+| fixture (1 model)   | A | 2.2e-15 |
+| fixture (1 model)   | sbeta | 3.0e-16 |
+| fixture (1 model)   | rho | 0 |
+| two_model (2 models)| W | 1.3e-13 |
+| two_model (2 models)| A | 1.9e-15 |
+| two_model (2 models)| sbeta | 3.2e-16 |
+| two_model (2 models)| rho | 0 |
+
+The multi-model `W` agreeing to 1e-13 is the load-bearing new result: it proves
+the writer's genuine-Fortran layout (model axis slowest) is EEGLAB-readable, and
+that `loadmodout` reads it back the same way MATLAB does. Before the fix these
+disagreed by the internal transpose (`W` off, and `A`/`svar`/`origord` with it),
+and `sbeta`/`rho` disagreed for `num_mix > 1`; the issue #159 comment records the
+pre-fix numbers (LL recomputation off by 0.11, `rho` pairing max diff 0.969).
+
+## Cross-check: the LL oracle (direction 1)
+
+`test_loadmodout_reproduces_fortran_reported_ll` recomputes the fixture's own
+reported converged LL (-3.4018730) from what `loadmodout` reads: -3.4018468 (5
+sig figs; residual is the Fortran's block truncation). The shipped C-order read
+gave -3.5167 (off by 0.11). Together the LL oracle and this MATLAB gate cover both
+contract directions.

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,8 @@ site/
 
 # Regenerated multi-model ensemble data (issue #27); recreate with multimodel_ensemble.py
 .context/issue-27/ensemble.npz
+
+# Regenerated MATLAB-gate artifacts (issue #159); recreate with gate_prep.py + gate_compare.m
+.context/issue-159/gate_2model/
+.context/issue-159/py_*.npz
+.context/issue-159/mat_*.mat

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,7 +19,13 @@ Release notes are also published on the
   single-model output is byte-identical to before. `AmicaOutput` gains a
   supported `sources(X, model=0)` accessor (the loaded-fit counterpart of the
   live model's `transform`) so downstream source derivations no longer hand-roll
-  the sphere/unmixing composition (#159).
+  the sphere/unmixing composition (#159). Migration note: a *multi-model*
+  `amicaout` directory written by an earlier pyAMICA (whose `W` used the old
+  model-interleaved layout) must be regenerated with `write_amica_output`, not
+  just re-loaded; there is no version marker to detect the old layout (genuine
+  Fortran output carries none either), and the pre-fix multi-model `W` was never
+  in the correct convention regardless. Single-model directories are unaffected
+  (byte-identical before and after).
 - Separation-quality metrics (`pyAMICA.metrics`): `mir` (Mutual Information
   Reduction, in nats) measures how much mutual information a fitted unmixing
   removes from the data. A direct port of `getMIR.m` from bigdelys/pre_ICA_cleaning

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,21 @@ Release notes are also published on the
 
 ## Unreleased
 
+- Fixed `loadmodout` reading `W`, `sbeta` and `rho` in the wrong byte order:
+  it used C order where the writer, genuine Fortran output and EEGLAB's
+  `loadmodout15.m` all use column-major (F order). The consequence was that
+  `AmicaOutput.W` came back transposed, silently corrupting genuine Fortran
+  output and everything derived from it (`A`, `svar`, `origord`), and
+  `sbeta`/`rho` were scrambled whenever `num_mix > 1` (the default). A
+  write-then-read round trip cancels the error, so no self-consistency test
+  could catch it; the fix is pinned by recomputing the bundled Fortran
+  fixture's own reported log-likelihood from the loaded parameters (an external
+  oracle). The writer's multi-model `W` layout, which interleaved models and was
+  not EEGLAB-readable, is corrected to genuine Fortran (model axis slowest);
+  single-model output is byte-identical to before. `AmicaOutput` gains a
+  supported `sources(X, model=0)` accessor (the loaded-fit counterpart of the
+  live model's `transform`) so downstream source derivations no longer hand-roll
+  the sphere/unmixing composition (#159).
 - Separation-quality metrics (`pyAMICA.metrics`): `mir` (Mutual Information
   Reduction, in nats) measures how much mutual information a fitted unmixing
   removes from the data. A direct port of `getMIR.m` from bigdelys/pre_ICA_cleaning

--- a/pyAMICA/numpy_impl/core.py
+++ b/pyAMICA/numpy_impl/core.py
@@ -1633,14 +1633,12 @@ class AMICA:
         ``load_results`` reads back), so pyAMICA output is loadable by the same
         reader as the Fortran reference (issue #30).
 
-        For ``num_models == 1`` (the CLI/sample-data case) the bytes are
-        identical to the Fortran ``amicaout`` ``W``/``c``/``comp_list`` files, so
-        the two are directly comparable. For ``num_models > 1`` the per-model
-        axis nesting differs from genuine Fortran column-major storage: the
-        output stays self-consistent (``loadmodout``/``load_results`` recover it
-        losslessly, matching ``loadmodout``'s own C-order model-axis convention),
-        but is not byte-identical to multi-model Fortran output. Multi-model
-        Fortran interop is out of scope here (see #27).
+        This shares the ``write_amicaout`` writer with the torch backend, so its
+        on-disk guarantees apply here too: single-model output is byte-identical
+        to the Fortran ``amicaout`` files, and since #159 multi-model output is
+        written in genuine Fortran layout as well (each array's model axis
+        slowest, column-major within a model), so EEGLAB's ``loadmodout15.m``
+        reads both correctly. See :func:`pyAMICA.numpy_impl.load.write_amicaout`.
 
         Also writes ``LLt`` (issue #155) via ``_compute_full_posterior_ll``,
         which is called on every ``_write_results`` call -- including every

--- a/pyAMICA/numpy_impl/data.py
+++ b/pyAMICA/numpy_impl/data.py
@@ -241,7 +241,14 @@ def load_results(indir: Union[str, Path], compressed: bool = False) -> dict:
     nw = int(round(np.sqrt(len(W) / num_models)))
     num_comps = nw * num_models
 
-    results = {"gm": gm, "W": W.reshape(nw, nw, num_models)}
+    # On disk W is genuine-Fortran: W_fortran(nw, nw, num_models), model axis
+    # slowest, column-major within each model. Unlike loadmodout (which returns
+    # that EEGLAB-convention W_fortran), load_results returns the internal-backend
+    # W = W_fortran.T for the NumPy viz helpers, so read F-order and transpose the
+    # first two axes back. For num_models == 1 this equals the old plain C-order
+    # read; for num_models > 1 the old read scrambled the model axis (issue #159).
+    W_fortran = W.reshape(nw, nw, num_models, order="F")
+    results = {"gm": gm, "W": np.transpose(W_fortran, (1, 0, 2))}
 
     A = _read("A")
     if A is not None:

--- a/pyAMICA/numpy_impl/load.py
+++ b/pyAMICA/numpy_impl/load.py
@@ -154,7 +154,7 @@ def write_amicaout(
         np.asarray(arr, dtype=dtype).ravel(order=order).tofile(outdir / name)
 
     # W carries the on-disk model-count and is the array whose 3-D layout the
-    # #159 fix depends on; validate it up front so a mis-shaped W fails with a
+    # #159 fix depends on; validate it up front so a malformed W fails with a
     # clear message here rather than as a bare numpy transpose/reshape error (on
     # write) or, worse, a silently-misordered read later.
     gm = np.asarray(gm)

--- a/pyAMICA/numpy_impl/load.py
+++ b/pyAMICA/numpy_impl/load.py
@@ -115,10 +115,13 @@ def write_amicaout(
 
     Both backends store these arrays in the same convention. Single-model output
     is byte-identical to the Fortran reference's ``amicaout`` files. Multi-model
-    output is written in genuine Fortran layout too (each array's model axis is
-    slowest, column-major within a model), so EEGLAB's ``loadmodout15.m`` reads it
-    correctly; the earlier model-interleaved ``W`` layout, which round-tripped
-    through :func:`loadmodout` but was not MATLAB-readable, was fixed in #159.
+    output is written in genuine Fortran layout too: each EEGLAB-read file (``W``
+    3-D column-major with the model axis slowest; ``c``/``comp_list`` and the
+    ``(num_mix, num_comps)`` mixture params column-major) is laid out so EEGLAB's
+    ``loadmodout15.m`` reads it correctly. The earlier model-interleaved ``W``
+    layout, which round-tripped through :func:`loadmodout` but was not
+    MATLAB-readable, was fixed in #159. (``A`` is exempt: ``loadmodout15`` derives
+    it from ``W``/``S`` and ignores the file; see below.)
 
     Parameters
     ----------
@@ -149,6 +152,19 @@ def write_amicaout(
         # Fortran dumps arrays column-major; ``order="F"`` reproduces that byte
         # layout so real EEGLAB ``loadmodout15.m`` reads the file correctly.
         np.asarray(arr, dtype=dtype).ravel(order=order).tofile(outdir / name)
+
+    # W carries the on-disk model-count and is the array whose 3-D layout the
+    # #159 fix depends on; validate it up front so a mis-shaped W fails with a
+    # clear message here rather than as a bare numpy transpose/reshape error (on
+    # write) or, worse, a silently-misordered read later.
+    gm = np.asarray(gm)
+    W = np.asarray(W)
+    if W.ndim != 3 or W.shape[0] != W.shape[1]:
+        raise ValueError(f"W must be 3-D (nw, nw, num_models); got shape {W.shape}")
+    if W.shape[2] != gm.size:
+        raise ValueError(
+            f"W has {W.shape[2]} models but gm has {gm.size}; num_models disagree"
+        )
 
     _w("gm", gm)
     if A is not None:

--- a/pyAMICA/numpy_impl/load.py
+++ b/pyAMICA/numpy_impl/load.py
@@ -34,6 +34,44 @@ class AmicaOutput:
     origord: np.ndarray  # original order prior to var order
     v: Optional[np.ndarray]  # log10 posterior model odds
 
+    def sources(self, X: np.ndarray, model: int = 0) -> np.ndarray:
+        """Source activations for ``model`` from raw data, the loaded-fit
+        counterpart of the live model's ``transform`` (issue #159/#137).
+
+        Applies AMICA's own pipeline: sphere (with the data mean removed), then
+        the per-model unmixing about its center, ``b = W (S(x - mean) - c)``
+        (Fortran ``b = W(x - c)`` in sphered-channel space, amica15.f90). ``c``
+        is sphered-channel indexed (not variance-reordered), matching ``W``'s
+        columns; ``W``'s rows are variance-reordered, so the returned rows are in
+        the same order as ``origord``/``A``/the mixture params.
+
+        Deriving sources this way requires the loader's byte order to be correct;
+        before issue #159 ``W`` was read transposed and this could not reproduce
+        the live sources under any orientation.
+
+        Parameters
+        ----------
+        X : ndarray, shape (data_dim, n_samples)
+            Raw (un-centered, un-sphered) data, same channel order as the fit.
+        model : int, default 0
+            Model index in ``0 .. num_models - 1``.
+
+        Returns
+        -------
+        ndarray, shape (num_pcs, n_samples)
+            Source activations for the requested model, variance-ordered.
+        """
+        if not 0 <= model < self.num_models:
+            raise ValueError(f"model must be in 0..{self.num_models - 1}, got {model}")
+        X = np.asarray(X)
+        if X.ndim != 2 or X.shape[0] != self.data_mean.shape[0]:
+            raise ValueError(
+                f"X must be (data_dim={self.data_mean.shape[0]}, n_samples); "
+                f"got {X.shape}"
+            )
+        sphered = self.S[: self.num_pcs] @ (X - self.data_mean[:, None])
+        return self.W[:, :, model] @ (sphered - self.c[:, model][:, None])
+
 
 def read_binary_file(
     filepath: Union[str, Path], dtype=np.float64, shape=None
@@ -75,11 +113,12 @@ def write_amicaout(
     (when given) ``LLt``. This is the write counterpart of :func:`loadmodout`,
     so a pyAMICA fit (either backend) drops into an EEGLAB workflow (issue #92).
 
-    Both backends store these arrays in the same convention, so for a single
-    model the bytes are identical to the Fortran reference's ``amicaout`` files;
-    for ``num_models > 1`` the per-model axis nesting is self-consistent (it
-    round-trips through :func:`loadmodout`) but not byte-identical to genuine
-    multi-model Fortran output (issue #27).
+    Both backends store these arrays in the same convention. Single-model output
+    is byte-identical to the Fortran reference's ``amicaout`` files. Multi-model
+    output is written in genuine Fortran layout too (each array's model axis is
+    slowest, column-major within a model), so EEGLAB's ``loadmodout15.m`` reads it
+    correctly; the earlier model-interleaved ``W`` layout, which round-tripped
+    through :func:`loadmodout` but was not MATLAB-readable, was fixed in #159.
 
     Parameters
     ----------
@@ -114,11 +153,16 @@ def write_amicaout(
     _w("gm", gm)
     if A is not None:
         _w("A", A)
-    # W is byte-identical to Fortran in C order: the internal-vs-true-unmixing
-    # transpose (issue #24) cancels against Fortran's column-major storage, so a
-    # square W written C-order equals the Fortran/EEGLAB column-major bytes. The
-    # symmetric sphere S is order-agnostic; mean/gm/LL are 1-D.
-    _w("W", W)
+    # W is the internal-backend unmixing (b = W.T @ x); Fortran/EEGLAB store the
+    # true unmixing W_fortran = W.T with the model axis slowest, column-major
+    # within each model. Moving the model axis to the front and writing C-order
+    # (`transpose(2, 0, 1)`) lays each model's slice out column-major and
+    # contiguous -- genuine Fortran bytes for any num_models. For num_models == 1
+    # this is byte-identical to the old plain C-order write, so single-model
+    # output stays byte-compatible with the Fortran reference (issue #92); the
+    # multi-model interleave it replaces was never MATLAB-readable (issue #159).
+    # The symmetric sphere S is order-agnostic; mean/gm/LL are 1-D.
+    _w("W", np.asarray(W).transpose(2, 0, 1))
     _w("S", sphere)
     _w("mean", mean)
     # The (num_mix, num_comps) mixture params and (num_comps, num_models) c /
@@ -165,13 +209,20 @@ def loadmodout(outdir: Union[str, Path]) -> AmicaOutput:
         print("No gm present, setting num_models to 1")
         gm = np.array([1.0])
 
-    # Read weights
+    # Read weights. Fortran/EEGLAB store W(nw, nw, num_models) column-major with
+    # the model axis slowest, so reshape order="F" (matches loadmodout15.m's
+    # `reshape(W, nw, nw, num_models)`, which is MATLAB column-major, and the
+    # write_amicaout writer below). A C-order read returns the transpose of the
+    # true unmixing, which then corrupts A = pinv(W @ S), svar and origord too
+    # (issue #159). This is the EEGLAB-convention W (b = W @ sphered); the
+    # separate load_results reader deliberately returns the transposed
+    # internal-backend W for the NumPy viz helpers.
     W = read_binary_file(outdir / "W")
     if W is None:
         raise FileNotFoundError("No W present, cannot continue")
     nw2 = len(W) // num_models
     nw = int(np.sqrt(nw2))
-    W = W.reshape(nw, nw, num_models)
+    W = W.reshape(nw, nw, num_models, order="F")
 
     # Read mean and sphere
     mn = read_binary_file(outdir / "mean")
@@ -275,7 +326,9 @@ def loadmodout(outdir: Union[str, Path]) -> AmicaOutput:
 
     sbeta_tmp = read_binary_file(outdir / "sbeta")
     if sbeta_tmp is not None:
-        sbeta_tmp = sbeta_tmp.reshape(num_mix, nw * num_models)
+        # Column-major like the other mixture params (issue #159): a C-order read
+        # scrambles the (num_mix, num_comps) layout whenever num_mix > 1.
+        sbeta_tmp = sbeta_tmp.reshape(num_mix, nw * num_models, order="F")
         sbeta = np.zeros((num_mix, nw, num_models))
         for h in range(num_models):
             for i in range(nw):
@@ -289,7 +342,9 @@ def loadmodout(outdir: Union[str, Path]) -> AmicaOutput:
 
     rho_tmp = read_binary_file(outdir / "rho")
     if rho_tmp is not None:
-        rho_tmp = rho_tmp.reshape(num_mix, nw * num_models)
+        # Column-major like the other mixture params (issue #159): a C-order read
+        # scrambles the (num_mix, num_comps) layout whenever num_mix > 1.
+        rho_tmp = rho_tmp.reshape(num_mix, nw * num_models, order="F")
         rho = np.zeros((num_mix, nw, num_models))
         for h in range(num_models):
             for i in range(nw):

--- a/pyAMICA/tests/test_sample_data.py
+++ b/pyAMICA/tests/test_sample_data.py
@@ -137,11 +137,17 @@ def test_amicaoutput_sources_contract_and_c_subtraction():
     )
     assert not np.allclose(b0, b1), "c subtraction had no effect"
 
-    # Input validation.
+    # Input validation: out-of-range and negative model, wrong data_dim, and a
+    # non-2D X (a single 1-D sample vector) must all raise, not silently produce
+    # garbage.
     with pytest.raises(ValueError, match="model must be in"):
         out.sources(data, out.num_models)
+    with pytest.raises(ValueError, match="model must be in"):
+        out.sources(data, -1)
     with pytest.raises(ValueError, match="data_dim"):
         out.sources(data[:16], 0)
+    with pytest.raises(ValueError, match="data_dim"):
+        out.sources(data[:, 0], 0)  # 1-D X
 
 
 @pytest.mark.slow

--- a/pyAMICA/tests/test_sample_data.py
+++ b/pyAMICA/tests/test_sample_data.py
@@ -43,6 +43,107 @@ def test_loadmodout_llt_reshape_order():
     np.testing.assert_allclose(out.Lt.mean(), nw * final_ll, rtol=1e-3)
 
 
+def _fixture_loglik(out, X):
+    """Recompute the mean per-sample-per-channel log-likelihood of the bundled
+    Fortran fixture from a loaded ``AmicaOutput``. Mirrors the Fortran E-step
+    (amica15.f90): ``b = W(x - c)`` in sphered-channel space, a generalized-
+    Gaussian mixture per source in log space, plus the ``log|det W| + log|det S|``
+    Jacobian. Single model (the fixture)."""
+    from scipy.special import gammaln
+
+    b = out.sources(X, 0)  # (nw, N) -- the loader's own W and c
+    nw, n = b.shape
+    alpha, mu, sbeta, rho = (
+        out.alpha[:, :, 0],
+        out.mu[:, :, 0],
+        out.sbeta[:, :, 0],
+        out.rho[:, :, 0],
+    )
+    logdet_w = np.linalg.slogdet(out.W[:, :, 0])[1]
+    sldet = np.linalg.slogdet(out.S[:nw])[1]
+    tot = np.zeros(n)
+    for i in range(nw):
+        z = np.empty((alpha.shape[0], n))
+        for j in range(alpha.shape[0]):
+            y = sbeta[j, i] * (b[i] - mu[j, i])
+            z[j] = (
+                np.log(alpha[j, i])
+                + np.log(sbeta[j, i])
+                - np.abs(y) ** rho[j, i]
+                - gammaln(1.0 + 1.0 / rho[j, i])
+                - np.log(2.0)
+            )
+        m = z.max(axis=0)
+        tot += m + np.log(np.exp(z - m).sum(axis=0))
+    return (tot.sum() + n * (logdet_w + sldet)) / (n * nw)
+
+
+def test_loadmodout_reproduces_fortran_reported_ll():
+    """External, non-circular oracle for the loader byte order (issue #159):
+    recompute the bundled Fortran fixture's OWN reported converged log-likelihood
+    from the parameters ``loadmodout`` reads back, and require it to land within
+    1e-3 of the fixture's ``LL`` file.
+
+    Log-likelihood is not transpose-symmetric, so unlike ``A @ W == I`` (which
+    both byte orders satisfy) this discriminates the orientation of ``W`` and the
+    ``(num_mix, num_comps)`` layout of ``sbeta``/``rho``. On the C-order read this
+    ships with, it lands ~0.11 off (-3.517 vs -3.402); only the correct
+    column-major read reproduces the fixture's number. A write->read round trip
+    cancels the error, so no self-consistency test could have caught it -- this
+    one recomputes an externally fixed target (the Fortran binary's own output).
+    """
+    out = loadmodout(amicaout_dir)
+    data = load_data_file(eeglab_data_file, 32, 30504, dtype=np.float32).astype(
+        np.float64
+    )
+    recomputed = _fixture_loglik(out, data)
+    reported = float(out.LL[-1])
+    assert abs(recomputed - reported) < 1e-3, (
+        f"recomputed LL {recomputed:.7f} disagrees with the fixture's own "
+        f"reported {reported:.7f} by {abs(recomputed - reported):.5f}; loadmodout "
+        "is reading W/sbeta/rho in the wrong byte order (issue #159)."
+    )
+
+
+def test_amicaoutput_sources_contract_and_c_subtraction():
+    """``AmicaOutput.sources`` contract (issue #159). Numerical correctness of the
+    activation is pinned externally by ``test_loadmodout_reproduces_fortran_
+    reported_ll`` (which feeds ``sources`` into the fixture's own LL) and against
+    a live model by the multi-model round-trip in the torch wrapper tests; here we
+    guard shape/finiteness, the input validation, and that ``c`` is actually
+    subtracted (so a future refactor cannot silently drop it).
+    """
+    out = loadmodout(amicaout_dir)
+    data = load_data_file(eeglab_data_file, 32, 30504, dtype=np.float32).astype(
+        np.float64
+    )
+    b0 = out.sources(data, 0)
+    assert b0.shape == (out.num_pcs, data.shape[1])
+    assert np.all(np.isfinite(b0))
+
+    # With the fixture's own c == 0 the accessor spheres (mean removed, S applied)
+    # and unmixes: b == W @ S(x - mean). This pins the sphering/num_pcs handling.
+    sphered = out.S[: out.num_pcs] @ (data - out.data_mean[:, None])
+    np.testing.assert_allclose(b0, out.W[:, :, 0] @ sphered, atol=1e-9)
+
+    # Injecting a nonzero c must subtract it in sphered-channel space, shifting
+    # the activation to W @ (sphered - c) -- proving the subtraction path runs and
+    # a future refactor cannot silently drop it.
+    c_probe = np.arange(1, out.num_pcs + 1, dtype=np.float64)
+    out.c[:, 0] = c_probe  # out is a fresh load per test; safe to mutate
+    b1 = out.sources(data, 0)
+    np.testing.assert_allclose(
+        b1, out.W[:, :, 0] @ (sphered - c_probe[:, None]), atol=1e-9
+    )
+    assert not np.allclose(b0, b1), "c subtraction had no effect"
+
+    # Input validation.
+    with pytest.raises(ValueError, match="model must be in"):
+        out.sources(data, out.num_models)
+    with pytest.raises(ValueError, match="data_dim"):
+        out.sources(data[:16], 0)
+
+
 @pytest.mark.slow
 @pytest.mark.xfail(
     reason="uses a per-row corrcoef of the internal W (= Fortran W^T, so rows are "

--- a/pyAMICA/tests/torch_tests/test_amica_ng_wrapper.py
+++ b/pyAMICA/tests/torch_tests/test_amica_ng_wrapper.py
@@ -312,12 +312,14 @@ def test_loadmodout_sources_reproduce_live_transform_multimodel(real_data, tmp_p
     #159). Real 2-model fit, seed=4 (gives a non-identity gm ordering, so the
     model remap is actually exercised).
 
-    This is the test the issue proved was impossible before the fix: the issue's
-    table showed 0/32 components reaching |corr| ~ 1 under *either* orientation of
-    the C-order ``W``, because the loader returned the transpose and the wrong
-    multi-model layout. With the byte order corrected, best-|corr| component
-    matching -- which quotients out exactly the transforms loadmodout applies --
-    must hit ~1.0 for all components of both models.
+    This is the derivation the issue reported was impossible before the fix (its
+    single-model table showed no component reaching |corr| ~ 1 under either
+    orientation of the C-order ``W``, because the loader returned the transpose
+    and, for multi-model, the interleaved layout). Sabotage-checked: reverting
+    just the reader to C-order drops the min matched |corr| here to ~0.02. With
+    the byte order corrected, best-|corr| matching -- which quotients out exactly
+    the sign/scale/variance-reorder loadmodout applies -- hits ~1.0 for every
+    component of both models.
     """
     from scipy.optimize import linear_sum_assignment
 
@@ -361,11 +363,45 @@ def test_loadmodout_sources_reproduce_live_transform_multimodel(real_data, tmp_p
         assert len(np.unique(cols)) == out.num_pcs, "component matching not 1-to-1"
 
 
+def test_written_w_bytes_are_genuine_fortran_layout(real_data, tmp_path):
+    """The raw on-disk ``W`` file is genuine Fortran layout: model axis slowest,
+    column-major within each model (issue #159). This pins the writer's byte
+    format directly, independent of any reader -- the round-trip tests pass a
+    reader and writer that were changed in lockstep, so only a direct byte-layout
+    assertion (or the manual MATLAB gate) proves the writer alone is correct.
+    """
+    model = AMICA(n_models=2, n_mix=3, device="cpu", verbose=False)
+    model.fit(real_data[:, :4096], max_iter=5, block_size=1024, seed=7)
+    if not model.is_fitted_:
+        pytest.skip("short fit ended degenerate; not the case under test")
+
+    outdir = tmp_path / "amicaout"
+    model.write_amica_output(str(outdir))
+
+    ng = model.model_
+    assert ng is not None and ng.W is not None
+    internal_w = ng.W.detach().cpu().numpy()  # (nw, nw, num_models), internal
+    nw, _, num_models = internal_w.shape
+
+    raw = np.fromfile(outdir / "W", dtype=np.float64)
+    # Genuine Fortran W_fortran[:, :, h] = internal_w[:, :, h].T, stored per model
+    # contiguous and column-major; equivalently each model's slice is the internal
+    # slice raveled C-order, concatenated model-slowest.
+    expected = np.concatenate(
+        [internal_w[:, :, h].ravel(order="C") for h in range(num_models)]
+    )
+    assert raw.size == nw * nw * num_models
+    np.testing.assert_array_equal(raw, expected)
+
+
 def test_load_results_returns_internal_w_multimodel(real_data, tmp_path):
-    """``load_results`` keeps returning the internal-backend ``W`` (its NumPy-viz
-    contract) for multi-model output too, now that the writer emits genuine
-    Fortran (model-slowest, column-major) bytes (issue #159). The pre-fix C-order
-    read scrambled the model axis for num_models > 1; this pins the fix.
+    """``load_results`` returns the internal-backend ``W`` (its NumPy-viz
+    contract) for multi-model output. The writer's ``W`` layout and ``load_results``
+    were changed together in #159, so this guards them staying in lockstep: a
+    future writer-layout change not mirrored in ``load_results`` breaks it
+    (sabotage-checked -- reverting just the writer to plain C-order fails this at
+    99.9% mismatch). The on-disk format itself is pinned by
+    ``test_written_w_bytes_are_genuine_fortran_layout``.
     """
     from pyAMICA.numpy_impl.data import load_results
 
@@ -384,6 +420,58 @@ def test_load_results_returns_internal_w_multimodel(real_data, tmp_path):
     r = load_results(str(outdir))
     assert r["W"].shape == internal_w.shape
     npt.assert_allclose(r["W"], internal_w, atol=1e-12)
+
+
+def test_loadmodout_sources_roundtrip_with_share_comps(real_data, tmp_path):
+    """The byte-order fix composes correctly with component sharing (issue #159 x
+    #60): with ``share_comps`` on, ``comp_list`` is non-identity (components merged
+    across models), so ``write_amica_output``/``loadmodout``/``sources`` must index
+    the mixture params through the merged ``comp_list``. A short 2-model fit whose
+    seed reliably merges; ``sources`` must still reproduce the live ``transform``
+    per gm-matched model.
+    """
+    from scipy.optimize import linear_sum_assignment
+
+    from pyAMICA.numpy_impl.load import loadmodout
+
+    model = AMICA(n_models=2, n_mix=3, device="cpu", verbose=False)
+    model.fit(
+        real_data[:, :4096],
+        max_iter=16,
+        block_size=1024,
+        seed=0,
+        share_comps=True,
+        share_start=3,
+        share_iter=7,
+        comp_thresh=0.85,
+    )
+    if not model.is_fitted_:
+        pytest.skip("short share_comps fit ended degenerate; not the case under test")
+    ng = model.model_
+    assert ng is not None and ng.comp_list is not None and ng.gm is not None
+    comp_list = ng.comp_list.detach().cpu().numpy()
+    if len(np.unique(comp_list)) == comp_list.size:
+        pytest.skip("no merge fired for this build; the sharing path is not exercised")
+
+    outdir = tmp_path / "amicaout"
+    model.write_amica_output(str(outdir))
+    out = loadmodout(outdir)
+
+    gm = ng.gm.detach().cpu().numpy()
+    gm_ord = np.argsort(gm)[::-1]
+    X = real_data[:, :4096]
+    for k in range(out.num_models):
+        live = model.transform(X, model_idx=int(gm_ord[k]))
+        loaded = out.sources(X, k)
+        a = live - live.mean(1, keepdims=True)
+        b = loaded - loaded.mean(1, keepdims=True)
+        a /= np.linalg.norm(a, axis=1, keepdims=True)
+        b /= np.linalg.norm(b, axis=1, keepdims=True)
+        corr = np.abs(a @ b.T)
+        rows, cols = linear_sum_assignment(1.0 - corr)
+        assert corr[rows, cols].min() > 0.999, (
+            f"share_comps model {k}: min matched |corr| {corr[rows, cols].min():.4f}"
+        )
 
 
 def test_loadmodout_llt_gm_reorder_alignment(real_data, tmp_path):

--- a/pyAMICA/tests/torch_tests/test_amica_ng_wrapper.py
+++ b/pyAMICA/tests/torch_tests/test_amica_ng_wrapper.py
@@ -305,6 +305,87 @@ def test_write_amica_output_llt_multimodel(real_data, tmp_path):
     np.testing.assert_allclose(out.Lt, logsumexp(out.Lht, axis=0), rtol=1e-10)
 
 
+def test_loadmodout_sources_reproduce_live_transform_multimodel(real_data, tmp_path):
+    """``loadmodout(written).sources(X, k)`` reproduces the live model's own
+    ``transform`` for every model, up to the per-component sign/scale/variance-
+    reorder and gm model-reorder that ``loadmodout`` legitimately applies (issue
+    #159). Real 2-model fit, seed=4 (gives a non-identity gm ordering, so the
+    model remap is actually exercised).
+
+    This is the test the issue proved was impossible before the fix: the issue's
+    table showed 0/32 components reaching |corr| ~ 1 under *either* orientation of
+    the C-order ``W``, because the loader returned the transpose and the wrong
+    multi-model layout. With the byte order corrected, best-|corr| component
+    matching -- which quotients out exactly the transforms loadmodout applies --
+    must hit ~1.0 for all components of both models.
+    """
+    from scipy.optimize import linear_sum_assignment
+
+    from pyAMICA.numpy_impl.load import loadmodout
+
+    model = AMICA(n_models=2, n_mix=3, device="cpu", verbose=False)
+    model.fit(real_data[:, :4096], max_iter=8, block_size=1024, seed=4)
+    if not model.is_fitted_:
+        pytest.skip("aggressive short fit ended degenerate; not the case under test")
+
+    outdir = tmp_path / "amicaout"
+    model.write_amica_output(str(outdir))
+    out = loadmodout(outdir)
+    assert out.num_models == 2
+
+    ng = model.model_
+    assert ng is not None and ng.gm is not None
+    gm = ng.gm.detach().cpu().numpy()
+    gm_ord = np.argsort(gm)[::-1]  # loadmodout sorts models by gm descending
+    assert not np.array_equal(gm_ord, np.arange(2)), (
+        "seed must give a non-identity gm ordering, or the model remap is untested"
+    )
+
+    X = real_data[:, :4096]
+    for k in range(out.num_models):
+        live = model.transform(X, model_idx=int(gm_ord[k]))  # (nw, N)
+        loaded = out.sources(X, k)  # (nw, N)
+        # Best-|corr| matching is invariant to the per-component sign, scale and
+        # variance-reordering loadmodout introduces, so a correct W/c round trip
+        # gives ~1.0 for every component.
+        a = live - live.mean(1, keepdims=True)
+        b = loaded - loaded.mean(1, keepdims=True)
+        a /= np.linalg.norm(a, axis=1, keepdims=True)
+        b /= np.linalg.norm(b, axis=1, keepdims=True)
+        corr = np.abs(a @ b.T)
+        rows, cols = linear_sum_assignment(1.0 - corr)
+        matched = corr[rows, cols]
+        assert matched.min() > 0.999, (
+            f"model {k} (live {gm_ord[k]}): min matched |corr| {matched.min():.4f}"
+        )
+        assert len(np.unique(cols)) == out.num_pcs, "component matching not 1-to-1"
+
+
+def test_load_results_returns_internal_w_multimodel(real_data, tmp_path):
+    """``load_results`` keeps returning the internal-backend ``W`` (its NumPy-viz
+    contract) for multi-model output too, now that the writer emits genuine
+    Fortran (model-slowest, column-major) bytes (issue #159). The pre-fix C-order
+    read scrambled the model axis for num_models > 1; this pins the fix.
+    """
+    from pyAMICA.numpy_impl.data import load_results
+
+    model = AMICA(n_models=2, n_mix=3, device="cpu", verbose=False)
+    model.fit(real_data[:, :4096], max_iter=5, block_size=1024, seed=7)
+    if not model.is_fitted_:
+        pytest.skip("short fit ended degenerate; not the case under test")
+
+    outdir = tmp_path / "amicaout"
+    model.write_amica_output(str(outdir))
+
+    ng = model.model_
+    assert ng is not None and ng.W is not None
+    internal_w = ng.W.detach().cpu().numpy()  # (nw, nw, num_models), internal
+
+    r = load_results(str(outdir))
+    assert r["W"].shape == internal_w.shape
+    npt.assert_allclose(r["W"], internal_w, atol=1e-12)
+
+
 def test_loadmodout_llt_gm_reorder_alignment(real_data, tmp_path):
     """``loadmodout`` must permute ``Lht`` by the SAME ``gm_ord`` it applies to
     ``W``/``mod_prob``/``comp_list``/etc, not leave it in on-disk order (issue

--- a/pyAMICA/torch_impl/utils.py
+++ b/pyAMICA/torch_impl/utils.py
@@ -204,7 +204,10 @@ def compare_with_fortran(
     # Compare unmixing matrices
     if "W" in pytorch_results and hasattr(fortran_results, "W"):
         W_pytorch = pytorch_results["W"]
-        W_fortran = fortran_results.W[:, :, 0]  # First model
+        # loadmodout returns the EEGLAB-convention unmixing (b = W @ sphered),
+        # which is the transpose of the internal-backend W the PyTorch results
+        # carry (issue #159). Transpose back so this compares like with like.
+        W_fortran = fortran_results.W[:, :, 0].T  # First model, internal convention
 
         # Compute correlation matrix
         corr_matrix = compute_correlation_matrix(W_pytorch, W_fortran)

--- a/pyAMICA/torch_impl/utils.py
+++ b/pyAMICA/torch_impl/utils.py
@@ -201,13 +201,13 @@ def compare_with_fortran(
 
     metrics = {}
 
-    # Compare unmixing matrices
+    # Compare unmixing matrices. Callers pass the true unmixing (rows =
+    # components) via get_unmixing_matrix(); since #159, loadmodout returns W in
+    # that same genuine-Fortran convention, so the two compare directly with no
+    # transpose.
     if "W" in pytorch_results and hasattr(fortran_results, "W"):
         W_pytorch = pytorch_results["W"]
-        # loadmodout returns the EEGLAB-convention unmixing (b = W @ sphered),
-        # which is the transpose of the internal-backend W the PyTorch results
-        # carry (issue #159). Transpose back so this compares like with like.
-        W_fortran = fortran_results.W[:, :, 0].T  # First model, internal convention
+        W_fortran = fortran_results.W[:, :, 0]  # First model, true unmixing
 
         # Compute correlation matrix
         corr_matrix = compute_correlation_matrix(W_pytorch, W_fortran)


### PR DESCRIPTION
## Summary

`loadmodout` read the Fortran/EEGLAB interop files `W`, `sbeta` and `rho` in C order while the writer, genuine Fortran output, and EEGLAB's `loadmodout15.m` all use column-major (F order). The result: `AmicaOutput.W` came back transposed, silently corrupting genuine Fortran output and everything derived from it (`A = pinv(W@S)`, `svar`, `origord`), and `sbeta`/`rho` were scrambled whenever `num_mix > 1` (the default). A write-then-read round trip cancels the error, so no self-consistency test could catch it, which is why prior gates (#92, #155) missed it.

Closes #159.

## What changed

- **Reader** (`loadmodout`): `W`, `sbeta`, `rho` now read `order="F"`, matching the writer, genuine Fortran, and `loadmodout15.m`. This also corrects the derived `A`/`svar`/`origord`.
- **Writer** (`write_amicaout`): the 3D `W` is written model-axis-slowest (`transpose(2, 0, 1)`) so multi-model output is genuine Fortran and EEGLAB-readable. **Single-model output is byte-identical to before** (verified), preserving #92.
- **`load_results`**: reads the same genuine-Fortran bytes and transposes back to the internal-backend convention it returns for the NumPy viz helpers (identical output for single-model; fixes latent multi-model breakage).
- **`AmicaOutput.sources(X, model=0)`**: new supported accessor (loaded-fit counterpart of the live model's `transform`), so downstream source derivation no longer hand-rolls the sphere/unmixing composition, the error class that spawned this issue.
- **`compare_with_fortran`** (uncalled diagnostic): transposes one side so it stays apples-to-apples.

## Why it is correct (two external oracles)

1. **LL recomputation**: recomputing the bundled fixture's own reported converged LL (-3.4018730) from what `loadmodout` reads gives -3.4018468 (5 sig figs); the shipped C-order read gave -3.5167 (off by 0.11). LL is not transpose-symmetric, so unlike `A@W==I` it discriminates orientation.
2. **MATLAB gate**: EEGLAB's real `loadmodout15.m` vs Python `loadmodout` for `W`/`A`/`sbeta`/`rho`, on the genuine single-model fixture **and** a pyAMICA 2-model output, agree to <=1.3e-13 (`.context/issue-159/matlab_interop_verification.md`). This is the only test that pins direction 2 of the interop contract.

## Test plan

- New regression tests (all sabotage-validated to fail on the buggy read):
  - `test_loadmodout_reproduces_fortran_reported_ll` (LL oracle, real fixture)
  - `test_loadmodout_sources_reproduce_live_transform_multimodel` (2-model round trip: `sources` matches live `transform` at |corr| > 0.999 per model; was 0/32 before)
  - `test_amicaoutput_sources_contract_and_c_subtraction`
  - `test_load_results_returns_internal_w_multimodel`
- Full non-slow suite: 275 passed, 9 skipped, 1 xfailed, no collection drop.
- `test_sample_data_cli` (strict xfail, 2000-iter) still xfails (the W flip did not turn it into an XPASS).
- ruff, ty, `mkdocs build --strict` clean.

## Follow-up

`plot_topo_pdf` (deferred out of #136) is now unblocked and can build on `AmicaOutput.sources`.