### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,8 +1,8 @@
 {
   "title": "pAMICA: a Python implementation of Adaptive Mixture ICA",
   "description": "pamica is a Python (PyTorch) implementation of Adaptive Mixture Independent Component Analysis (AMICA) that reproduces the reference Fortran implementation within numerical tolerance, with CPU, NVIDIA GPU (CUDA), and Apple GPU (MLX) support. It targets EEG/EMG blind source separation and provides a scikit-learn-style interface and byte-identical EEGLAB (loadmodout15) output.",
-  "version": "0.1.2",
-  "publication_date": "2026-07-14",
+  "version": "0.2.1",
+  "publication_date": "2026-07-18",
   "upload_type": "software",
   "access_right": "open",
   "license": "bsd-3-clause",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,8 +29,8 @@ authors:
     affiliation:
       name: "Swartz Center for Computational Neuroscience"
       ror: "https://ror.org/01bt2qm76"
-version: 0.1.2
-date-released: "2026-07-14"
+version: 0.2.1
+date-released: "2026-07-18"
 license: BSD-3-Clause
 repository-code: "https://github.com/sccn/pyAMICA"
 url: "https://eeglab.org/pyAMICA/"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,10 @@
 Release notes are also published on the
 [GitHub releases page](https://github.com/sccn/pyAMICA/releases).
 
-## Unreleased
+## 0.2.1
+
+PyPI publishing, release-metadata sync, the pAMICA display title, and
+native-engine documentation.
 
 - Packaging and release: a PyPI publish workflow (`publish.yml`) uploads the
   `pamica` sdist and wheel via Trusted Publishing (OIDC) when a GitHub release
@@ -20,6 +23,23 @@ Release notes are also published on the
   `--native-engine`/`--fortran-binary` so the real Fortran reference runs as a
   backend on any platform, not only through the bundled macOS `amica15mac`
   fixture (#147 phase 5, #179).
+
+## 0.2.0
+
+Package rename to align with the reserved PyPI name.
+
+- Renamed the Python package `pyAMICA` -> `pamica`: the import path is now
+  `import pamica` and the distribution installs as `pip install pamica` (pip
+  name matching is case-insensitive, so `pip install pAmica` resolves to the
+  same project). The GitHub repository (`sccn/pyAMICA`), the documentation
+  domain (`eeglab.org/pyAMICA`), and the release-asset repository are unchanged
+  (#176).
+
+## 0.1.3
+
+Native Fortran run engine, separation-quality metrics, LLt output parity, and
+the `loadmodout` byte-order fix.
+
 - Native Fortran run engine (`AMICANative`), the fourth backend alongside NumPy,
   PyTorch and MLX. It runs the AMICA Fortran reference itself and returns an
   `AmicaOutput` with the usual accessors, so it is the parity oracle the Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pamica"
-version = "0.1.2"
+version = "0.2.1"
 description = "pAMICA: Python implementation of the Adaptive Mixture ICA algorithm"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1191,7 +1191,7 @@ wheels = [
 
 [[package]]
 name = "pamica"
-version = "0.1.2"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "json5" },


### PR DESCRIPTION
## Summary

Release-prep for 0.2.1 (the first PyPI release). Splits the changelog into three proper version sections and syncs the version across all metadata.

- **Changelog** split from a single `Unreleased` bucket into:
  - **0.1.3** — native Fortran run engine (`AMICANative`, #165), MIR/PMI separation metrics (#133), LLt output parity (#155), and the `loadmodout` byte-order fix (#159).
  - **0.2.0** — the `pyAMICA` -> `pamica` package rename (#176).
  - **0.2.1** — the PyPI publish workflow + pAMICA display title (#177) and the native-engine docs + validate wiring (#179).
- **Version 0.2.1** synced across `pyproject.toml`, `CITATION.cff` (`version` + `date-released`), `.zenodo.json` (`version` + `publication_date`) and `uv.lock` via `scripts/sync_version.py sync 0.2.1` + `uv lock`.

## Release plan (after this merges)

Three annotated history tags pinned to their commits, only the last cut as a Release:
- `v0.1.3` -> 79d1fa7 (native engine, last pre-rename)
- `v0.2.0` -> 30b32be (rename)
- `v0.2.1` -> this release commit; a GitHub Release is created only for v0.2.1, which fires the PyPI publish and native-binary attach.

## Test plan

- [x] `sync_version.py check 0.2.1` passes; all four files agree.
- [x] `uv build` produces `pamica-0.2.1`; `twine check` PASSED.
- [x] `mkdocs build --strict` clean.