### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
   "title": "pAMICA: a Python implementation of Adaptive Mixture ICA",
   "description": "pamica is a Python (PyTorch) implementation of Adaptive Mixture Independent Component Analysis (AMICA) that reproduces the reference Fortran implementation within numerical tolerance, with CPU, NVIDIA GPU (CUDA), and Apple GPU (MLX) support. It targets EEG/EMG blind source separation and provides a scikit-learn-style interface and byte-identical EEGLAB (loadmodout15) output.",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "publication_date": "2026-07-18",
   "upload_type": "software",
   "access_right": "open",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,7 +29,7 @@ authors:
     affiliation:
       name: "Swartz Center for Computational Neuroscience"
       ror: "https://ror.org/01bt2qm76"
-version: 0.2.2
+version: 0.3.0
 date-released: "2026-07-18"
 license: BSD-3-Clause
 repository-code: "https://github.com/sccn/pAMICA"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pamica"
-version = "0.2.2"
+version = "0.3.0"
 description = "pAMICA: Python implementation of the Adaptive Mixture ICA algorithm"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1191,7 +1191,7 @@ wheels = [
 
 [[package]]
 name = "pamica"
-version = "0.2.2"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "json5" },


### PR DESCRIPTION
Release 0.3.0: the MNE-Python compatibility layer (epic #139).

Syncs the version to 0.3.0 across `pyproject.toml`, `CITATION.cff`, `.zenodo.json`, and `uv.lock` (via `scripts/sync_version.py sync 0.3.0`; the `check` gate passes). The `## 0.3.0` changelog section is already in place from the epic.

Merging this, then tagging `v0.3.0` and cutting the GitHub Release, fires `publish.yml` (PyPI Trusted Publishing) and `release-binaries.yml`.