### PR TITLE
Reset rholrate per iteration to match Fortran

### DIFF
--- a/pamica/numpy_impl/core.py
+++ b/pamica/numpy_impl/core.py
@@ -628,6 +628,9 @@ class AMICA:
             self.good_idx = saved_good_idx
             self.num_good_samples = saved_num_good
         self.lrate = self.lrate0
+        # rholrate is the (maxdecs-ratcheted) rho-rate ceiling; restore it to the
+        # pristine rholrate0 so a re-fit starts fresh (issue #193).
+        self.rholrate = self.rholrate0
         self.ll = []
         self.nd = []
 
@@ -1468,10 +1471,13 @@ class AMICA:
 
         Mirrors Fortran's per-iteration convergence handling
         (amica17.f90:1062-1103). On a likelihood decrease Fortran does NOT stop
-        at ``maxdecs``; it lowers the learning-rate *ceiling* (``lrate0``, and
-        ``newtrate``/``rholrate0`` under Newton) and continues, which is what
-        keeps a long run from oscillating and drifting past its converged
-        solution (issue #41). The updated ``numdecs``/``numincs`` counters are
+        at ``maxdecs``; it lowers the learning-rate *ceilings* (``lrate0``; the
+        rho rate once ``iter > newt_start``; ``newtrate`` under Newton) and
+        continues, which is what keeps a long run from oscillating and drifting
+        past its converged solution (issue #41). The rho ceiling is
+        ``self.rholrate`` here (reset to ``rholrate0`` each fit), ratcheted only
+        at ``maxdecs`` -- never per-decrease (issue #193). The updated
+        ``numdecs``/``numincs`` counters are
         returned so they accumulate across iterations (they previously did not).
 
         Parameters
@@ -1517,8 +1523,8 @@ class AMICA:
         grad_norm = self.nd[-1] if len(self.nd) > 0 else None
 
         # Likelihood decrease (Fortran amica17.f90:1062-1083): reduce the current
-        # lrate, and once maxdecs decreases have accrued, ratchet the ceiling
-        # (lrate0, plus newtrate/rholrate0 under Newton) down and continue --
+        # lrate, and once maxdecs decreases have accrued, ratchet the ceilings
+        # (lrate0; the rho rate; newtrate under Newton) down and continue --
         # NOT stop. Only a lrate/gradient floor terminates on a decrease.
         if self.ll[-1] < self.ll[-2]:
             if self.lrate <= self.minlrate or (
@@ -1531,12 +1537,17 @@ class AMICA:
                     numincs,
                 )
             self.lrate *= self.lratefact
-            self.rholrate *= self.rholratefact
             numdecs += 1
             if numdecs >= self.max_decs:
                 self.lrate0 *= self.lratefact
                 if self.iter > self.newt_start:
-                    self.rholrate0 *= self.rholratefact
+                    # rho rate is a ceiling reset to rholrate0 each iteration
+                    # (Fortran amica15.f90:1788); it ratchets ONLY here at maxdecs
+                    # (amica15.f90:1050), never per LL-decrease. The old per-decrease
+                    # self.rholrate *= rholratefact was a monotone decay with no
+                    # reset that collapsed the rho rate and froze rho at a stale
+                    # shape (issue #193).
+                    self.rholrate *= self.rholratefact
                 if self.do_newton and self.iter > self.newt_start:
                     self.newtrate *= self.lratefact
                 numdecs = 0

--- a/pamica/tests/test_sample_data.py
+++ b/pamica/tests/test_sample_data.py
@@ -709,6 +709,33 @@ def test_check_convergence_ratchets_lrate_on_decrease():
     assert model.rholrate == pytest.approx(rholrate_before * model.rholratefact)
 
 
+def test_reinitialize_for_restart_resets_rho_ceiling():
+    """Issue #193: a mid-fit restart (non-finite LL, Fortran restartiter path)
+    resets the rho-rate ceiling to rholrate0, exactly like the lrate reset -- a
+    previously-ratcheted rholrate must not carry across the restart.
+    """
+    model = AMICA(num_models=1, num_mix=3, seed=0)
+    model.data_dim = 4
+    model.num_samples = 16
+    model.num_comps = 4
+    model.good_idx = None
+    model.num_good_samples = 16
+    model._initialize_parameters()
+
+    # Simulate a fit that ratcheted both ceilings, then hit a non-finite LL.
+    model.rholrate = model.rholrate0 * 0.25
+    model.lrate = model.lrate0 * 0.25
+    model.ll = [-3.0, -3.1]
+    model.nd = [0.5]
+
+    model._reinitialize_for_restart()
+
+    # Both ceilings restored to pristine; history cleared for a fresh judgment.
+    assert model.rholrate == model.rholrate0
+    assert model.lrate == model.lrate0
+    assert model.ll == []
+
+
 @pytest.mark.skipif(not op.exists(eeglab_data_file), reason="sample data missing")
 def test_cli_subprocess_output_loadable(tmp_path):
     """The actual cli entrypoint writes loadmodout-readable output.

--- a/pamica/tests/test_sample_data.py
+++ b/pamica/tests/test_sample_data.py
@@ -665,9 +665,14 @@ def test_restart_gives_up_after_maxrestarts(tmp_path):
 
 def test_check_convergence_ratchets_lrate_on_decrease():
     """After max_decs consecutive LL decreases, _check_convergence lowers the
-    learning-rate ceiling (lrate0, and newtrate under Newton) and resets numdecs
-    -- it does NOT stop -- matching Fortran's ratchet (#41). Drives the
-    convergence handler directly with a decreasing LL history.
+    learning-rate ceilings (lrate0; the rho rate once iter>newt_start; newtrate
+    under Newton) and resets numdecs -- it does NOT stop -- matching Fortran's
+    ratchet (#41). Drives the convergence handler directly with a decreasing LL
+    history.
+
+    Also pins the #193 fix: the rho rate is a maxdecs-ratcheted CEILING, NOT a
+    per-decrease monotone decay. rholrate must stay untouched on a decrease below
+    max_decs and only ratchet when numdecs hits max_decs.
     """
     model = AMICA(
         num_models=1,
@@ -679,16 +684,19 @@ def test_check_convergence_ratchets_lrate_on_decrease():
         use_grad_norm=False,
         use_min_dll=False,
     )
-    model.iter = 100  # past newt_start, so the Newton-rate ratchet applies
+    model.iter = 100  # past newt_start, so the Newton/rho-rate ratchets apply
     model.nd = [1.0]  # gradient norm well above min_grad_norm (no floor stop)
     lrate0_before = model.lrate0
     newtrate_before = model.newtrate
+    rholrate_before = model.rholrate
 
-    # First decrease: numdecs -> 1 (below max_decs), so just reduce lrate.
+    # First decrease: numdecs -> 1 (below max_decs), so just reduce lrate. The rho
+    # ceiling must NOT move here -- pre-#193 it decayed on every decrease.
     model.ll = [-3.0, -3.1]
     conv, _, numdecs, numincs = model._check_convergence(0, 0)
     assert conv is False
     assert numdecs == 1
+    assert model.rholrate == rholrate_before
 
     # Second consecutive decrease: numdecs hits max_decs=2 -> ratchet ceilings,
     # reset numdecs, and CONTINUE (not converged).
@@ -698,6 +706,7 @@ def test_check_convergence_ratchets_lrate_on_decrease():
     assert numdecs == 0
     assert model.lrate0 == lrate0_before * 0.5
     assert model.newtrate == newtrate_before * 0.5
+    assert model.rholrate == pytest.approx(rholrate_before * model.rholratefact)
 
 
 @pytest.mark.skipif(not op.exists(eeglab_data_file), reason="sample data missing")

--- a/pamica/tests/torch_tests/test_ng_backend.py
+++ b/pamica/tests/torch_tests/test_ng_backend.py
@@ -1380,3 +1380,43 @@ def test_keep_best_inactive_under_reject():
     m.fit(data, max_iter=12, verbose=False)
     assert m.numrej >= 1  # rejection actually fired, so the good set changed
     assert m.final_ll_ == m.ll_history[-1]  # no best-iterate restore under reject
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not DATA_FILE.exists(), reason="sample data missing")
+def test_rholrate_ratchets_at_maxdecs_not_per_decrease():
+    """Issue #193: the rho learning rate is a maxdecs-ratcheted *ceiling*, not a
+    per-LL-decrease monotone decay.
+
+    Fortran resets ``rholrate = rholrate0`` every iteration before the rho update
+    (amica15.f90:1788) and only tightens the ceiling at ``maxdecs``
+    (amica15.f90:1050, gated on ``iter > newt_start``). torch previously decayed
+    ``rholrate`` on EVERY LL decrease with no reset, collapsing it to ~1e-5 within
+    a few hundred iterations and freezing rho at a stale shape.
+
+    On the real sample data a long-enough Newton run overshoots and triggers
+    several LL decreases. The surviving ``rholrate`` must have ratcheted exactly
+    as often as ``newtrate`` (both gated on ``iter > newt_start`` at ``maxdecs``,
+    matched 0.5 factor here), NOT once per decrease.
+    """
+    data = _load_real_data()
+    m = _fresh_ng(
+        block_size=512, do_newton=True, newt_start=50, newtrate=1.0, lrate=0.05,
+        lratefact=0.5, rholrate=0.05, rholratefact=0.5, maxdecs=3,
+    )  # fmt: skip
+    m.fit(data, max_iter=300, verbose=False)
+
+    ll = m.ll_history
+    n_dec = sum(1 for i in range(1, len(ll)) if ll[i] < ll[i - 1])
+    # The run must actually exercise the schedule (Newton overshoots past
+    # newt_start), or the assertions below prove nothing.
+    assert m.newtrate < m.newtrate0, "no newtrate ratchet fired; budget too short"
+    assert n_dec > m.maxdecs, "too few LL decreases to distinguish the schedules"
+
+    # rholrate and newtrate share the maxdecs ratchet schedule, so the surviving
+    # rho ceiling ratcheted the same number of times as newtrate.
+    assert m.rholrate == pytest.approx(m.rholrate0 * (m.newtrate / m.newtrate0))
+    # The old per-decrease decay (rholrate0 * rholratefact**n_dec) sits orders of
+    # magnitude below the fixed ceiling; guard against a regression to it.
+    buggy = m.rholrate0 * (m.rholratefact**n_dec)
+    assert m.rholrate > buggy * 10

--- a/pamica/torch_impl/core.py
+++ b/pamica/torch_impl/core.py
@@ -1824,12 +1824,24 @@ class AMICATorchNG:
 
             # Learning-rate control, ported from Fortran (amica17.f90:1062-1108).
             # Natural-gradient/Newton ascent is not monotonic at a fixed rate:
-            # when the log-likelihood decreases, anneal the working rates
-            # (lrate, rholrate). If decreases persist for maxdecs iterations,
-            # ratchet the *ceilings* down (lrate_cap, and newtrate once Newton
-            # is running) so the per-iteration ramp can no longer re-inflate
-            # lrate back to the overshooting value -- without this the ramp and
-            # a one-shot halving just oscillate and the LL drifts down.
+            # when the log-likelihood decreases, anneal the working lrate. If
+            # decreases persist for maxdecs iterations, ratchet the *ceilings*
+            # down (lrate_cap; newtrate once Newton is running; and the rho rate)
+            # so the per-iteration ramp can no longer re-inflate lrate back to the
+            # overshooting value -- without this the ramp and a one-shot halving
+            # just oscillate and the LL drifts down.
+            #
+            # rholrate is a CEILING here, not a per-decrease-annealed working
+            # rate. Fortran resets rholrate=rholrate0 each iteration before the
+            # rho update (amica15.f90:1788) and only tightens the rholrate0
+            # ceiling at maxdecs (amica15.f90:1050, gated on iter>newt_start), so
+            # its per-decrease rholrate*=rholratefact (:1045) is always overwritten
+            # by the reset and never reaches the rho update. rho has no ramp, so
+            # self.rholrate carries that ceiling directly (reset to rholrate0 each
+            # fit, nothing re-inflates it) and must ratchet ONLY at maxdecs. The
+            # previous per-decrease self.rholrate*=rholratefact was a monotone
+            # decay with no reset that collapsed the rho rate to ~1e-5 within a few
+            # hundred iterations and froze rho at a stale shape (issue #193).
             if len(self.ll_history) > 1 and ll < self.ll_history[-2]:
                 if self.lrate <= self.minlrate:
                     logger.warning(
@@ -1840,10 +1852,11 @@ class AMICATorchNG:
                     self.stop_reason = "lrate_floor"
                     break
                 self.lrate *= self.lratefact
-                self.rholrate *= self.rholratefact
                 numdecs += 1
                 if numdecs >= self.maxdecs:
                     self.lrate_cap *= self.lratefact
+                    if it > self.newt_start:
+                        self.rholrate *= self.rholratefact
                     if self.do_newton and it > self.newt_start:
                         self.newtrate *= self.lratefact
                     numdecs = 0


### PR DESCRIPTION
## Summary

`AMICATorchNG` (and the legacy `numpy_impl` backend) diverged from the Fortran reference in the rho (generalized-Gaussian shape) learning-rate schedule: **torch permanently decayed `rholrate` on every log-likelihood decrease**, whereas Fortran **resets `rholrate = rholrate0` each iteration** and only ratchets the ceiling at `maxdecs`. Once an LL decrease shrank `rholrate` it stayed shrunk (monotone decay), so on a long run the rho update was progressively under-relaxed and eventually frozen (rate collapsed to ~1e-5 within a few hundred iterations). Refs #193.

## Fortran expressions

- `amica15.f90:1788`/`:1795` — `update_params` sets `rholrate = rholrate0` every iteration, before the rho update at `:1814`. So Fortran's per-decrease `rholrate = rholrate*rholratefact` (`:1045`) is overwritten and never reaches the rho update; the effective rate is always the `rholrate0` ceiling.
- `amica15.f90:1050` — the ceiling `rholrate0` ratchets `*= rholratefact` only at `maxdecs`, gated on `iter > newt_start` (unlike `newtrate`, which is additionally gated on `do_newton`).

## Fix

rho has no per-iteration ramp, so the effective rho rate is exactly its ceiling. Both backends now carry that ceiling directly:
- **torch** (`pamica/torch_impl/core.py`): `self.rholrate` is the ceiling — reset to `rholrate0` at fit start (existing), ratcheted only in the `maxdecs` block (gated `it > newt_start`), never per-decrease. The buggy per-decrease `self.rholrate *= self.rholratefact` is removed.
- **numpy** (`pamica/numpy_impl/core.py`): same — `self.rholrate` is the ceiling, reset to `rholrate0` at fit start, ratcheted at `maxdecs` (the previously-dead `rholrate0` ratchet is retargeted to `rholrate`); the per-decrease decay is removed.

`rholrate0` stays the pristine constructor value in both. No state-dict format change (the persisted `rholrate` field now carries the ceiling; round-trip is unchanged).

## Parity validation (vs `amica15mac`, bundled 32ch/30504 data, 2000 iters, do_newton)

Converged rho distribution (shape param, bounded [1,2]) — sorted, permutation-free:

| | min | q25 | med | q75 | max |
|---|---|---|---|---|---|
| torch (fixed) | 1.000 | 1.606 | 1.822 | 1.994 | 2.000 |
| Fortran run #1 | 1.000 | 1.614 | 1.829 | 2.000 | 2.000 |
| Fortran run #2 | 1.000 | 1.636 | 1.845 | 2.000 | 2.000 |

Sorted-rho L1 distance: torch-vs-Fortran = 0.032, Fortran-vs-Fortran = 0.018 — torch's rho distribution sits within Fortran's own run-to-run spread on this data. Post-fit `rholrate` ends at 0.00039 (= `0.05 * 0.5**7`, seven `maxdecs` ratchets, matching `newtrate`), not the buggy per-decrease collapse (`0.05 * 0.5**19 ~ 1e-7`).

## Note on #145

This is a correctness/parity fix on its own merits; it is evaluated against the Fortran binary, NOT the #145 long-budget Newton metric. As documented in #193, matching Fortran here **worsens** the #145 min-correlation on the (data-inadequate, k=29.8) bundled recording, because the accidental decay was freezing rho and removing a Newton noise source. That is expected and is a red herring for #145 (see the #145 investigation notes).

## Test plan

- New real-data regression test `test_rholrate_ratchets_at_maxdecs_not_per_decrease` (marked slow): on the sample EEG a 300-iter Newton run overshoots and triggers several LL decreases; asserts the surviving `rholrate` ratcheted exactly as often as `newtrate` (both gated on `iter > newt_start` at `maxdecs`), and is orders of magnitude above the old per-decrease-decay value.
- Existing gates green: `test_full_fit_parity_numpy_vs_ng`, `test_end_to_end_correlation_vs_fortran`, `test_sample_data.py` (numpy-vs-Fortran), torch/numpy non-slow suites, `ruff`, `ty`.

Refs #193