### PR TITLE
Derive __version__ from package metadata

### DIFF
--- a/pamica/version.py
+++ b/pamica/version.py
@@ -1,62 +1,14 @@
-from os.path import join as pjoin
+"""Single source of truth for the package version.
 
-# Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"
-_version_major = 0
-_version_minor = 1
-_version_micro = "2"  # use '' for first of series, number for 1 and above
-_version_extra = ""  # '' for full releases; 'dev' for development
-
-# Construct full version string from these.
-_ver = [_version_major, _version_minor]
-if _version_micro:
-    _ver.append(_version_micro)
-if _version_extra:
-    _ver.append(_version_extra)
-
-__version__ = ".".join(map(str, _ver))
-
-CLASSIFIERS = [
-    "Development Status :: 3 - Alpha",
-    "Environment :: Console",
-    "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python",
-    "Topic :: Scientific/Engineering",
-]
-
-# Description should be a one-liner:
-description = "pamica: Python implementation of Adaptive Mixture ICA algorithm"
-# Long description will go up on the pypi page
-long_description = """
-AMICA (Adaptive Mixture ICA) is an advanced blind source separation algorithm
-that uses adaptive mixtures of independent component analyzers. This implementation provides:
-
-- Multiple source models
-- Different PDF types
-- Newton optimization
-- Component sharing
-- Outlier rejection
-- Data preprocessing (mean removal, sphering)
-
-For more information, visit: http://github.com/neuromechanist/pamica
+``__version__`` is read from the installed distribution metadata, which
+setuptools fills from ``pyproject.toml`` at build time. Deriving it (rather than
+hardcoding a second copy here) means ``pamica.__version__`` can never drift from
+the packaged version, and ``scripts/sync_version.py`` only has to bump one place.
 """
 
-NAME = "pamica"
-MAINTAINER = "Seyed Yahya Shirazi"
-MAINTAINER_EMAIL = "shirazi@ieee.org"
-DESCRIPTION = description
-LONG_DESCRIPTION = long_description
-URL = "http://github.com/neuromechanist/pamica"
-DOWNLOAD_URL = ""
-LICENSE = "BSD-3-Clause"
-AUTHOR = "Seyed Yahya Shirazi"
-AUTHOR_EMAIL = "shirazi@ieee.org"
-PLATFORMS = "OS Independent"
-MAJOR = _version_major
-MINOR = _version_minor
-MICRO = _version_micro
-VERSION = __version__
-PACKAGE_DATA = {"pamica": [pjoin("data", "*")]}
-REQUIRES = ["numpy", "scipy", "matplotlib", "tqdm", "json5"]
-PYTHON_REQUIRES = ">= 3.10"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("pamica")
+except PackageNotFoundError:  # a source tree with no installed distribution
+    __version__ = "0.0.0+unknown"


### PR DESCRIPTION
## Summary

`pamica/version.py` hardcoded the version (`_version_major/minor/micro` = `0.1.2`) and `scripts/sync_version.py` only bumps `pyproject.toml`/`CITATION.cff`/`.zenodo.json`, so the released 0.2.1 wheel had correct dist metadata (`0.2.1`) but `pamica.__version__` returned the stale `0.1.2`. Caught by a clean `pip install pamica==0.2.1` + `import pamica; pamica.__version__`.

Fix: read `__version__` from `importlib.metadata.version("pamica")` (single source of truth = pyproject, filled by setuptools at build time), with a source-tree fallback. Drops the dead setup.py-era constants in `version.py` (verified nothing imports them; the file also carried a wrong `neuromechanist/pamica` URL).

Lands in 0.2.2; 0.2.1 is already on PyPI with the stale attribute (dist metadata is correct, so pip/resolution are unaffected).

## Test plan

- [x] `ruff`/`ty` clean.
- [x] `import pamica; pamica.__version__` == `0.2.1` (was `0.1.2`).
- [x] Tracks a bump: temp-setting pyproject to `0.2.2` + `uv sync` makes `__version__` report `0.2.2`.

Closes #182