### PR TITLE
Add PyPI publish workflow; display title pAMICA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,75 @@
+name: Publish to PyPI
+
+# Builds the pamica sdist + wheel and uploads them to PyPI when a GitHub release
+# is published. Uploading uses PyPI Trusted Publishing (OIDC): no API token is
+# stored. PyPI is configured to trust this repository, this workflow file
+# (publish.yml), and the `pypi` deployment environment.
+#
+# Release procedure (metadata must be correct in the *tag's* tree, because
+# PyPI publishes the built dist and Zenodo archives the tag on release):
+#   1. python scripts/sync_version.py sync X.Y.Z   # pyproject + CITATION.cff + .zenodo.json
+#   2. commit "Bump version to X.Y.Z", open/merge the bump PR
+#   3. create a GitHub release with tag vX.Y.Z (or X.Y.Z)
+# The build job's `check` step then fails the release if the tag and the three
+# metadata files disagree, before anything is uploaded.
+#
+# workflow_dispatch runs a build-only dry run (the publish job is gated on the
+# release event), so the package can be built and metadata-checked without
+# publishing.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      # On a real release, the tag must match the version declared in
+      # pyproject.toml, CITATION.cff, and .zenodo.json (all kept in lockstep by
+      # scripts/sync_version.py). This gates PyPI + the Zenodo archive + the
+      # citation record on one agreed version.
+      - name: Verify tag matches metadata version
+        if: github.event_name == 'release'
+        run: uv run python scripts/sync_version.py check "${GITHUB_REF_NAME#v}"
+
+      - name: Build distributions
+        run: uv build
+
+      # Fail early on a broken long-description / invalid metadata rather than at
+      # the upload step.
+      - name: Check distribution metadata
+        run: uvx twine check dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pamica
+    permissions:
+      id-token: write  # OIDC token for Trusted Publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ name: Publish to PyPI
 # Release procedure (metadata must be correct in the *tag's* tree, because
 # PyPI publishes the built dist and Zenodo archives the tag on release):
 #   1. python scripts/sync_version.py sync X.Y.Z   # pyproject + CITATION.cff + .zenodo.json
+#      uv lock                                      # refresh uv.lock to the new version
 #   2. commit "Bump version to X.Y.Z", open/merge the bump PR
 #   3. create a GitHub release with tag vX.Y.Z (or X.Y.Z)
 # The build job's `check` step then fails the release if the tag and the three
