### PR TITLE
Fix cross-platform release build (Linux/Windows)

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -72,10 +72,12 @@ jobs:
           update: true
           # OpenBLAS provides both BLAS and LAPACK. The package prefix differs by
           # environment (mingw-w64-x86_64-* vs mingw-w64-clang-aarch64-*).
+          # gcc-fortran (gfortran + gcc/cc), openblas (BLAS+LAPACK), python (for
+          # patch_sources.py). Package prefix differs by environment.
           install: >-
             ${{ matrix.msystem == 'CLANGARM64'
-              && 'mingw-w64-clang-aarch64-gcc-fortran mingw-w64-clang-aarch64-openblas'
-              || 'mingw-w64-x86_64-gcc-fortran mingw-w64-x86_64-openblas' }}
+              && 'mingw-w64-clang-aarch64-gcc-fortran mingw-w64-clang-aarch64-openblas mingw-w64-clang-aarch64-python'
+              || 'mingw-w64-x86_64-gcc-fortran mingw-w64-x86_64-openblas mingw-w64-x86_64-python' }}
 
       # --- Build -----------------------------------------------------------
       - name: Build native binary
@@ -90,7 +92,7 @@ jobs:
               ;;
             linux-*)
               # Static LAPACK/BLAS + Fortran runtime; glibc stays dynamic.
-              export LAPACK_LIBS="-l:liblapack.a -l:lblas.a"
+              export LAPACK_LIBS="-l:liblapack.a -l:libblas.a"
               export EXTRA_LDFLAGS="-static-libquadmath"
               ;;
             windows-*)

--- a/native/build.sh
+++ b/native/build.sh
@@ -20,7 +20,10 @@ mode="${MPI_MODE:-shim}"
 build_dir="$here/build_$mode"
 out="${OUT:-$here/amica15_$mode}"
 os="$(uname -s)"
-cc="${CC:-cc}"
+# `cc` is not always present (MSYS2 mingw ships `gcc`, not `cc`); fall back.
+cc="${CC:-$(command -v cc 2>/dev/null || command -v gcc 2>/dev/null || echo cc)}"
+# patch_sources.py needs a Python; MSYS2 mingw calls it `python`, not `python3`.
+python="${PYTHON:-$(command -v python3 2>/dev/null || command -v python 2>/dev/null || echo python3)}"
 
 if [[ "$mode" == "shim" ]]; then
   fc="${FC:-gfortran}"
@@ -53,7 +56,7 @@ work="$build_dir/src"
 cp "$src_dir/funmod2.f90" "$src_dir/amica15.f90" "$src_dir/amica15_header.f90" "$work/"
 
 # --- Patch the build copy only (the tracked sources stay the parity reference).
-python3 "$here/patch_sources.py" "$work/amica15.f90" "$work/amica15_header.f90"
+"$python" "$here/patch_sources.py" "$work/amica15.f90" "$work/amica15_header.f90"
 
 set -x
 # Vector-math shim (vrda_exp/vrda_log as libm loops); portable, no AMD LibM.


### PR DESCRIPTION
## Summary

Fixes the release matrix (#167) so the native binaries actually build on Linux and Windows. Validated by dispatching the workflow on this branch: macos-arm64, linux-x64, linux-arm64 and windows-x64 all build and smoke-test green (4 artifacts uploaded). windows-arm64 remains experimental (no MSYS2 gfortran for CLANGARM64; tracked in #173).

## Fixes

- Linux: `-l:lblas.a` -> `-l:libblas.a` (the `-l:` syntax needs the full archive filename; Ubuntu ships `libblas.a`).
- Windows (MSYS2 MINGW64): `build.sh` used `python3` and `cc`, which the mingw shell does not provide; `build.sh` now falls back to `python`/`gcc`, and the workflow installs `mingw-w64-*-python`.

## Test plan

Dispatched run: 4/5 native targets green, each smoke-tested (2-iteration fit on real sample EEG -> finite negative LL). windows-arm64 fails at toolchain setup only (continue-on-error), tracked in #173.