### PR TITLE
Native backend docs + validate wiring (#147 phase 5)

### DIFF
--- a/docs/api/native-backend.md
+++ b/docs/api/native-backend.md
@@ -1,0 +1,88 @@
+# Native backend (AMICANative)
+
+`AMICANative` runs the **real AMICA Fortran reference binary** as a fourth
+backend, alongside the [PyTorch](torch-backend.md), [MLX](mlx-backend.md) and
+[NumPy](numpy-backend.md) backends. Because it executes the literal reference
+implementation, it is the strongest possible parity oracle: rather than checking
+pamica *against* Fortran, you can run Fortran *as* a pamica backend, with no
+separate toolchain to build or drive.
+
+The reference is built dependency-free (a single-rank MPI shim removes the Open
+MPI runtime, on top of the no-MKL recipe) and released as a self-contained binary
+per platform. The engine resolves the binary for your host, downloads it from the
+GitHub release on first use (verifying its SHA-256), caches it, and runs it.
+
+```python
+import numpy as np
+from pamica import AMICANative
+
+# X is (n_channels, n_samples) of real EEG/EMG.
+model = AMICANative(n_models=1, n_mix=3).fit(X)
+
+out = model.output_             # an AmicaOutput (W, A, mixing/unmixing, LL, ...)
+sources = model.transform(X)    # source activations, EEGLAB variance order
+```
+
+`fit` writes the data and a full `input.param` (so it does not depend on an
+installed `sample_data`), runs the binary, and loads the result with
+`loadmodout`, exposed as `model.output_` (an
+[`AmicaOutput`](numpy-backend.md)). `n_models` and `n_mix` are friendly aliases;
+any Fortran `input.param` field (`max_iter`, `lrate`, `pdftype`, `do_newton`,
+...) can be passed as a keyword. A collapsed fit (non-finite weights) is raised
+as a clear degenerate-fit error rather than an opaque SVD failure.
+
+## Binary resolution and caching
+
+On the first run for a given host, the engine downloads the matching release
+asset and caches it, so later runs are offline:
+
+- **Cache location:** `~/.cache/pamica/bin/<version>/` (or
+  `$XDG_CACHE_HOME/pamica/bin/`; override with `PAMICA_NATIVE_CACHE`).
+- **Integrity:** the download is staged in a temporary directory, verified
+  against its `.sha256` release asset, marked executable, and only then moved
+  atomically into the cache. A file therefore exists at the cache path only once
+  it has passed its checksum; a failed or tampered download never runs.
+- **Platforms:** prebuilt binaries are attached to each release for macOS arm64,
+  Linux x64, Linux arm64 and Windows x64. Windows arm64 has no native Fortran
+  toolchain yet ([#173](https://github.com/sccn/pyAMICA/issues/173)); it maps to
+  the x64 binary, which runs under Windows 11 ARM's x64 emulation.
+
+Install the binary explicitly (for example to pre-populate the cache in an
+offline or CI environment):
+
+```bash
+python -m pamica.native                 # download + cache the latest release binary
+python -m pamica.native --version v0.2.1 # a specific release
+python -m pamica.native --print         # print where it resolves to; do not download
+```
+
+## Using a local build
+
+Set `PAMICA_NATIVE_BINARY` to a locally built binary to bypass the resolver
+entirely (this is what the tests use, and the fallback on a platform with no
+prebuilt asset):
+
+```bash
+export PAMICA_NATIVE_BINARY=/path/to/amica15
+```
+
+Build one with `native/build.sh` (gfortran + LAPACK; the single-rank MPI shim
+means no MPI runtime is required). If no prebuilt binary matches your host and
+`PAMICA_NATIVE_BINARY` is unset, the resolver raises a clear, actionable error
+pointing at the build script.
+
+## Validation harness
+
+`validate_implementations.py` can source the reference through this engine
+instead of the bundled macOS-only `amica15mac` fixture, so the real Fortran
+reference can be compared against the PyTorch backend on any platform:
+
+```bash
+# Resolve/download the native binary (or honor PAMICA_NATIVE_BINARY):
+python validate_implementations.py --native-engine
+
+# Or point at a specific binary:
+python validate_implementations.py --fortran-binary /path/to/amica15
+```
+
+::: pamica.native.engine.AMICANative

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,13 @@ Release notes are also published on the
   **pAMICA**; the package, import and `pip install pamica` stay lowercase
   `pamica` (pip name matching is case-insensitive, so `pip install pAmica`
   resolves to the same project) (#177).
+- Native engine docs and validation wiring: a dedicated `AMICANative`
+  documentation page (usage, binary cache/SHA-256 verification,
+  `PAMICA_NATIVE_BINARY`, the `python -m pamica.native` installer, and the
+  offline `native/build.sh` fallback), and `validate_implementations.py` gains
+  `--native-engine`/`--fortran-binary` so the real Fortran reference runs as a
+  backend on any platform, not only through the bundled macOS `amica15mac`
+  fixture (#147 phase 5, #179).
 - Native Fortran run engine (`AMICANative`), the fourth backend alongside NumPy,
   PyTorch and MLX. It runs the AMICA Fortran reference itself and returns an
   `AmicaOutput` with the usual accessors, so it is the parity oracle the Python

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
       - PyTorch backend: api/torch-backend.md
       - MLX backend: api/mlx-backend.md
       - NumPy backend: api/numpy-backend.md
+      - Native backend: api/native-backend.md
       - Separation metrics: api/metrics.md
       - Visualization: api/viz.md
   - Development:

--- a/validate_implementations.py
+++ b/validate_implementations.py
@@ -81,11 +81,23 @@ def load_sample_data() -> Tuple[np.ndarray, Dict]:
 
 
 def run_fortran_amica(
-    data: np.ndarray, params: Dict, output_dir: Path, seed: int
+    data: np.ndarray,
+    params: Dict,
+    output_dir: Path,
+    seed: int,
+    binary_path: Optional[Path] = None,
 ) -> Optional[Dict]:
-    """Run Fortran AMICA binary and collect results."""
-    # Use the macOS binary in sample_data directory
-    binary_path = Path("pamica/sample_data/amica15mac")
+    """Run the AMICA reference binary and collect results.
+
+    ``binary_path`` selects which reference binary to run. It defaults to the
+    bundled macOS x86_64 fixture (``pamica/sample_data/amica15mac``); pass the
+    cross-platform native-engine binary (see ``--native-engine`` in ``main``) to
+    run the real Fortran reference on Linux/Windows/Apple-Silicon instead.
+    """
+    if binary_path is None:
+        binary_path = Path("pamica/sample_data/amica15mac")
+    # Resolve to an absolute path now, before the run chdirs into fortran_dir.
+    binary_path = Path(binary_path).resolve()
     if not binary_path.exists():
         print(
             f"Warning: Fortran binary not found at {binary_path}. Skipping Fortran comparison."
@@ -138,7 +150,7 @@ def run_fortran_amica(
         os.chdir(fortran_dir)
 
         result = subprocess.run(
-            [str(original_dir / binary_path), "input.param"],
+            [str(binary_path), "input.param"],
             capture_output=True,
             text=True,
             timeout=300,  # 5 minute timeout
@@ -494,6 +506,21 @@ def main():
     parser.add_argument(
         "--skip-fortran", action="store_true", help="Skip Fortran comparison"
     )
+    parser.add_argument(
+        "--native-engine",
+        action="store_true",
+        help="Run the reference through pamica.native: resolve the binary via "
+        "PAMICA_NATIVE_BINARY or the cached/downloaded cross-platform release "
+        "binary, instead of the bundled macOS-only sample_data/amica15mac. This "
+        "is how to run the real Fortran reference on Linux/Windows/Apple Silicon.",
+    )
+    parser.add_argument(
+        "--fortran-binary",
+        type=str,
+        default=None,
+        help="Explicit path to the AMICA reference binary (overrides the bundled "
+        "fixture; ignored when --native-engine is given).",
+    )
 
     args = parser.parse_args()
 
@@ -516,10 +543,30 @@ def main():
         # Update parameters
         params["max_iter"] = args.max_iter
 
+        # Resolve which reference binary to run: the bundled macOS fixture by
+        # default, or the cross-platform native-engine binary on request.
+        fortran_binary = None
+        if not args.skip_fortran and args.native_engine:
+            from pamica.native import resolver
+
+            try:
+                fortran_binary = resolver.resolve()
+                print(f"Reference binary (native engine): {fortran_binary}")
+            except Exception as e:
+                print(
+                    f"Could not resolve a native AMICA binary ({e}); "
+                    "skipping Fortran comparison."
+                )
+                args.skip_fortran = True
+        elif args.fortran_binary:
+            fortran_binary = Path(args.fortran_binary)
+
         # Run Fortran implementation
         fortran_results = None
         if not args.skip_fortran:
-            fortran_results = run_fortran_amica(data, params, output_dir, args.seed)
+            fortran_results = run_fortran_amica(
+                data, params, output_dir, args.seed, binary_path=fortran_binary
+            )
 
         # Run PyTorch implementation
         pytorch_results = run_pytorch_amica(data, params, output_dir, args.seed)


### PR DESCRIPTION
## Summary

Completes the last uncovered phase of the Fortran-engine epic (#147). Epic #147's phases 1-4 (resolver/fetch/checksum/cache, the `AMICANative` engine, cross-platform release CI) were delivered under the duplicate epic #165; its phase 5 was never done.

- **`validate_implementations.py`**: `run_fortran_amica` takes an optional `binary_path`; `--native-engine` resolves the reference binary via `pamica.native` (honoring `PAMICA_NATIVE_BINARY` or the cached/downloaded release binary), and `--fortran-binary` takes an explicit path. So the real Fortran reference can be run as a backend on Linux/Windows/Apple Silicon, not only through the bundled macOS `amica15mac` fixture. Default behavior (no flags) is unchanged.
- **`docs/api/native-backend.md`** (new, + nav entry): documents `AMICANative` usage, the binary cache location and SHA-256 verification, the windows-arm64 emulation gap (#173), `PAMICA_NATIVE_BINARY`, the `python -m pamica.native` installer, and the offline `native/build.sh` fallback.

## Test plan

- [x] `ruff` / `ty` clean (pre-commit + CI).
- [x] `mkdocs build --strict` passes; the new page renders and `::: pamica.native.engine.AMICANative` resolves.
- [x] End-to-end: `PAMICA_NATIVE_BINARY=<bundled> validate_implementations.py --native-engine --max-iter 8` ran the real reference (Fortran LL -3.4526 vs PyTorch -3.4527, component correlation 0.9999) on real sample EEG.

Closes #179
Part of #147