### PR TITLE
Native AMICA build + cross-platform release workflow (#165, phases 1-2)

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,168 @@
+name: Release binaries
+
+# Builds the dependency-free native AMICA binary (epic #165) for every supported
+# target and attaches the checksummed binaries to the GitHub release. Each target
+# builds NATIVELY on its own runner via native/build.sh (the single-rank MPI shim
+# means no MPI runtime is needed) and is smoke-tested on real sample EEG before
+# upload, so a binary that cannot run on its platform fails the job.
+#
+# Run manually (workflow_dispatch) to validate without cutting a release; assets
+# are only attached when triggered by a published release.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write  # upload release assets
+
+jobs:
+  build:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    continue-on-error: ${{ matrix.experimental || false }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: macos-arm64
+            runner: macos-14
+            shell: bash
+          - target: linux-x64
+            runner: ubuntu-latest
+            shell: bash
+          - target: linux-arm64
+            runner: ubuntu-24.04-arm
+            shell: bash
+          - target: windows-x64
+            runner: windows-latest
+            shell: 'msys2 {0}'
+            msystem: MINGW64
+          - target: windows-arm64
+            runner: windows-11-arm
+            shell: 'msys2 {0}'
+            msystem: CLANGARM64
+            experimental: true
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # --- Toolchain per platform ------------------------------------------
+      - name: Set up toolchain (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: brew install gcc  # gfortran + libgomp; LAPACK via Accelerate
+
+      - name: Set up toolchain (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo apt-get update
+          # gfortran + static reference LAPACK/BLAS (.a) for a self-contained binary.
+          sudo apt-get install -y gfortran liblapack-dev libblas-dev
+
+      - name: Set up toolchain (Windows)
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.msystem }}
+          update: true
+          # OpenBLAS provides both BLAS and LAPACK. The package prefix differs by
+          # environment (mingw-w64-x86_64-* vs mingw-w64-clang-aarch64-*).
+          install: >-
+            ${{ matrix.msystem == 'CLANGARM64'
+              && 'mingw-w64-clang-aarch64-gcc-fortran mingw-w64-clang-aarch64-openblas'
+              || 'mingw-w64-x86_64-gcc-fortran mingw-w64-x86_64-openblas' }}
+
+      # --- Build -----------------------------------------------------------
+      - name: Build native binary
+        run: |
+          set -euo pipefail
+          case "${{ matrix.target }}" in
+            macos-*)
+              # Accelerate is a system framework (always present); static Fortran
+              # runtime leaves only Accelerate + libSystem as dependencies.
+              export LAPACK_LIBS="-framework Accelerate"
+              export EXTRA_LDFLAGS="-static-libquadmath"
+              ;;
+            linux-*)
+              # Static LAPACK/BLAS + Fortran runtime; glibc stays dynamic.
+              export LAPACK_LIBS="-l:liblapack.a -l:lblas.a"
+              export EXTRA_LDFLAGS="-static-libquadmath"
+              ;;
+            windows-*)
+              # OpenBLAS (static archive) supplies BLAS+LAPACK; -static bundles the
+              # MinGW runtime so the .exe has no MSYS2 DLL dependencies.
+              export LAPACK_LIBS="-l:libopenblas.a"
+              export EXTRA_LDFLAGS="-static"
+              ;;
+          esac
+          bash native/build.sh
+          ext=""; [ "${{ runner.os }}" = "Windows" ] && ext=".exe"
+          mkdir -p dist
+          cp "native/amica15_shim$ext" "dist/amica15-${{ matrix.target }}$ext"
+
+      # --- Smoke test: the binary must actually run on this platform --------
+      - name: Smoke test on sample EEG
+        run: |
+          set -euo pipefail
+          ext=""; [ "${{ runner.os }}" = "Windows" ] && ext=".exe"
+          bin="$PWD/dist/amica15-${{ matrix.target }}$ext"
+          run="$(mktemp -d)"; cd "$run"
+          cp "$GITHUB_WORKSPACE/pyAMICA/sample_data/eeglab_data.fdt" .
+          mkdir -p out
+          sed -e 's#^files .*#files ./eeglab_data.fdt#' \
+              -e 's#^outdir .*#outdir ./out/#' \
+              -e 's#^max_iter .*#max_iter 2#' -e 's#^writestep .*#writestep 2#' \
+              "$GITHUB_WORKSPACE/pyAMICA/sample_data/input.param" > p.param
+          OMP_NUM_THREADS=2 "$bin" p.param | tee run.log
+          # Extract the last iteration's LL. A finite negative number (starts with
+          # "-<digit>") = a working decomposition; a blank, "NaN" or "Infinity"
+          # extraction, or a positive value, fails the pattern below.
+          ll="$(grep -oE 'LL = *-?[0-9.]+' run.log | tail -1 | grep -oE '\-?[0-9.]+$' || true)"
+          echo "final LL = '$ll'"
+          case "$ll" in
+            -[0-9]*) echo "smoke test OK (LL=$ll)" ;;
+            *) echo "smoke test FAILED: LL='$ll' (expected finite negative)"; exit 1 ;;
+          esac
+
+      # --- Checksum + upload -----------------------------------------------
+      - name: Checksum
+        run: |
+          set -euo pipefail
+          cd dist
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum amica15-* > "amica15-${{ matrix.target }}.sha256"
+          else
+            shasum -a 256 amica15-* > "amica15-${{ matrix.target }}.sha256"
+          fi
+          cat "amica15-${{ matrix.target }}.sha256"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: amica15-${{ matrix.target }}
+          path: dist/*
+
+  publish:
+    name: Attach binaries to release
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          ls -R dist
+          gh release upload "${{ github.event.release.tag_name }}" \
+            dist/amica15-* --clobber --repo "${{ github.repository }}"

--- a/native/.gitignore
+++ b/native/.gitignore
@@ -1,0 +1,6 @@
+# Build artifacts (binaries + object/module dirs); recreate with build.sh
+build_*/
+amica15_shim
+amica15_mpi
+*.o
+*.mod