@@ -56,6 +57,7 @@ jobs:
         with:
           name: dist
           path: dist/*
+          if-no-files-found: error  # an empty dist/ means the build silently produced nothing
 
   publish:
     name: Publish to PyPI

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,8 @@
 {
-  "title": "pamica: a Python implementation of Adaptive Mixture ICA",
+  "title": "pAMICA: a Python implementation of Adaptive Mixture ICA",
   "description": "pamica is a Python (PyTorch) implementation of Adaptive Mixture Independent Component Analysis (AMICA) that reproduces the reference Fortran implementation within numerical tolerance, with CPU, NVIDIA GPU (CUDA), and Apple GPU (MLX) support. It targets EEG/EMG blind source separation and provides a scikit-learn-style interface and byte-identical EEGLAB (loadmodout15) output.",
+  "version": "0.1.2",
+  "publication_date": "2026-07-14",
   "upload_type": "software",
   "access_right": "open",
   "license": "bsd-3-clause",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.3.0
 message: "If you use this software, please cite it using the metadata below."
-title: "pamica: a Python implementation of Adaptive Mixture ICA"
+title: "pAMICA: a Python implementation of Adaptive Mixture ICA"
 abstract: >-
   pamica is a Python (PyTorch) implementation of Adaptive Mixture Independent
   Component Analysis (AMICA) that reproduces the reference Fortran

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# pamica: Adaptive Mixture ICA
+# pAMICA: Adaptive Mixture ICA
 
 [![CI](https://github.com/sccn/pyAMICA/actions/workflows/ci.yml/badge.svg)](https://github.com/sccn/pyAMICA/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/sccn/pyAMICA/branch/main/graph/badge.svg)](https://codecov.io/gh/sccn/pyAMICA)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21312148.svg)](https://doi.org/10.5281/zenodo.21312148)
-[![Docs](https://img.shields.io/badge/docs-eeglab.org%2Fpamica-blue)](https://eeglab.org/pyAMICA/)
+[![Docs](https://img.shields.io/badge/docs-eeglab.org%2FpyAMICA-blue)](https://eeglab.org/pyAMICA/)
 
 Python (PyTorch) implementation of Adaptive Mixture Independent Component Analysis
 (AMICA) that reproduces the reference Fortran implementation within numerical

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,14 @@ Release notes are also published on the
 
 ## Unreleased
 
+- Packaging and release: a PyPI publish workflow (`publish.yml`) uploads the
+  `pamica` sdist and wheel via Trusted Publishing (OIDC) when a GitHub release
+  is published, and `scripts/sync_version.py` keeps the release version in step
+  across `pyproject.toml`, `CITATION.cff` and `.zenodo.json` (the publish job
+  fails a release whose tag disagrees with them). The display title is now
+  **pAMICA**; the package, import and `pip install pamica` stay lowercase
+  `pamica` (pip name matching is case-insensitive, so `pip install pAmica`
+  resolves to the same project) (#177).
 - Native Fortran run engine (`AMICANative`), the fourth backend alongside NumPy,
   PyTorch and MLX. It runs the AMICA Fortran reference itself and returns an
   `AmicaOutput` with the usual accessors, so it is the parity oracle the Python

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# pamica
+# pAMICA
 
 Python (PyTorch) implementation of **Adaptive Mixture Independent Component
 Analysis (AMICA)** that reproduces the results of the reference Fortran binary,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,10 @@
-# pamica documentation (MkDocs Material).
+# pAMICA documentation (MkDocs Material).
 # Deployed to GitHub Pages by .github/workflows/docs.yml. The repo lives at
 # github.com/sccn/pyAMICA, whose project Pages inherit the sccn org Pages custom
-# domain (eeglab.org) at the /pamica subpath, so the site is served at
+# domain (eeglab.org) at the /pyAMICA subpath, so the site is served at
 # https://eeglab.org/pyAMICA/. Links are relative so the build is location-independent.
 
-site_name: pamica Documentation
+site_name: pAMICA Documentation
 site_url: https://eeglab.org/pyAMICA/
 site_description: Python (PyTorch) implementation of Adaptive Mixture ICA (AMICA) with Fortran parity and GPU/MPS/CPU support.
 site_author: Seyed Yahya Shirazi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pamica"
 version = "0.1.2"
-description = "pamica: Python implementation of the Adaptive Mixture ICA algorithm"
+description = "pAMICA: Python implementation of the Adaptive Mixture ICA algorithm"
 readme = "README.md"
 authors = [
     {name = "Seyed Yahya Shirazi", email = "shirazi@ieee.org"},

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -16,7 +16,8 @@ Two modes:
     python scripts/sync_version.py sync 0.1.3 --date 2026-08-01
     python scripts/sync_version.py check 0.1.3           # verifies, exit 1 on drift
 
-``sync`` is the release-prep step (run it, commit "Bump version to X.Y.Z", tag).
+``sync`` is the release-prep step: run it, then ``uv lock`` (so ``uv.lock``
+tracks the new version), commit "Bump version to X.Y.Z", and tag.
 ``check`` is the release gate that ``publish.yml`` runs against the release tag,
 so a mistagged or half-bumped release fails before anything reaches PyPI.
 
@@ -63,31 +64,65 @@ def read_versions() -> dict[str, str]:
     }
 
 
+def _sub_once(text: str, pattern: str, repl: str, *, where: str) -> str:
+    """Substitute exactly one match, raising if the pattern is absent.
+
+    ``re.sub`` returns the input unchanged (no error) when nothing matches, which
+    would let ``sync`` write a file back untouched while reporting success -- a
+    silent no-op if a file's formatting ever drifts from what the pattern expects.
+    Raising instead turns that drift into a loud, actionable failure.
+    """
+    new, n = re.subn(pattern, repl, text, count=1)
+    if n == 0:
+        raise ValueError(f"{where}: no line matched {pattern!r}; nothing written")
+    return new
+
+
 def sync(version: str, released: str) -> None:
-    pyproject = re.sub(
-        r'(?m)^version = "[^"]*"',
-        f'version = "{version}"',
-        PYPROJECT.read_text(),
-        count=1,
+    PYPROJECT.write_text(
+        _sub_once(
+            PYPROJECT.read_text(),
+            r'(?m)^version = "[^"]*"',
+            f'version = "{version}"',
+            where="pyproject.toml version",
+        )
     )
-    PYPROJECT.write_text(pyproject)
 
     citation = CITATION.read_text()
-    citation = re.sub(r"(?m)^version:.*$", f"version: {version}", citation, count=1)
-    citation = re.sub(
-        r"(?m)^date-released:.*$", f'date-released: "{released}"', citation, count=1
+    citation = _sub_once(
+        citation,
+        r"(?m)^version:.*$",
+        f"version: {version}",
+        where="CITATION.cff version",
+    )
+    citation = _sub_once(
+        citation,
+        r"(?m)^date-released:.*$",
+        f'date-released: "{released}"',
+        where="CITATION.cff date-released",
     )
     CITATION.write_text(citation)
 
     zenodo = ZENODO.read_text()
-    zenodo = re.sub(r'"version": "[^"]*"', f'"version": "{version}"', zenodo, count=1)
-    zenodo = re.sub(
+    zenodo = _sub_once(
+        zenodo,
+        r'"version": "[^"]*"',
+        f'"version": "{version}"',
+        where=".zenodo.json version",
+    )
+    zenodo = _sub_once(
+        zenodo,
         r'"publication_date": "[^"]*"',
         f'"publication_date": "{released}"',
-        zenodo,
-        count=1,
+        where=".zenodo.json publication_date",
     )
     ZENODO.write_text(zenodo)
+
+    # Belt-and-suspenders: never report success while a file is still out of sync
+    # (e.g. a substitution that matched an unexpected line and wrote a wrong value).
+    drift = {name: got for name, got in read_versions().items() if got != version}
+    if drift:
+        raise RuntimeError(f"sync wrote the files but they still disagree: {drift}")
 
     print(f"Set version {version} (released {released}) in all three metadata files.")
 

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -1,0 +1,138 @@
+"""Keep the release version consistent across the three metadata files.
+
+A pamica release version lives in three places that must agree, because each is
+consumed by a different tool at release time:
+
+- ``pyproject.toml``  -> the wheel/sdist that ``publish.yml`` uploads to PyPI.
+- ``CITATION.cff``    -> the citation record (``version`` + ``date-released``).
+- ``.zenodo.json``    -> the Zenodo archive metadata (``version`` +
+  ``publication_date``); Zenodo reads it from the *tag's* tree when the GitHub
+  release is published, so it must be correct **before** tagging, not committed
+  afterward.
+
+Two modes:
+
+    python scripts/sync_version.py sync 0.1.3            # writes all three
+    python scripts/sync_version.py sync 0.1.3 --date 2026-08-01
+    python scripts/sync_version.py check 0.1.3           # verifies, exit 1 on drift
+
+``sync`` is the release-prep step (run it, commit "Bump version to X.Y.Z", tag).
+``check`` is the release gate that ``publish.yml`` runs against the release tag,
+so a mistagged or half-bumped release fails before anything reaches PyPI.
+
+Only string-level substitutions are used so the files' formatting, key order,
+and comments are preserved untouched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = ROOT / "pyproject.toml"
+CITATION = ROOT / "CITATION.cff"
+ZENODO = ROOT / ".zenodo.json"
+
+_SEMVER = re.compile(r"^\d+\.\d+\.\d+([.\-+][0-9A-Za-z.\-+]+)?$")
+_ISO_DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def read_versions() -> dict[str, str]:
+    """Return the version string currently declared in each metadata file."""
+    pyproject = tomllib.loads(PYPROJECT.read_text())["project"]["version"]
+
+    m = re.search(r"(?m)^version:\s*(.+?)\s*$", CITATION.read_text())
+    if m is None:
+        raise ValueError("CITATION.cff has no top-level 'version:' key")
+    citation = m.group(1).strip().strip('"')
+
+    zenodo = json.loads(ZENODO.read_text()).get("version")
+    if zenodo is None:
+        raise ValueError(".zenodo.json has no 'version' key")
+
+    return {
+        "pyproject.toml": pyproject,
+        "CITATION.cff": citation,
+        ".zenodo.json": zenodo,
+    }
+
+
+def sync(version: str, released: str) -> None:
+    pyproject = re.sub(
+        r'(?m)^version = "[^"]*"',
+        f'version = "{version}"',
+        PYPROJECT.read_text(),
+        count=1,
+    )
+    PYPROJECT.write_text(pyproject)
+
+    citation = CITATION.read_text()
+    citation = re.sub(r"(?m)^version:.*$", f"version: {version}", citation, count=1)
+    citation = re.sub(
+        r"(?m)^date-released:.*$", f'date-released: "{released}"', citation, count=1
+    )
+    CITATION.write_text(citation)
+
+    zenodo = ZENODO.read_text()
+    zenodo = re.sub(r'"version": "[^"]*"', f'"version": "{version}"', zenodo, count=1)
+    zenodo = re.sub(
+        r'"publication_date": "[^"]*"',
+        f'"publication_date": "{released}"',
+        zenodo,
+        count=1,
+    )
+    ZENODO.write_text(zenodo)
+
+    print(f"Set version {version} (released {released}) in all three metadata files.")
+
+
+def check(version: str) -> int:
+    versions = read_versions()
+    drift = {name: got for name, got in versions.items() if got != version}
+    if drift:
+        print(f"Version mismatch (expected {version}):", file=sys.stderr)
+        for name, got in versions.items():
+            mark = "!=" if name in drift else "=="
+            print(f"  {name}: {got} {mark} {version}", file=sys.stderr)
+        return 1
+    print(f"All metadata files agree on version {version}.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="mode", required=True)
+
+    p_sync = sub.add_parser("sync", help="write the version into all three files")
+    p_sync.add_argument("version", help="release version, e.g. 0.1.3")
+    p_sync.add_argument(
+        "--date",
+        default=date.today().isoformat(),
+        help="release date (ISO YYYY-MM-DD); defaults to today",
+    )
+
+    p_check = sub.add_parser("check", help="verify all three files match the version")
+    p_check.add_argument("version", help="expected version, e.g. 0.1.3")
+
+    args = parser.parse_args()
+    version = args.version.removeprefix("v")
+
+    if not _SEMVER.match(version):
+        parser.error(f"'{version}' is not a MAJOR.MINOR.PATCH version")
+
+    if args.mode == "sync":
+        if not _ISO_DATE.match(args.date):
+            parser.error(f"--date '{args.date}' is not ISO YYYY-MM-DD")
+        sync(version, args.date)
+        return 0
+    return check(version)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the PyPI publish workflow and applies the light-touch display-title split (title reads **pAMICA**; package/import/`pip install pamica` stay lowercase `pamica`).

**Publish workflow** (`.github/workflows/publish.yml`): on a published GitHub release, `uv build` -> `pypa/gh-action-pypi-publish` uploads the sdist and wheel to PyPI via Trusted Publishing (OIDC, no stored token), using the `pypi` deployment environment. `workflow_dispatch` is a build-only dry run. The build job runs `twine check` and, on a release, gates on the tag matching the metadata version.

**Version-sync tool** (`scripts/sync_version.py`): one command keeps the release version consistent across `pyproject.toml`, `CITATION.cff` (`version` + `date-released`) and `.zenodo.json` (`version` + `publication_date`). `sync X.Y.Z` writes all three (release-prep); `check X.Y.Z` verifies them (the publish gate). Zenodo archives the tag's tree on release, so the metadata must be correct before tagging; this enforces that. `.zenodo.json` gains explicit `version`/`publication_date` fields.

**Display title** -> pAMICA in the visible titles only: README H1, docs landing H1, MkDocs `site_name`, PyPI summary, and the CITATION/Zenodo record titles. Body prose and all code identifiers stay `pamica`.

**Rename-artifact fixes:** the README docs badge label and an mkdocs comment read `/pamica` but link to `/pyAMICA`; both corrected to match the actual docs URL.

## Test plan

- [x] `ruff check` / `ruff format --check` / `ty check` clean (pre-commit + CI).
- [x] `mkdocs build --strict` passes with the retitled pages.
- [x] `uv build` produces `pamica-0.1.2` sdist+wheel; `twine check` PASSED on both (the publish job's gate).
- [x] `sync_version.py check 0.1.2` passes; `sync`/`check` round-trip verified to preserve file formatting.
- [ ] First real PyPI publish happens when v0.2.1 is released (separate release-prep step).

Closes #177