### PR TITLE
Phase 3: native run engine + binary resolver/installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,16 @@ jobs:
           python-version: "3.12"
           enable-cache: true
       - run: uv sync
+      # Build the dependency-free native binary (epic #165) so the AMICANative
+      # engine's end-to-end tests run for real on Linux (they skip without
+      # PAMICA_NATIVE_BINARY). Static reference LAPACK/BLAS, same as the release.
+      - name: Build native AMICA binary (for engine E2E tests)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gfortran liblapack-dev libblas-dev
+          LAPACK_LIBS="-l:liblapack.a -l:libblas.a" EXTRA_LDFLAGS="-static-libquadmath" \
+            bash native/build.sh
+          echo "PAMICA_NATIVE_BINARY=$PWD/native/amica15_shim" >> "$GITHUB_ENV"
       # Exclude the "slow" parity tests: they invoke the macOS-only Fortran
       # reference binary (pyAMICA/sample_data/amica15mac), which cannot run on
       # the Linux runner. MPS-specific tests self-skip when MPS is absent.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,17 @@ Release notes are also published on the
 
 ## Unreleased
 
+- Native Fortran run engine (`AMICANative`), the fourth backend alongside NumPy,
+  PyTorch and MLX. It runs the AMICA Fortran reference itself and returns an
+  `AmicaOutput` with the usual accessors, so it is the parity oracle the Python
+  backends are checked against. The reference is now built dependency-free (a
+  single-rank MPI shim removes the Open MPI runtime, on top of sccn/amica PR
+  \#53's no-MKL recipe; proven identical to real Open MPI at machine epsilon) and
+  released as a self-contained binary for macOS arm64, Linux x64/arm64 and Windows
+  x64 (Windows arm64 runs the x64 binary via emulation until a native toolchain
+  exists, issue #173). The binary is resolved for the host and downloaded from the
+  release on first use (SHA-256 verified); `python -m pyAMICA.native` installs it
+  explicitly, or set `PAMICA_NATIVE_BINARY` to a local build (epic #165).
 - Fixed `loadmodout` reading `W`, `sbeta` and `rho` in the wrong byte order:
   it used C order where the writer, genuine Fortran output and EEGLAB's
   `loadmodout15.m` all use column-major (F order). The consequence was that

--- a/pyAMICA/__init__.py
+++ b/pyAMICA/__init__.py
@@ -25,10 +25,14 @@ from .viz import plot_model_probability, plot_pmi_heatmap
 # issue #34); AMICA_NumPy is its scikit-learn-style interface.
 from .numpy_impl import AMICA as AMICA_NumPy
 
+# Native Fortran run engine (epic #165): runs the dependency-free reference binary.
+from .native import AMICANative
+
 __all__ = [
     "AMICA",
     "AMICATorchNG",
     "AMICA_NumPy",
+    "AMICANative",
     "metrics",
     "numpy_impl",
     "torch_impl",

--- a/pyAMICA/native/__init__.py
+++ b/pyAMICA/native/__init__.py
@@ -1,0 +1,7 @@
+"""Native Fortran run engine (epic #165): the ``AMICANative`` backend and the
+binary resolver that fetches the right release binary for the host."""
+
+from .engine import AMICANative
+from .resolver import asset_name, platform_tag, resolve
+
+__all__ = ["AMICANative", "asset_name", "platform_tag", "resolve"]

--- a/pyAMICA/native/__main__.py
+++ b/pyAMICA/native/__main__.py
@@ -1,0 +1,41 @@
+"""Install the native AMICA binary for this system (epic #165).
+
+    python -m pyAMICA.native                 # download+cache the latest release binary
+    python -m pyAMICA.native --version v0.2.0 # a specific release
+    python -m pyAMICA.native --print         # just print where it would resolve to
+
+Downloads the release asset matching the host platform, verifies its SHA-256, and
+caches it; prints the resolved path. Idempotent (a cached binary is reused).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from . import resolver
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python -m pyAMICA.native")
+    parser.add_argument(
+        "--version", default="latest", help="release tag (default: latest)"
+    )
+    parser.add_argument(
+        "--print",
+        action="store_true",
+        dest="print_only",
+        help="resolve from override/cache only; do not download",
+    )
+    args = parser.parse_args(argv)
+    try:
+        path = resolver.resolve(args.version, download=not args.print_only)
+    except Exception as exc:  # surface a clear message, not a traceback
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyAMICA/native/engine.py
+++ b/pyAMICA/native/engine.py
@@ -1,0 +1,245 @@
+"""``AMICANative``: run the native AMICA Fortran binary as a pyAMICA backend.
+
+The fourth run engine, alongside the NumPy, PyTorch (``AMICATorchNG``) and MLX
+backends. It writes the data and an ``input.param``, runs the dependency-free
+binary resolved by :mod:`pyAMICA.native.resolver`, and reads the result back
+through :func:`pyAMICA.numpy_impl.load.loadmodout` -- so its output is an
+``AmicaOutput`` with the same accessors (``.sources``, ``.W``, ``.A``, ...) as a
+loaded fit. This is the Fortran reference itself, so it is the parity oracle the
+Python backends are validated against.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Optional, Union
+
+import numpy as np
+
+from ..numpy_impl.load import AmicaOutput, loadmodout
+from . import resolver
+
+# Full default parameter set (mirrors sample_data/input.param) so the engine does
+# not depend on the sample data being installed. ``files``/``outdir``/``data_dim``/
+# ``field_dim`` are set per fit; everything else is a tunable default. Keys are the
+# Fortran param names; friendly aliases are mapped in ``fit``.
+_DEFAULT_PARAMS: dict[str, object] = {
+    "block_size": 512,
+    "do_opt_block": 0,
+    "blk_min": 256,
+    "blk_step": 256,
+    "blk_max": 1024,
+    "num_models": 1,
+    "max_threads": 10,
+    "use_min_dll": 1,
+    "min_dll": 1e-09,
+    "use_grad_norm": 1,
+    "min_grad_norm": 1e-07,
+    "num_mix_comps": 3,
+    "pdftype": 0,
+    "max_iter": 2000,
+    "num_samples": 1,
+    "field_blocksize": 1,
+    "do_history": 0,
+    "histstep": 10,
+    "share_comps": 0,
+    "share_start": 100,
+    "comp_thresh": 0.99,
+    "share_iter": 100,
+    "lrate": 0.05,
+    "minlrate": 1e-08,
+    "mineig": 1e-12,
+    "lratefact": 0.5,
+    "rholrate": 0.05,
+    "rho0": 1.5,
+    "minrho": 1.0,
+    "maxrho": 2.0,
+    "rholratefact": 0.5,
+    "kurt_start": 3,
+    "num_kurt": 5,
+    "kurt_int": 1,
+    "do_newton": 1,
+    "newt_start": 50,
+    "newt_ramp": 10,
+    "newtrate": 1.0,
+    "do_reject": 0,
+    "numrej": 3,
+    "rejsig": 3.0,
+    "rejstart": 2,
+    "rejint": 3,
+    "writestep": 20,
+    "write_nd": 0,
+    "write_LLt": 1,
+    "decwindow": 1,
+    "max_decs": 3,
+    "fix_init": 0,
+    "update_A": 1,
+    "update_c": 1,
+    "update_gm": 1,
+    "update_alpha": 1,
+    "update_mu": 1,
+    "update_beta": 1,
+    "invsigmax": 100.0,
+    "invsigmin": 0.0,
+    "do_rho": 1,
+    "load_rej": 0,
+    "load_W": 0,
+    "load_c": 0,
+    "load_gm": 0,
+    "load_alpha": 0,
+    "load_mu": 0,
+    "load_beta": 0,
+    "load_rho": 0,
+    "load_comp_list": 0,
+    "do_mean": 1,
+    "do_sphere": 1,
+    "doPCA": 1,
+    "pcakeep": 0,
+    "pcadb": 30.0,
+    "byte_size": 4,
+    "doscaling": 1,
+    "scalestep": 1,
+}
+
+# Friendly kwarg -> Fortran param-name aliases (match the Python backends' names).
+_ALIASES = {"n_models": "num_models", "n_mix": "num_mix_comps"}
+
+
+def _render_param(params: dict[str, object]) -> str:
+    return "".join(f"{k} {_fmt(v)}\n" for k, v in params.items())
+
+
+def _fmt(v: object) -> str:
+    if isinstance(v, bool):
+        return str(int(v))
+    if isinstance(v, float):
+        return f"{v:.6e}" if (v != 0 and abs(v) < 1e-3) else f"{v:.6f}"
+    return str(v)
+
+
+class AMICANative:
+    """Run the native AMICA binary on data and expose the result as an
+    ``AmicaOutput``.
+
+    Parameters
+    ----------
+    binary : path-like, optional
+        Explicit binary path; otherwise resolved for the host (downloaded from the
+        release on first use). Equivalent to setting ``PAMICA_NATIVE_BINARY``.
+    version : str, default "latest"
+        Release tag to resolve the binary from when not given explicitly.
+    threads : int, optional
+        ``OMP_NUM_THREADS`` for the run (default: the binary's own default).
+    timeout : float, optional
+        Seconds before the subprocess is killed (default: no timeout).
+    **params
+        Any Fortran ``input.param`` field (or a friendly alias: ``n_models``,
+        ``n_mix``), overriding the defaults; e.g. ``max_iter``, ``lrate``,
+        ``pdftype``, ``do_newton``.
+    """
+
+    def __init__(
+        self,
+        binary: Optional[Union[str, Path]] = None,
+        *,
+        version: str = "latest",
+        threads: Optional[int] = None,
+        timeout: Optional[float] = None,
+        **params: object,
+    ) -> None:
+        self.binary = Path(binary) if binary is not None else None
+        self.version = version
+        self.threads = threads
+        self.timeout = timeout
+        self.params = params
+        self.output_: Optional[AmicaOutput] = None
+
+    def _resolve_binary(self) -> Path:
+        if self.binary is not None:
+            if not self.binary.exists():
+                raise FileNotFoundError(f"binary not found: {self.binary}")
+            return self.binary
+        return resolver.resolve(self.version)
+
+    def fit(self, X: np.ndarray, **params: object) -> "AMICANative":
+        """Run AMICA on ``X`` (shape ``(n_channels, n_samples)``) and store the
+        result as ``self.output_`` (an ``AmicaOutput``)."""
+        X = np.asarray(X)
+        if X.ndim != 2:
+            raise ValueError(f"X must be 2-D (n_channels, n_samples); got {X.shape}")
+        n_channels, n_samples = X.shape
+
+        merged = dict(_DEFAULT_PARAMS)
+        for src in (self.params, params):
+            for key, value in src.items():
+                merged[_ALIASES.get(key, key)] = value
+        merged["data_dim"] = n_channels
+        merged["field_dim"] = n_samples
+        if not merged.get("pcakeep"):
+            merged["pcakeep"] = n_channels  # default: keep all components
+
+        binary = self._resolve_binary()
+
+        with tempfile.TemporaryDirectory(prefix="amica_native_") as td:
+            work = Path(td)
+            # AMICA reads the data as raw byte_size floats in column-major order
+            # (numpy_impl/data.py: reshape order="F"); write it that way.
+            byte_size = merged["byte_size"]
+            dtype = (
+                np.float32
+                if isinstance(byte_size, int) and byte_size == 4
+                else np.float64
+            )
+            X.astype(dtype).ravel(order="F").tofile(work / "data.fdt")
+
+            outdir = work / "amicaout"
+            outdir.mkdir()
+            param = {"files": "./data.fdt", "outdir": "./amicaout/", **merged}
+            (work / "input.param").write_text(_render_param(param))
+
+            env = None
+            if self.threads is not None:
+                import os
+
+                env = {**os.environ, "OMP_NUM_THREADS": str(self.threads)}
+
+            proc = subprocess.run(
+                [str(binary), "input.param"],
+                cwd=work,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                env=env,
+            )
+            if proc.returncode != 0:
+                raise RuntimeError(
+                    f"native AMICA failed (exit {proc.returncode}).\n"
+                    f"stdout tail:\n{proc.stdout[-2000:]}\n"
+                    f"stderr tail:\n{proc.stderr[-2000:]}"
+                )
+            if not (outdir / "W").exists():
+                raise RuntimeError(
+                    "native AMICA produced no output (no 'W' file); stdout tail:\n"
+                    f"{proc.stdout[-2000:]}"
+                )
+            # A collapsed fit writes NaN weights (and zero model probabilities);
+            # loadmodout's pinv(W@S) would then fail with an opaque SVD error, so
+            # detect it here and report it as the degenerate fit it is (cf. the
+            # #50 degenerate-fit contract for the Python backends).
+            if not np.all(np.isfinite(np.fromfile(outdir / "W"))):
+                raise RuntimeError(
+                    "native AMICA produced a degenerate fit (non-finite weights); "
+                    "the run did not converge. Try more iterations, more data, or "
+                    "fewer models."
+                )
+            self.output_ = loadmodout(outdir)
+        return self
+
+    def transform(self, X: np.ndarray, model_idx: int = 0) -> np.ndarray:
+        """Source activations for ``X`` from the fitted model (delegates to
+        ``AmicaOutput.sources``)."""
+        if self.output_ is None:
+            raise RuntimeError("call fit() before transform().")
+        return self.output_.sources(X, model_idx)

--- a/pyAMICA/native/engine.py
+++ b/pyAMICA/native/engine.py
@@ -149,7 +149,9 @@ class AMICANative:
         timeout: Optional[float] = None,
         **params: object,
     ) -> None:
-        self.binary = Path(binary) if binary is not None else None
+        # resolve() now: the subprocess runs with cwd set to a tempdir, so a
+        # relative binary path would pass the existence check but fail to launch.
+        self.binary = Path(binary).resolve() if binary is not None else None
         self.version = version
         self.threads = threads
         self.timeout = timeout
@@ -196,6 +198,8 @@ class AMICANative:
 
             outdir = work / "amicaout"
             outdir.mkdir()
+            # `files` must come first: amica15.f90 hard-stops if it parses other
+            # keys before the data file. Dict insertion order preserves that.
             param = {"files": "./data.fdt", "outdir": "./amicaout/", **merged}
             (work / "input.param").write_text(_render_param(param))
 
@@ -227,8 +231,11 @@ class AMICANative:
             # A collapsed fit writes NaN weights (and zero model probabilities);
             # loadmodout's pinv(W@S) would then fail with an opaque SVD error, so
             # detect it here and report it as the degenerate fit it is (cf. the
-            # #50 degenerate-fit contract for the Python backends).
-            if not np.all(np.isfinite(np.fromfile(outdir / "W"))):
+            # #50 degenerate-fit contract for the Python backends). An empty W
+            # (truncated write) is caught too -- an all-NaN check vacuously passes
+            # on a zero-length array.
+            w_raw = np.fromfile(outdir / "W")
+            if w_raw.size == 0 or not np.all(np.isfinite(w_raw)):
                 raise RuntimeError(
                     "native AMICA produced a degenerate fit (non-finite weights); "
                     "the run did not converge. Try more iterations, more data, or "

--- a/pyAMICA/native/resolver.py
+++ b/pyAMICA/native/resolver.py
@@ -1,0 +1,140 @@
+"""Resolve the native AMICA binary for the host platform (epic #165, phase 3).
+
+The dependency-free binaries built by ``.github/workflows/release-binaries.yml``
+are attached to each GitHub release. This module maps the host to the right asset
+and returns a runnable path, downloading and caching (with a SHA-256 check) on
+first use. Set ``PAMICA_NATIVE_BINARY`` to a local path to bypass all of this
+(used by the tests and for a hand-built binary).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import stat
+import urllib.request
+from pathlib import Path
+
+_REPO = os.environ.get("PAMICA_NATIVE_REPO", "sccn/pyAMICA")
+_ENV_BINARY = "PAMICA_NATIVE_BINARY"
+_ENV_CACHE = "PAMICA_NATIVE_CACHE"
+
+# windows-arm64 has no native binary yet (issue #173); Windows 11 ARM runs the
+# x64 binary via emulation, so it maps there until a native one exists.
+_TAG_ALIAS = {"windows-arm64": "windows-x64"}
+
+
+def platform_tag() -> str:
+    """The release-asset tag for the host, e.g. ``linux-x64``.
+
+    Raises ``RuntimeError`` for a platform no binary is built for (rather than
+    silently returning a tag whose asset does not exist)."""
+    system = platform.system()
+    machine = platform.machine().lower()
+    if system == "Darwin":
+        if machine in ("arm64", "aarch64"):
+            return "macos-arm64"
+        raise RuntimeError(
+            f"No native AMICA binary for macOS/{machine} (only Apple Silicon "
+            "macos-arm64 is built). Build one with native/build.sh, or set "
+            f"{_ENV_BINARY}."
+        )
+    if system == "Linux":
+        if machine in ("x86_64", "amd64"):
+            return "linux-x64"
+        if machine in ("aarch64", "arm64"):
+            return "linux-arm64"
+    if system == "Windows":
+        if machine in ("amd64", "x86_64"):
+            return "windows-x64"
+        if machine in ("arm64", "aarch64"):
+            return "windows-arm64"
+    raise RuntimeError(
+        f"No native AMICA binary for {system}/{machine}. Set {_ENV_BINARY} to a "
+        "locally built binary."
+    )
+
+
+def asset_name(tag: str) -> str:
+    """Release-asset filename for a platform tag (applying the arm64->x64
+    Windows alias and the .exe suffix)."""
+    resolved = _TAG_ALIAS.get(tag, tag)
+    ext = ".exe" if resolved.startswith("windows") else ""
+    return f"amica15-{resolved}{ext}"
+
+
+def _default_cache() -> Path:
+    if env := os.environ.get(_ENV_CACHE):
+        return Path(env)
+    if os.environ.get("XDG_CACHE_HOME"):
+        return Path(os.environ["XDG_CACHE_HOME"]) / "pamica" / "bin"
+    return Path.home() / ".cache" / "pamica" / "bin"
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def verify_checksum(binary: Path, sha256_file: Path) -> None:
+    """Verify ``binary`` against a ``sha256sum``-format file (``<hex>  <name>``).
+    Raises ``ValueError`` on mismatch so a corrupt/tampered download never runs."""
+    expected = sha256_file.read_text().split()[0].lower()
+    actual = _sha256(binary)
+    if actual != expected:
+        raise ValueError(
+            f"SHA-256 mismatch for {binary.name}: expected {expected}, got "
+            f"{actual}. Refusing to use a binary that does not match its checksum."
+        )
+
+
+def _download(url: str, dest: Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".part")
+    with urllib.request.urlopen(url) as r:  # noqa: S310 (fixed github.com host)
+        tmp.write_bytes(r.read())
+    tmp.replace(dest)
+
+
+def resolve(version: str = "latest", *, download: bool = True) -> Path:
+    """Return a runnable path to the native AMICA binary for this host.
+
+    Resolution order: ``PAMICA_NATIVE_BINARY`` env override -> cached download ->
+    fresh download from the ``version`` release (verified against its ``.sha256``
+    asset, then marked executable). ``download=False`` restricts to the override
+    and cache (no network), raising if neither is present.
+    """
+    if override := os.environ.get(_ENV_BINARY):
+        path = Path(override)
+        if not path.exists():
+            raise FileNotFoundError(f"{_ENV_BINARY}={override} does not exist.")
+        return path
+
+    tag = platform_tag()
+    asset = asset_name(tag)
+    cached = _default_cache() / version / asset
+    if cached.exists():
+        return cached
+
+    if not download:
+        raise FileNotFoundError(
+            f"No cached native binary at {cached} and download=False. Cut a "
+            f"release with the binary attached, or set {_ENV_BINARY}."
+        )
+
+    base = (
+        f"https://github.com/{_REPO}/releases/latest/download"
+        if version == "latest"
+        else f"https://github.com/{_REPO}/releases/download/{version}"
+    )
+    _download(f"{base}/{asset}", cached)
+    sha_asset = f"amica15-{_TAG_ALIAS.get(tag, tag)}.sha256"
+    sha_path = cached.with_name(sha_asset)
+    _download(f"{base}/{sha_asset}", sha_path)
+    verify_checksum(cached, sha_path)
+    cached.chmod(cached.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return cached

--- a/pyAMICA/native/resolver.py
+++ b/pyAMICA/native/resolver.py
@@ -13,6 +13,7 @@ import hashlib
 import os
 import platform
 import stat
+import tempfile
 import urllib.request
 from pathlib import Path
 
@@ -93,11 +94,8 @@ def verify_checksum(binary: Path, sha256_file: Path) -> None:
 
 
 def _download(url: str, dest: Path) -> None:
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    tmp = dest.with_suffix(dest.suffix + ".part")
     with urllib.request.urlopen(url) as r:  # noqa: S310 (fixed github.com host)
-        tmp.write_bytes(r.read())
-    tmp.replace(dest)
+        dest.write_bytes(r.read())
 
 
 def resolve(version: str = "latest", *, download: bool = True) -> Path:
@@ -109,14 +107,16 @@ def resolve(version: str = "latest", *, download: bool = True) -> Path:
     and cache (no network), raising if neither is present.
     """
     if override := os.environ.get(_ENV_BINARY):
-        path = Path(override)
+        # resolve() so a relative override still runs under the engine's tempdir cwd.
+        path = Path(override).resolve()
         if not path.exists():
             raise FileNotFoundError(f"{_ENV_BINARY}={override} does not exist.")
         return path
 
     tag = platform_tag()
     asset = asset_name(tag)
-    cached = _default_cache() / version / asset
+    # `version` is used as a path segment; guard against traversal ("../").
+    cached = _default_cache() / Path(version).name / asset
     if cached.exists():
         return cached
 
@@ -131,10 +131,20 @@ def resolve(version: str = "latest", *, download: bool = True) -> Path:
         if version == "latest"
         else f"https://github.com/{_REPO}/releases/download/{version}"
     )
-    _download(f"{base}/{asset}", cached)
     sha_asset = f"amica15-{_TAG_ALIAS.get(tag, tag)}.sha256"
-    sha_path = cached.with_name(sha_asset)
-    _download(f"{base}/{sha_asset}", sha_path)
-    verify_checksum(cached, sha_path)
-    cached.chmod(cached.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    cached.parent.mkdir(parents=True, exist_ok=True)
+    # Download to a private staging dir on the SAME filesystem, verify, mark
+    # executable, then atomically move into place -- so a file only ever exists at
+    # `cached` (the path future calls return unchecked) once it has passed its
+    # SHA-256. A failed download/verify never lands there (no cache poisoning, no
+    # execute-before-verify on Windows), and the atomic rename makes concurrent
+    # cold-cache callers safe.
+    with tempfile.TemporaryDirectory(dir=cached.parent) as td:
+        staged = Path(td) / asset
+        staged_sha = Path(td) / sha_asset
+        _download(f"{base}/{asset}", staged)
+        _download(f"{base}/{sha_asset}", staged_sha)
+        verify_checksum(staged, staged_sha)
+        staged.chmod(staged.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        os.replace(staged, cached)
     return cached

--- a/pyAMICA/tests/test_native_engine.py
+++ b/pyAMICA/tests/test_native_engine.py
@@ -88,6 +88,47 @@ def test_resolve_no_download_without_cache(monkeypatch, tmp_path):
         resolver.resolve(download=False)
 
 
+def _fake_source(monkeypatch, tmp_path, *, content: bytes, good_sha: bool):
+    """Redirect the resolver's downloader to a local 'release' directory, so the
+    staging/verify/atomic-rename path is exercised with real files and no network."""
+    src = tmp_path / "release"
+    src.mkdir(exist_ok=True)
+    (src / "amica15-linux-x64").write_bytes(content)
+    digest = hashlib.sha256(content if good_sha else b"other").hexdigest()
+    (src / "amica15-linux-x64.sha256").write_text(f"{digest}  amica15-linux-x64\n")
+
+    def fake_download(url, dest):
+        dest.write_bytes((src / Path(url).name).read_bytes())
+
+    monkeypatch.setenv("PAMICA_NATIVE_CACHE", str(tmp_path / "cache"))
+    monkeypatch.delenv("PAMICA_NATIVE_BINARY", raising=False)
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    monkeypatch.setattr(resolver, "_download", fake_download)
+
+
+def test_resolve_download_verifies_and_caches(monkeypatch, tmp_path):
+    _fake_source(monkeypatch, tmp_path, content=b"binary-bytes", good_sha=True)
+    path = resolver.resolve("v1")
+    assert path.exists() and path.read_bytes() == b"binary-bytes"
+    assert os.access(path, os.X_OK)  # marked executable only after verifying
+    # second call hits the cache (same path, no re-download needed)
+    assert resolver.resolve("v1") == path
+
+
+def test_resolve_bad_checksum_does_not_poison_cache(monkeypatch, tmp_path):
+    _fake_source(monkeypatch, tmp_path, content=b"tampered", good_sha=False)
+    with pytest.raises(ValueError, match="SHA-256 mismatch"):
+        resolver.resolve("v1")
+    # The unverified binary must NOT have landed at the cache path (else future
+    # calls would return it unchecked -- the security bug this guards).
+    cached = tmp_path / "cache" / "v1" / "amica15-linux-x64"
+    assert not cached.exists()
+    # A subsequent good download still succeeds (cache slot not poisoned).
+    _fake_source(monkeypatch, tmp_path, content=b"good", good_sha=True)
+    assert resolver.resolve("v1").read_bytes() == b"good"
+
+
 # --------------------------------------------------------------------------
 # Engine end-to-end (real binary required)
 # --------------------------------------------------------------------------

--- a/pyAMICA/tests/test_native_engine.py
+++ b/pyAMICA/tests/test_native_engine.py
@@ -1,0 +1,157 @@
+"""Tests for the native Fortran run engine (epic #165, phase 3).
+
+Resolver logic is unit-tested directly; the engine is tested end-to-end against a
+REAL native binary (no mocks) on the bundled sample EEG. The binary path comes
+from ``PAMICA_NATIVE_BINARY`` (set in CI after building via native/build.sh, or
+locally); the E2E tests skip cleanly when it is absent.
+"""
+
+import hashlib
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from pyAMICA import AMICANative
+from pyAMICA.native import resolver
+from pyAMICA.numpy_impl.data import load_data_file
+
+SAMPLE = Path(__file__).resolve().parents[1] / "sample_data"
+DATA = SAMPLE / "eeglab_data.fdt"
+_BINARY = os.environ.get("PAMICA_NATIVE_BINARY")
+
+
+# --------------------------------------------------------------------------
+# Resolver (no binary needed)
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "system,machine,expected",
+    [
+        ("Darwin", "arm64", "macos-arm64"),
+        ("Linux", "x86_64", "linux-x64"),
+        ("Linux", "aarch64", "linux-arm64"),
+        ("Windows", "AMD64", "windows-x64"),
+        ("Windows", "ARM64", "windows-arm64"),
+    ],
+)
+def test_platform_tag(monkeypatch, system, machine, expected):
+    monkeypatch.setattr("platform.system", lambda: system)
+    monkeypatch.setattr("platform.machine", lambda: machine)
+    assert resolver.platform_tag() == expected
+
+
+def test_platform_tag_unsupported_raises(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")  # Intel mac: not built
+    with pytest.raises(RuntimeError, match="macos"):
+        resolver.platform_tag()
+
+
+def test_asset_name_alias_and_extension():
+    # windows-arm64 has no native binary -> resolves to the x64 asset (#173).
+    assert resolver.asset_name("windows-arm64") == "amica15-windows-x64.exe"
+    assert resolver.asset_name("windows-x64") == "amica15-windows-x64.exe"
+    assert resolver.asset_name("linux-arm64") == "amica15-linux-arm64"
+    assert resolver.asset_name("macos-arm64") == "amica15-macos-arm64"
+
+
+def test_verify_checksum(tmp_path):
+    binary = tmp_path / "amica15-linux-x64"
+    binary.write_bytes(b"not really a binary, but real bytes")
+    digest = hashlib.sha256(binary.read_bytes()).hexdigest()
+    sha = tmp_path / "amica15-linux-x64.sha256"
+    sha.write_text(f"{digest}  amica15-linux-x64\n")
+    resolver.verify_checksum(binary, sha)  # passes
+
+    binary.write_bytes(b"tampered")
+    with pytest.raises(ValueError, match="SHA-256 mismatch"):
+        resolver.verify_checksum(binary, sha)
+
+
+def test_resolve_env_override(monkeypatch, tmp_path):
+    fake = tmp_path / "amica"
+    fake.write_bytes(b"x")
+    monkeypatch.setenv("PAMICA_NATIVE_BINARY", str(fake))
+    assert resolver.resolve() == fake
+    monkeypatch.setenv("PAMICA_NATIVE_BINARY", str(tmp_path / "missing"))
+    with pytest.raises(FileNotFoundError):
+        resolver.resolve()
+
+
+def test_resolve_no_download_without_cache(monkeypatch, tmp_path):
+    monkeypatch.delenv("PAMICA_NATIVE_BINARY", raising=False)
+    monkeypatch.setenv("PAMICA_NATIVE_CACHE", str(tmp_path))
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    with pytest.raises(FileNotFoundError, match="download=False"):
+        resolver.resolve(download=False)
+
+
+# --------------------------------------------------------------------------
+# Engine end-to-end (real binary required)
+# --------------------------------------------------------------------------
+requires_binary = pytest.mark.skipif(
+    not _BINARY or not Path(_BINARY).exists(),
+    reason="set PAMICA_NATIVE_BINARY to a built native binary for E2E tests",
+)
+
+
+@pytest.fixture(scope="module")
+def real_data():
+    if not DATA.exists():
+        pytest.skip("sample data missing")
+    return load_data_file(str(DATA), 32, 30504, dtype=np.float32).astype(np.float64)
+
+
+@requires_binary
+def test_native_engine_runs_and_produces_amica_output(real_data):
+    eng = AMICANative(binary=_BINARY, n_models=1, n_mix=3, max_iter=8, threads=2)
+    eng.fit(real_data)
+    out = eng.output_
+    assert out is not None
+    assert out.num_models == 1
+    assert out.W.shape == (32, 32, 1)
+    assert out.A.shape == (32, 32, 1)
+    assert np.all(np.isfinite(out.W))
+    # A working decomposition converges to a finite, negative per-sample LL.
+    assert np.isfinite(out.LL[-1]) and out.LL[-1] < 0
+
+    sources = eng.transform(real_data)
+    assert sources.shape == (32, real_data.shape[1])
+    assert np.all(np.isfinite(sources))
+
+
+@requires_binary
+def test_native_engine_param_aliases_and_multimodel(real_data):
+    # n_models/n_mix aliases reach the Fortran num_models/num_mix_comps. Full data
+    # + enough iterations so the 2-model fit converges (a too-short multi-model run
+    # collapses -- exercised separately below).
+    eng = AMICANative(binary=_BINARY, n_models=2, n_mix=3, max_iter=15, threads=2)
+    eng.fit(real_data)
+    assert eng.output_ is not None
+    assert eng.output_.num_models == 2
+    assert eng.output_.W.shape == (32, 32, 2)
+    assert np.all(np.isfinite(eng.output_.W))
+
+
+@requires_binary
+def test_native_engine_degenerate_fit_raises_clearly(real_data):
+    # A too-short multi-model fit collapses to non-finite weights; the engine must
+    # report that as a degenerate fit, not let loadmodout's pinv raise an opaque
+    # SVD error (cf. the #50 degenerate-fit contract).
+    eng = AMICANative(binary=_BINARY, n_models=2, max_iter=3, threads=2)
+    with pytest.raises(RuntimeError, match="degenerate"):
+        eng.fit(real_data[:, :2048])
+
+
+@requires_binary
+def test_native_engine_rejects_non_2d(real_data):
+    with pytest.raises(ValueError, match="2-D"):
+        AMICANative(binary=_BINARY).fit(real_data[0])
+
+
+def test_native_engine_missing_binary_errors(tmp_path):
+    eng = AMICANative(binary=tmp_path / "nope")
+    with pytest.raises(FileNotFoundError):
+        eng.fit(np.zeros((4, 100)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ Repository = "https://github.com/sccn/pyAMICA"
 [tool.setuptools]
 # List subpackages explicitly so the wheel is deterministic across platforms
 # (a bare ["pyAMICA"] dropped torch_impl/ on some setuptools versions).
-packages = ["pyAMICA", "pyAMICA.numpy_impl", "pyAMICA.torch_impl", "pyAMICA.mlx_impl", "pyAMICA.metrics"]
+packages = ["pyAMICA", "pyAMICA.numpy_impl", "pyAMICA.torch_impl", "pyAMICA.mlx_impl", "pyAMICA.metrics", "pyAMICA.native"]
 # numpy_impl/params.json is the NumPy backend's default parameter file, loaded at
 # runtime via importlib/__file__, so it must ship in the wheel.
 package-data = {"pyAMICA" = ["data/*"], "pyAMICA.numpy_impl" = ["params.json"]}


### PR DESCRIPTION
## Summary

Adds `AMICANative`, the fourth run engine (alongside NumPy, PyTorch, MLX). It runs the dependency-free native binary and returns an `AmicaOutput` with the usual accessors, so it is the parity oracle the Python backends are checked against.

Closes #168. Part of epic #165.

## What's included

- `pyAMICA.native.resolver`: maps the host to its release asset, downloads on first use with SHA-256 verification, caches it, and honors `PAMICA_NATIVE_BINARY`. windows-arm64 -> windows-x64 (emulation, #173). `python -m pyAMICA.native` installs the binary explicitly.
- `pyAMICA.native.AMICANative`: writes the data (`.fdt`, column-major) + a full `input.param` (embedded template, so no dependency on installed sample data), runs the binary, and loads the result via `loadmodout`. Friendly `n_models`/`n_mix` aliases; a collapsed fit is reported as a clear degenerate-fit error instead of an opaque SVD failure (cf. #50).
- Exported as `from pyAMICA import AMICANative`; `pyAMICA.native` added to the wheel packages.
- CI builds the binary on Linux and sets `PAMICA_NATIVE_BINARY`, so the engine's end-to-end tests run for real (not skipped).

## Test plan

- 15 tests: resolver logic (platform tag, asset alias, SHA-256 verify, override, no-download) + real end-to-end engine runs on sample EEG (single- and multi-model, transform, degenerate-fit detection, input validation). No mocks; the E2E tests use a real locally/CI-built binary.
- Full non-slow suite: 292 passed, 1 xfailed, no regressions.