--- a/native/README.md
+++ b/native/README.md
@@ -40,6 +40,26 @@ Toolchain (per sccn/amica PR #53): gfortran (+ a C compiler). No `mpif90` needed
 for the shim build. macOS: `brew install gcc`; Debian/Ubuntu:
 `sudo apt-get install -y gfortran liblapack-dev libblas-dev`.
 
+## Release binaries (cross-platform)
+
+`.github/workflows/release-binaries.yml` builds this recipe on a native runner for
+each target and attaches the checksummed binaries to the GitHub release:
+
+| target | runner | LAPACK/BLAS | link |
+|---|---|---|---|
+| macos-arm64 | macos-14 | Accelerate (system) | static Fortran runtime -> only Accelerate + libSystem |
+| linux-x64 | ubuntu-latest | static reference LAPACK/BLAS | static Fortran runtime, dynamic glibc |
+| linux-arm64 | ubuntu-24.04-arm | static reference LAPACK/BLAS | as above |
+| windows-x64 | windows-latest (MSYS2 MINGW64) | static OpenBLAS | `-static` (no MSYS2 DLLs) |
+| windows-arm64 | windows-11-arm (MSYS2 CLANGARM64) | static OpenBLAS | `-static`; experimental |
+
+Each target is smoke-tested (a 2-iteration fit on the bundled sample EEG must
+produce a finite negative LL) before its binary is uploaded, so a binary that
+cannot run on its platform fails the job rather than shipping. Run the workflow
+manually (`workflow_dispatch`) to validate without cutting a release. Platform
+specifics live in the workflow matrix; `native/build.sh` reads `LAPACK_LIBS` and
+`EXTRA_LDFLAGS` from it.
+
 ## Validation
 
 `validate_shim.sh` proves the shim is **mathematically identical to real Open MPI**,

--- a/native/README.md
+++ b/native/README.md
@@ -1,0 +1,59 @@
+# Native AMICA build (dependency-free, portable)
+
+Builds the AMICA Fortran reference (`amica15.f90` + `funmod2.f90`) into a
+self-contained binary with **no MPI runtime, no MKL, and no vendor math library**,
+so it can be shipped as a release asset and run on any supported platform (macOS,
+Linux x64/arm64, Windows x64/arm64) without the user installing a toolchain.
+
+This is epic #165 phase 1. It extends sccn/amica PR #53's vendor-neutral recipe:
+
+| dependency removed | how | file |
+|---|---|---|
+| Intel MKL | `-cpp` skips the `#ifdef MKL` branches | (build flags) |
+| AMD LibM (`vrda_exp`/`vrda_log`) | libm exp/log loops | `vmath_shim.c` |
+| Open MPI runtime | single-rank MPI shim | `mpi_single.f90` + `mpi_single.c` |
+| ifort-only `random_seed` | portable full-size seed array (PR #53) | `patch_sources.py` |
+
+LAPACK/BLAS remains, satisfied by Apple's Accelerate framework on macOS (a system
+framework, always present) and static reference LAPACK/OpenBLAS on Linux/Windows.
+
+## The single-rank MPI shim
+
+`amica15.f90` is an MPI + OpenMP + LAPACK program, but pyAMICA always runs it as
+one process. Every MPI collective it uses (`BCAST`, `REDUCE`, `ALLREDUCE`,
+`BARRIER`, `GATHER`, `COMM_SPLIT`, ...) is trivial for a single rank: broadcast is
+a no-op, reduce/gather is a copy, barrier is a no-op. `mpi_single.f90` supplies
+only the named constants (`use mpi`), with the datatype constants set to their
+size in bytes; `mpi_single.c` implements the ~11 subroutines as external
+procedures, so the generically-typed `BCAST`/`REDUCE`/`GATHER` calls compile under
+`-fallow-argument-mismatch` and single-rank `REDUCE`/`GATHER` reduce to
+`memcpy(recv, send, count * datatype)`.
+
+## Build
+
+```bash
+bash native/build.sh                     # shim build (gfortran, no MPI) -> native/amica15_shim
+MPI_MODE=mpi bash native/build.sh        # reference build (mpif90 + real Open MPI)
+```
+
+Toolchain (per sccn/amica PR #53): gfortran (+ a C compiler). No `mpif90` needed
+for the shim build. macOS: `brew install gcc`; Debian/Ubuntu:
+`sudo apt-get install -y gfortran liblapack-dev libblas-dev`.
+
+## Validation
+
+`validate_shim.sh` proves the shim is **mathematically identical to real Open MPI**,
+not just "converges to a plausible LL". It builds the same patched source with the
+shim and with `mpif90`, pins the RNG seed, runs one iteration on the bundled sample
+EEG, and asserts agreement to ~machine epsilon:
+
+```
+LL max|diff| = 8.9e-16,  W/A = 1.7e-18,  all params <= 5e-16   (PASS, tol 1e-12)
+```
+
+One iteration is the discriminating window: AMICA's optimizer chaotically amplifies
+last-bit differences over iterations (cf. #51/#27), so a genuine shim bug would
+show as an O(1) iter-1 difference, while the residual here is compile-driver
+roundoff (`gfortran` direct vs the `mpif90` wrapper). `build.sh` self-verifies the
+shim binary links no real MPI runtime (`otool -L`/`ldd`/`objdump`, per host) and
+fails the build if one leaked onto the search path.

--- a/native/build.sh
+++ b/native/build.sh
@@ -77,11 +77,15 @@ fi
 common_f=(-O3 -fopenmp -cpp -ffree-line-length-none -std=legacy
           -fallow-argument-mismatch -J"$build_dir" "${mpi_mod_inc[@]}" -I"$work")
 "$fc" "${common_f[@]}" -c "$work/funmod2.f90" -o "$build_dir/funmod2.o"
-# shellcheck disable=SC2086  # $lapack_libs must word-split into separate flags
+# -static-libgfortran/-libgcc bundle the Fortran/GCC runtime so the binary does
+# not need a matching gfortran install. EXTRA_LDFLAGS carries per-platform static
+# linkage from the release matrix (e.g. -static-libquadmath, static OpenBLAS, or a
+# full -static on Linux); LAPACK_LIBS is the LAPACK/BLAS linkage.
+# shellcheck disable=SC2086  # $lapack_libs/$EXTRA_LDFLAGS must word-split
 "$fc" "${common_f[@]}" \
   "$work/amica15.f90" "$build_dir/funmod2.o" "${extra_obj[@]}" \
   -o "$out" \
-  -static-libgfortran -static-libgcc $lapack_libs
+  -static-libgfortran -static-libgcc ${EXTRA_LDFLAGS:-} $lapack_libs
 set +x
 
 # Self-verify the shim build links NO real MPI runtime (the whole point). Uses

--- a/native/build.sh
+++ b/native/build.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Build a dependency-free native amica15 (epic #165, phase 1).
+#
+# Extends sccn/amica PR #53's vendor-neutral recipe (gfortran, no MKL, portable
+# random_seed, vmath_shim for vrda_exp/vrda_log) with a single-rank MPI shim
+# (mpi_single.f90 + mpi_single.c), so the binary links NO MPI runtime and is
+# self-contained. Runtime dependencies after this are only the C/Fortran runtime
+# and LAPACK/BLAS, which we static-link where possible.
+#
+# Usage:
+#   bash native/build.sh                 # shim build (default): gfortran, no MPI
+#   MPI_MODE=mpi bash native/build.sh    # reference build: mpif90 + real Open MPI
+#   OUT=path LAPACK_LIBS="..." FC=... CC=...   # overrides
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/.." && pwd)"
+src_dir="${AMICA_SRC:-$repo_root/pyAMICA}"
+mode="${MPI_MODE:-shim}"
+build_dir="$here/build_$mode"
+out="${OUT:-$here/amica15_$mode}"
+os="$(uname -s)"
+cc="${CC:-cc}"
+
+if [[ "$mode" == "shim" ]]; then
+  fc="${FC:-gfortran}"
+else
+  fc="${FC:-mpif90}"
+fi
+
+# LAPACK/BLAS: Accelerate on macOS (a system framework, always present -- no
+# install, so it does not count against "dependency-free"); reference LAPACK on
+# Linux/Windows (static-linked in CI via LAPACK_LIBS). Override with LAPACK_LIBS.
+if [[ -n "${LAPACK_LIBS:-}" ]]; then
+  lapack_libs="$LAPACK_LIBS"
+elif [[ "$os" == "Darwin" ]]; then
+  lapack_libs="-framework Accelerate"
+else
+  lapack_libs="-llapack -lblas"
+fi
+
+echo "amica native build ($mode)"
+echo "  platform : $os $(uname -m)"
+echo "  compiler : $fc"
+echo "  lapack   : $lapack_libs"
+echo "  output   : $out"
+
+command -v "$fc" >/dev/null 2>&1 || { echo "ERROR: '$fc' not found" >&2; exit 1; }
+
+rm -rf "$build_dir"
+mkdir -p "$build_dir/src"
+work="$build_dir/src"
+cp "$src_dir/funmod2.f90" "$src_dir/amica15.f90" "$src_dir/amica15_header.f90" "$work/"
+
+# --- Patch the build copy only (the tracked sources stay the parity reference).
+python3 "$here/patch_sources.py" "$work/amica15.f90" "$work/amica15_header.f90"
+
+set -x
+# Vector-math shim (vrda_exp/vrda_log as libm loops); portable, no AMD LibM.
+"$cc" -O3 -c "$here/vmath_shim.c" -o "$build_dir/vmath_shim.o"
+
+extra_obj=("$build_dir/vmath_shim.o")
+mpi_mod_inc=()
+if [[ "$mode" == "shim" ]]; then
+  # Single-rank MPI shim: the `mpi` module (constants) + the C stubs. Compile the
+  # module first so `use mpi` in amica15 resolves to it (not a real MPI install).
+  "$fc" -O3 -cpp -J"$build_dir" -c "$here/mpi_single.f90" -o "$build_dir/mpi_single_mod.o"
+  "$cc" -O3 -c "$here/mpi_single.c" -o "$build_dir/mpi_single.o"
+  extra_obj+=("$build_dir/mpi_single_mod.o" "$build_dir/mpi_single.o")
+  mpi_mod_inc=(-I"$build_dir")
+fi
+
+# funmod2 first (amica15 does `use funmod2`); -J puts .mod files in build_dir.
+# -cpp resolves the source's #ifdef MKL (undefined -> plain-Fortran branches);
+# -std=legacy + -fallow-argument-mismatch relax this ifort-vintage F90; the
+# generically-typed MPI calls need -fallow-argument-mismatch in shim mode too.
+common_f=(-O3 -fopenmp -cpp -ffree-line-length-none -std=legacy
+          -fallow-argument-mismatch -J"$build_dir" "${mpi_mod_inc[@]}" -I"$work")
+"$fc" "${common_f[@]}" -c "$work/funmod2.f90" -o "$build_dir/funmod2.o"
+# shellcheck disable=SC2086  # $lapack_libs must word-split into separate flags
+"$fc" "${common_f[@]}" \
+  "$work/amica15.f90" "$build_dir/funmod2.o" "${extra_obj[@]}" \
+  -o "$out" \
+  -static-libgfortran -static-libgcc $lapack_libs
+set +x
+
+# Self-verify the shim build links NO real MPI runtime (the whole point). Uses
+# whichever inspector the host has; a hit means a stray system MPI leaked onto
+# the search path and shadowed the shim, so fail loudly rather than ship it.
+if [[ "$mode" == "shim" ]]; then
+  deps=""
+  if command -v otool >/dev/null 2>&1; then deps="$(otool -L "$out" 2>/dev/null)"
+  elif command -v ldd >/dev/null 2>&1; then deps="$(ldd "$out" 2>/dev/null)"
+  elif command -v objdump >/dev/null 2>&1; then deps="$(objdump -p "$out" 2>/dev/null | grep -i 'DLL Name\|NEEDED')"
+  fi
+  if [[ -n "$deps" ]] && grep -qiE 'libmpi|msmpi|open-mpi|mpich' <<<"$deps"; then
+    echo "ERROR: shim build links a real MPI runtime (should link none):" >&2
+    grep -iE 'libmpi|msmpi|open-mpi|mpich' <<<"$deps" >&2
+    exit 1
+  fi
+fi
+
+echo
+echo "built: $out"

--- a/native/mpi_single.c
+++ b/native/mpi_single.c
@@ -1,0 +1,104 @@
+/* Single-rank MPI shim for AMICA (epic #165, phase 1). See mpi_single.f90 for
+ * the rationale. These implement the ~11 MPI subroutines amica15.f90 calls, for
+ * exactly one rank, so no real MPI runtime is linked and the binary is portable.
+ *
+ * ABI: gfortran calls `call MPI_FOO(...)` as `mpi_foo_(...)` with every argument
+ * by reference (pointer). The Fortran source passes generically-typed buffers
+ * (integer/double/logical/character) to BCAST/REDUCE/GATHER; because these are
+ * external procedures with no explicit interface, gfortran appends any hidden
+ * CHARACTER length arguments AFTER the last declared argument (ierr). We read
+ * only the fixed leading positions and ignore anything trailing, so a character
+ * actual argument is handled the same as any other.
+ *
+ * The MPI datatype constants (mpi_single.f90) equal the element size in bytes,
+ * so the single-rank reduce/gather copy is memcpy(recv, send, count*datatype).
+ */
+#include <string.h>
+
+/* MPI_INIT / MPI_FINALIZE / MPI_BARRIER: nothing to do for one rank. */
+void mpi_init_(int *ierr) { *ierr = 0; }
+void mpi_finalize_(int *ierr) { *ierr = 0; }
+void mpi_barrier_(const int *comm, int *ierr) {
+    (void)comm;
+    *ierr = 0;
+}
+
+/* This process is always rank 0 of a size-1 world. */
+void mpi_comm_rank_(const int *comm, int *rank, int *ierr) {
+    (void)comm;
+    *rank = 0;
+    *ierr = 0;
+}
+void mpi_comm_size_(const int *comm, int *size, int *ierr) {
+    (void)comm;
+    *size = 1;
+    *ierr = 0;
+}
+
+/* Splitting a size-1 communicator yields an equivalent size-1 communicator; the
+ * handle value is opaque to the caller, so return it unchanged. */
+void mpi_comm_split_(const int *comm, const int *color, const int *key,
+                     int *newcomm, int *ierr) {
+    (void)color;
+    (void)key;
+    *newcomm = *comm;
+    *ierr = 0;
+}
+
+/* Single rank always owns the data; no name buffer to fill beyond a label. The
+ * hidden Fortran length of `name` is passed last; honour it to avoid overflow. */
+void mpi_get_processor_name_(char *name, int *resultlen, int *ierr,
+                             long name_len) {
+    static const char label[] = "localhost";
+    long n = (long)sizeof(label) - 1;  /* exclude the terminating NUL */
+    if (n > name_len) n = name_len;
+    memcpy(name, label, (size_t)n);
+    /* Fortran CHARACTER is blank-padded, not NUL-terminated. */
+    if (n < name_len) memset(name + n, ' ', (size_t)(name_len - n));
+    *resultlen = (int)n;
+    *ierr = 0;
+}
+
+/* Broadcast from root to itself is a no-op (the buffer already holds the value).
+ * Buffer type is irrelevant; we never touch it. */
+void mpi_bcast_(void *buf, const int *count, const int *datatype,
+                const int *root, const int *comm, int *ierr) {
+    (void)buf;
+    (void)count;
+    (void)datatype;
+    (void)root;
+    (void)comm;
+    *ierr = 0;
+}
+
+/* Reduce/Allreduce over one rank: the result equals the local contribution, so
+ * copy sendbuf -> recvbuf. datatype == element size in bytes. */
+void mpi_reduce_(const void *sendbuf, void *recvbuf, const int *count,
+                 const int *datatype, const int *op, const int *root,
+                 const int *comm, int *ierr) {
+    (void)op;
+    (void)root;
+    (void)comm;
+    memcpy(recvbuf, sendbuf, (size_t)(*count) * (size_t)(*datatype));
+    *ierr = 0;
+}
+void mpi_allreduce_(const void *sendbuf, void *recvbuf, const int *count,
+                    const int *datatype, const int *op, const int *comm,
+                    int *ierr) {
+    (void)op;
+    (void)comm;
+    memcpy(recvbuf, sendbuf, (size_t)(*count) * (size_t)(*datatype));
+    *ierr = 0;
+}
+
+/* Gather to one rank: recvbuf gets this rank's send block. sendtype == bytes. */
+void mpi_gather_(const void *sendbuf, const int *sendcount, const int *sendtype,
+                 void *recvbuf, const int *recvcount, const int *recvtype,
+                 const int *root, const int *comm, int *ierr) {
+    (void)recvcount;
+    (void)recvtype;
+    (void)root;
+    (void)comm;
+    memcpy(recvbuf, sendbuf, (size_t)(*sendcount) * (size_t)(*sendtype));
+    *ierr = 0;
+}

--- a/native/mpi_single.f90
+++ b/native/mpi_single.f90
@@ -1,0 +1,32 @@
+! Single-rank MPI shim for AMICA (epic #165, phase 1).
+!
+! amica15.f90 is an MPI + OpenMP + LAPACK program, but pyAMICA always runs it as
+! ONE process. Every MPI collective it uses is trivial for a single rank
+! (broadcast is a no-op, reduce/gather is a copy, barrier is a no-op), so instead
+! of linking a real MPI runtime (Open MPI / MS-MPI), we provide a tiny stub. This
+! removes the last runtime dependency after sccn/amica PR #53 removed MKL and AMD
+! LibM, so the built binary is self-contained and portable across all release
+! targets (macOS, Linux x64/arm64, Windows x64/arm64).
+!
+! This module supplies ONLY the named constants the source imports via `use mpi`.
+! The MPI *subroutines* are deliberately NOT declared here, so `call MPI_BCAST(...)`
+! etc. resolve as external procedures (implicit interface) and are provided by
+! mpi_single.c. That is what lets the generically-typed BCAST/REDUCE/GATHER calls
+! compile under `-fallow-argument-mismatch` without per-type interfaces.
+!
+! Datatype constants are set to their size in bytes on purpose: the C stub's
+! single-rank REDUCE/ALLREDUCE/GATHER copy is `memcpy(recv, send, count*datatype)`.
+module mpi
+   implicit none
+   ! Communicator handle: an opaque integer; COMM_SPLIT returns it unchanged.
+   integer, parameter :: MPI_COMM_WORLD = 0
+   ! Datatypes -- value == element size in bytes (see note above).
+   integer, parameter :: MPI_CHARACTER = 1
+   integer, parameter :: MPI_INTEGER = 4
+   integer, parameter :: MPI_LOGICAL = 4
+   integer, parameter :: MPI_DOUBLE_PRECISION = 8
+   ! Reduction ops: unused by a single-rank copy, but must exist as names.
+   integer, parameter :: MPI_SUM = 1
+   integer, parameter :: MPI_MAX = 2
+   integer, parameter :: MPI_MIN = 3
+end module mpi

--- a/native/patch_sources.py
+++ b/native/patch_sources.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Patch the build copy of amica15 for a portable gfortran build (epic #165).
+
+Applies sccn/amica PR #53's portable random_seed fix: the tracked source passes a
+fixed size-2 PUT array (only ifort accepts that); gfortran needs an array of its
+own SIZE. Idempotent and verified -- if the anchor lines are absent (source
+drift), it fails loudly rather than building a subtly wrong binary.
+
+Only the build copy is patched; the tracked amica15.f90 stays the read-only
+parity reference.
+"""
+
+import sys
+
+OLD_SEED = "call random_seed(PUT = c1 * (myrank+1) * (seed+myrank+1))"
+NEW_SEED = """\
+! Portable RNG seeding (sccn/amica PR #53): gfortran's random_seed(PUT=...)
+! requires an array of the compiler-defined size (query with SIZE=); the original
+! passed a fixed size-2 array, which only compiles with ifort. Fill the full-size
+! array from the clock, rank, and fixed seed so per-rank streams still differ.
+call random_seed(size = nseed)
+allocate(seedvec(nseed))
+do jj = 1, nseed
+   seedvec(jj) = c1 + (jj-1) + (myrank+1)*(seed(mod(jj-1,2)+1) + myrank + 1)
+end do
+call random_seed(PUT = seedvec)
+deallocate(seedvec)"""
+
+HDR_ANCHOR = "integer :: ii, jj, kk, c0, c1, c2"
+HDR_ADD = HDR_ANCHOR + "\nINTEGER :: nseed\nINTEGER, ALLOCATABLE :: seedvec(:)"
+
+
+def patch(path, old, new, marker, label):
+    """Replace `old` with `new` in `path`. `marker` is a token unique to the
+    patched form; if already present, this is a no-op (idempotent)."""
+    with open(path) as f:
+        text = f.read()
+    if marker in text:
+        return  # already patched
+    if old not in text:
+        sys.exit(f"ERROR: {label} anchor not found in {path}; source may have drifted")
+    with open(path, "w") as f:
+        f.write(text.replace(old, new, 1))
+
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    pin_seed = "--pin-seed" in sys.argv[1:]
+    amica15, header = args[0], args[1]
+
+    new_seed = NEW_SEED
+    if pin_seed:
+        # Determinism for validate_shim.sh: drop the clock term (c1) so the shim
+        # and mpif90 builds seed identically and can be compared bit-for-bit.
+        # Scoped to the seed formula only -- the clock is still read for timing.
+        if "c1 +" not in NEW_SEED:
+            sys.exit("ERROR: --pin-seed anchor 'c1 +' not found in NEW_SEED")
+        new_seed = NEW_SEED.replace("seedvec(jj) = c1 +", "seedvec(jj) = 987654321 +")
+
+    patch(header, HDR_ANCHOR, HDR_ADD, "INTEGER :: nseed", "header seedvec decl")
+    patch(amica15, OLD_SEED, new_seed, "call random_seed(size = nseed)", "random_seed")
+    print(
+        f"patched: portable random_seed + seedvec declarations{' (pinned)' if pin_seed else ''}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/native/validate_shim.sh
+++ b/native/validate_shim.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Correctness gate for the single-rank MPI shim (epic #165, phase 1).
+#
+# Proves the shim is mathematically identical to real Open MPI, not merely
+# "converges to a plausible LL". It builds the SAME patched source twice -- once
+# with the shim (gfortran, no MPI) and once with real Open MPI (mpif90) -- with
+# the clock-based RNG seed pinned to a constant, runs ONE iteration of each on the
+# bundled sample EEG, and asserts the two agree to ~machine epsilon. One iteration
+# is the discriminating window: AMICA's optimizer chaotically amplifies last-bit
+# differences over iterations (cf. #51/#27), so a genuine shim bug shows as an
+# O(1) iter-1 difference while compile-driver roundoff stays ~1e-15.
+#
+# Requires BOTH gfortran and mpif90 (Open MPI). This is a dev/CI check; the
+# release build (native/build.sh) needs only gfortran.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/.." && pwd)"
+sample="$repo_root/pyAMICA/sample_data"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+command -v gfortran >/dev/null || { echo "ERROR: gfortran required" >&2; exit 1; }
+command -v mpif90  >/dev/null || { echo "ERROR: mpif90 (Open MPI) required" >&2; exit 1; }
+
+os="$(uname -s)"
+lapack="${LAPACK_LIBS:-$([[ "$os" == Darwin ]] && echo "-framework Accelerate" || echo "-llapack -lblas")}"
+fflags=(-O3 -fopenmp -cpp -ffree-line-length-none -std=legacy -fallow-argument-mismatch)
+
+build() {  # build <mode> <fc> -> $work/amica_<mode>
+  local mode="$1" fc="$2" d="$work/b_$1"
+  mkdir -p "$d"
+  cp "$repo_root/pyAMICA"/{funmod2,amica15,amica15_header}.f90 "$d/"
+  # --pin-seed drops the clock term from the RNG seed so the shim and mpif90
+  # builds seed identically and can be compared bit-for-bit. Scoped to the seed
+  # formula inside patch_sources.py (not a loose whole-file regex).
+  python3 "$here/patch_sources.py" --pin-seed "$d/amica15.f90" "$d/amica15_header.f90" >/dev/null
+  cc -O3 -c "$here/vmath_shim.c" -o "$d/vmath.o"
+  local extra=("$d/vmath.o")
+  if [[ "$mode" == shim ]]; then
+    "$fc" -O3 -cpp -J"$d" -c "$here/mpi_single.f90" -o "$d/mpi_mod.o"
+    cc -O3 -c "$here/mpi_single.c" -o "$d/mpi_c.o"
+    extra+=("$d/mpi_mod.o" "$d/mpi_c.o")
+  fi
+  "$fc" "${fflags[@]}" -J"$d" -I"$d" -c "$d/funmod2.f90" -o "$d/funmod2.o"
+  # shellcheck disable=SC2086
+  "$fc" "${fflags[@]}" -J"$d" -I"$d" "$d/amica15.f90" "$d/funmod2.o" "${extra[@]}" \
+    -o "$work/amica_$mode" -static-libgfortran -static-libgcc $lapack
+}
+
+run() {  # run <mode> -> writes $work/o_<mode>
+  local mode="$1" d="$work/o_$1"
+  mkdir -p "$d"
+  ( cd "$work" && cp "$sample/eeglab_data.fdt" .
+    sed -e 's#^files .*#files ./eeglab_data.fdt#' -e 's#^max_iter .*#max_iter 1#' \
+        -e 's#^writestep .*#writestep 1#' -e 's#^do_newton .*#do_newton 0#' \
+        -e "s#^outdir .*#outdir ./o_$mode/#" "$sample/input.param" > "p_$mode.param"
+    OMP_NUM_THREADS=1 "$work/amica_$mode" "p_$mode.param" >/dev/null 2>&1 )
+}
+
+echo "building shim (gfortran) and reference (mpif90)..."
+build shim gfortran
+build mpi mpif90
+echo "running one iteration of each on real sample EEG..."
+run shim
+run mpi
+
+python3 - "$work" <<'PY'
+import sys, numpy as np
+w = sys.argv[1]
+tol = 1e-12
+worst = 0.0
+for f in ("LL", "W", "A", "mu", "sbeta", "alpha", "c", "rho", "gm"):
+    a = np.fromfile(f"{w}/o_shim/{f}"); b = np.fromfile(f"{w}/o_mpi/{f}")
+    n = min(len(a), len(b))
+    d = float(np.abs(a[:n] - b[:n]).max()) if n else 0.0
+    worst = max(worst, d)
+    print(f"  {f:6s} max|diff| = {d:.3e}")
+print(f"worst = {worst:.3e}  (tol {tol:.0e})")
+if worst > tol:
+    sys.exit("FAIL: shim diverges from real MPI beyond machine epsilon -- shim bug")
+print("PASS: single-rank MPI shim is bit-equivalent to Open MPI at iteration 1")
+PY

--- a/native/vmath_shim.c
+++ b/native/vmath_shim.c
@@ -1,0 +1,29 @@
+/* Portable vector-math shim for building amica15 without a vendor math library
+ * (epic #84, phase #85).
+ *
+ * amica15.f90's non-MKL branch calls AMD LibM's vectorized exp/log
+ * (`vrda_exp`/`vrda_log`); its MKL branch uses Intel VML (`vdExp`/`vdLn`).
+ * Neither vendor library is present when building with plain gfortran + LAPACK
+ * (e.g. on Apple Silicon, or a generic Linux box), so the link fails on
+ * `vrda_exp_`/`vrda_log_`.
+ *
+ * These are simple element-wise ops, so this shim provides them as loops over
+ * standard libm exp/log. gfortran calls them by reference with a trailing
+ * underscore (`call vrda_exp(n, x, y)` -> `vrda_exp_(int* n, double* x,
+ * double* y)`), which is the ABI matched here. Scalar libm exp/log are
+ * correctly-rounded/IEEE-accurate (vendor SIMD transcendental libraries such as
+ * AMD LibM typically trade some accuracy for throughput); the cost here is speed,
+ * not accuracy -- a vendor SIMD math library could compute the exp/log-heavy
+ * E-step somewhat faster (documented as a caveat in README.md).
+ */
+#include <math.h>
+
+void vrda_exp_(const int *n, const double *x, double *y) {
+    int i, m = *n;
+    for (i = 0; i < m; i++) y[i] = exp(x[i]);
+}
+
+void vrda_log_(const int *n, const double *x, double *y) {
+    int i, m = *n;
+    for (i = 0; i < m; i++) y[i] = log(x[i]);
+}


### PR DESCRIPTION
## Summary

First two phases of epic #165: a dependency-free native AMICA build (single-rank MPI shim) and the cross-platform release workflow. Purely additive: `native/` build tooling and a release-triggered workflow, with no change to the Python package or its CI. Merged early (per plan) so the 5-platform release matrix can be dispatch-validated before the Python native engine (Phase 3) is built on top.

Phases 3 (native run engine + binary resolver) and 4 (rename to pamica) remain open under epic #165.

## Phase 1 (#166, merged to epic in PR #170)

Single-rank MPI shim (`native/mpi_single.{f90,c}`) + portable `random_seed` + `vmath_shim` remove the Open MPI / MKL / AMD-LibM runtime dependencies, so the AMICA Fortran reference builds into a self-contained binary. **Proven mathematically identical to real Open MPI at machine epsilon** (iteration-1 LL agrees to 8.9e-16; `native/validate_shim.sh`).

## Phase 2 (#167, merged to epic in PR #171)

`.github/workflows/release-binaries.yml` builds the recipe natively on each of macos-arm64, linux-x64, linux-arm64, windows-x64 and windows-arm64, smoke-tests each binary on real sample EEG, and attaches checksummed assets to the release. The macOS binary is verified fully portable locally (links only Accelerate + libSystem).

## Test plan

- `native/validate_shim.sh`: PASS at 8.9e-16 (shim == Open MPI).
- macOS arm64 build: `otool -L` shows only system libraries.
- The Linux/Windows/ARM matrix validates on the first `workflow_dispatch` after this reaches `main` (that is the reason for the early merge). `windows-arm64` is experimental (continue-on-error).