### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
   "title": "pAMICA: a Python implementation of Adaptive Mixture ICA",
   "description": "pamica is a Python (PyTorch) implementation of Adaptive Mixture Independent Component Analysis (AMICA) that reproduces the reference Fortran implementation within numerical tolerance, with CPU, NVIDIA GPU (CUDA), and Apple GPU (MLX) support. It targets EEG/EMG blind source separation and provides a scikit-learn-style interface and byte-identical EEGLAB (loadmodout15) output.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "publication_date": "2026-07-18",
   "upload_type": "software",
   "access_right": "open",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,7 +29,7 @@ authors:
     affiliation:
       name: "Swartz Center for Computational Neuroscience"
       ror: "https://ror.org/01bt2qm76"
-version: 0.2.1
+version: 0.2.2
 date-released: "2026-07-18"
 license: BSD-3-Clause
 repository-code: "https://github.com/sccn/pAMICA"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,23 @@
 Release notes are also published on the
 [GitHub releases page](https://github.com/sccn/pAMICA/releases).
 
+## 0.2.2
+
+GitHub repository rename to pAMICA and a `__version__` fix.
+
+- Fixed `pamica.__version__` reporting the stale `0.1.2`: `version.py` hardcoded
+  the version and the release sync never touched it, so the 0.2.1 wheel shipped
+  correct distribution metadata but a wrong runtime attribute. `__version__` now
+  derives from the installed package metadata, so `pyproject.toml` is the single
+  source of truth and it can never drift again (#182).
+- Canonicalized `pyAMICA` -> `pAMICA` URLs after the GitHub repository was
+  renamed `sccn/pyAMICA` -> `sccn/pAMICA`. The documentation site moved to
+  <https://eeglab.org/pAMICA/>, so the old `eeglab.org/pyAMICA` links (including
+  the README docs badge) now 404; the repository URLs, codecov, the native
+  binary resolver's default repository, the docs badge, and `git clone`/`cd`
+  snippets are updated to match. GitHub redirects the old repo URLs, and the
+  package/import name stays lowercase `pamica` (#184).
+
 ## 0.2.1
 
 PyPI publishing, release-metadata sync, the pAMICA display title, and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pamica"
-version = "0.2.1"
+version = "0.2.2"
 description = "pAMICA: Python implementation of the Adaptive Mixture ICA algorithm"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1191,7 +1191,7 @@ wheels = [
 
 [[package]]
 name = "pamica"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "json5" },


### PR DESCRIPTION
## Summary

Release-prep for 0.2.2, which ships two post-0.2.1 fixes already merged to main:

- **#182 / #183** — `pamica.__version__` now derives from package metadata (was reporting the stale `0.1.2` even in the 0.2.1 wheel).
- **#184 / #185** — `pyAMICA` -> `pAMICA` URL canonicalization after the GitHub repo rename (fixes the 404'd `eeglab.org/pyAMICA` docs links, updates repo URLs / badge / resolver default).

Adds the 0.2.2 changelog section and syncs the version across `pyproject.toml`, `CITATION.cff`, `.zenodo.json` and `uv.lock`.

## Release plan (after merge)

Tag `v0.2.2` on the release commit and cut a GitHub Release, which republishes to PyPI (with the corrected `__version__` and links) and re-attaches the native binaries.

## Test plan

- [x] `sync_version.py check 0.2.2` passes; all four files agree.
- [x] `uv build` -> `pamica-0.2.2`; `twine check` PASSED; built package reports `__version__ == 0.2.2`.
- [x] `mkdocs build --strict` clean.