### PR TITLE
Document #145 investigation (init-basin sensitivity)

### DIFF
--- a/.context/issue-145/diagnostic.md
+++ b/.context/issue-145/diagnostic.md
@@ -1,0 +1,60 @@
+# Issue #145 diagnostic - near-singular-Hessian hypothesis REFUTED
+
+## What was tested
+Instrumented `AMICATorchNG` M-step to log, per iteration, per model: Hessian
+conditioning (`min` over off-diagonal source pairs of `p_i*p_k - 1`, where
+`p_i = sigma2_i*kappa_i`; a pair is near-singular as `p_i*p_k -> 1+`), the
+accepted Newton step magnitude (`maxHoff`, `max_a_step`), and per-component
+density params. Ran seed 42 (the collapser) and seed 7 (the matcher) to 2000
+iters, CUDA float64, `do_newton=1`, on the full 70ch/k=152 data. Trajectories +
+scripts on hallu: `/mnt/local/taskB/diag/{s42,s7}_traj.npz`,
+`analyze_newton_145.py`.
+
+## Hypothesis (refuted)
+Weak components' Hessians graze singular (`p_i*p_k -> 1+`), the Newton
+denominator `-> 0`, so a ~1e-9 per-step difference from Fortran is amplified by
+`1/(prod-1)` into a basin-jumping step that is still technically posdef (accepted,
+not a fallback).
+
+## Evidence it is REFUTED
+- **Conditioning never approaches the singular boundary.** `min(p_i*p_k)-1` goes
+  2.24 (iter 50) -> 0.68 (iter 2000) for seed 42, 2.27 -> 0.59 for seed 7. The
+  count of off-diagonal pairs in the marginal zone `(1, 1.02]` is **0 at every
+  iteration** for both seeds. Nothing grazes singular.
+- **No step blowup.** `maxHoff` stays ~1e-3..5e-2, `max_a_step` ~1e-3..3e-2, all
+  run. `n_newton_fallbacks = 0` because the Hessian is comfortably posdef, not
+  because it is marginally posdef.
+- **The collapsed components are not the ill-conditioned ones.** Collapsed torch
+  rows (seed 42, corr<0.9 vs F_d03): [0, 11, 26, 35, 42, 43, 52], with final
+  `p_i*p_k` = 1.6-2.7 (well clear of 1) and 0 iterations near-singular. Fraction
+  of iters (>=50) where the globally worst-conditioned component is a collapsed
+  component: **0.003**.
+- **Seeds 42 and 7 have nearly identical aggregate trajectories** (LL,
+  conditioning, step magnitudes match at every logged iteration) yet seed 42
+  collapses 7 components and seed 7 collapses 0 - on the *same* intrinsically-weak
+  components (0, 26, 35, 42, 43...). The difference is which basin those weak
+  components settle into, not any measured numerical pathology.
+
+## Reframed finding
+The `do_newton=1` divergence is **basin selection on the ~7 weakest
+(under-determined) components**, via well-conditioned Newton steps. Torch's
+extended optimization settles them into a different configuration than Fortran's,
+at an **equal-or-higher LL** (seed 42 collapser final LL -3.69759 > seed 7 matcher
+-3.69780; both `best_iter=1999`, LL still rising at 2000). Combined with the
+issue's established fact that correlation *degrades* from ~300 iters (0.98-0.999)
+to 2000 iters (0.87-0.97), this says the extended Newton phase moves torch *away*
+from Fortran's basin into a nearby higher-LL one, on the weak components only.
+Torch has more run-to-run spread on these components than Fortran (within-torch
+0.963 vs within-Fortran 0.9997).
+
+## Why this matters for the fix
+There is no conditioning/Hessian-damping lever to pull (zero marginal pairs), so a
+posdef-threshold or step-cap "fix" would be a pure no-op on this data. The real
+question is now: is the torch-vs-Fortran divergence (a) a compounding
+implementation difference in the well-conditioned steps (per-step ~1e-9
+differences accumulating along the flat weak-component directions over ~1700
+Newton steps), or (b) genuine multi-basin structure that Fortran's dynamics is
+more consistently attracted out of than torch's? These are distinguished only by a
+**same-init torch-vs-Fortran trajectory comparison** (init torch from Fortran's
+exact starting A/sphere and log both), which no prior run has done - every
+comparison so far used independent inits.

--- a/.context/issue-145/full_data_reproduction.md
+++ b/.context/issue-145/full_data_reproduction.md
@@ -1,0 +1,58 @@
+# Issue #145 - reproduction on adequate (k~152) full-length data
+
+## Setup
+- Data: full ds002718 sub-002, **70 channels x 747,750 frames**, so the
+  data-adequacy factor **k = frames / ch^2 ~= 152** (well above the k>=60
+  rule-of-thumb; the bundled 32ch fixture is only k=29.8, which is data-inadequate
+  and where Fortran itself is not self-consistent - hence not a valid oracle for
+  #145).
+- Reference: two independent Fortran `amica15` fits (`F_d03`, `F_pdb0`),
+  W read F-order (70x70).
+- Torch: `AMICATorchNG`, CUDA float64, `do_newton=True`, 2000 iters, seeds
+  42 / 7 / 13. All three converged cleanly (0 Newton fallbacks; final LL
+  -3.6975 / -3.6978 / -3.6978).
+- Comparison: Hungarian-matched `|corr|` of de-normalized W rows.
+  Scripts + W's + verdict preserved on hallu at `/mnt/local/taskB/`
+  (`VERDICT_full70ch.txt`, `compare_local.py`).
+
+## Result (Hungarian-matched |corr|, 70 components)
+
+| pairing        | n | mean   | min (worst) |
+|----------------|---|--------|-------------|
+| within-Fortran | 1 | 0.9997 | 0.9983      |
+| within-torch   | 3 | 0.9631 | 0.6540 (0.5121) |
+| between (t-F)  | 6 | 0.9771 | 0.7697 (0.4822) |
+
+Per torch seed vs Fortran:
+- **seed 7:  mean 0.996, min 0.94, 0/70 below 0.9** - matches Fortran.
+- **seed 13: mean 0.994, min 0.87, 1/70 below 0.9** - matches Fortran (1 weak comp).
+- **seed 42: mean 0.942, min 0.48, 10-11/70 below 0.9** - COLLAPSE (the #145 signal).
+
+## Verdict: the defect reproduces, but it is seed-dependent, not systematic
+
+- **Fortran is a valid oracle here**: two independent Fortran runs agree at
+  0.9997/0.9983 (vs only ~0.93/0.68 on the k=30 32ch fixture). So at k~152 the
+  data is adequate and self-consistency is meaningful. This validates the issue
+  premise and confirms #90's k-factor hypothesis (bulk equivalence rises to ~1.0
+  as k grows; it was ~0.90 at k=30).
+- **Torch usually matches Fortran** (2 of 3 seeds: ~0.99+ mean, essentially all
+  70 components), but **~1 seed in 3 (seed 42) lands in a different basin that
+  reshuffles ~10 of the 70 weak/under-determined components** down to |corr| ~0.48.
+- **The collapsing seed is at a marginally HIGHER LL** (-3.6975 vs -3.6978), i.e.
+  it is a genuinely different, slightly-better-LL local optimum - not a failure to
+  converge and not a worse fit. This is the fingerprint of the Fable agent's root
+  cause: the Newton step is faithful (~1e-9 vs Fortran); the drift is mu/beta/rho
+  exact-EM ill-conditioning on weak components, amplified by Newton's sharpening,
+  which occasionally tips a fit into a neighbouring basin Fortran's plain-EM path
+  does not enter.
+
+## Next step
+Implement the faithful mu/beta/rho ill-conditioning guard (keep the Newton step,
+stabilise the exact-EM weak-component updates so the Newton-preconditioned path
+stays in Fortran's basin), then re-run this exact ensemble on
+`/mnt/local/pamica-145` and re-measure - expectation: seed 42 stops collapsing
+(all seeds -> ~0.99 vs Fortran, matching within-Fortran self-consistency).
+
+Byproduct already filed: the rholrate reset porting bug (#193, PR #194; same bug
+in MLX #195) was found during this investigation but is independent of the
+weak-component collapse.

--- a/.context/issue-145/same_init_result.md
+++ b/.context/issue-145/same_init_result.md
@@ -1,0 +1,52 @@
+# Issue #145 - same-init test result (DEFINITIVE)
+
+## Method
+Ran BOTH torch (`AMICATorchNG`, CUDA float64) and native Fortran (`amica15`,
+gfortran) from an IDENTICAL deterministic start: A=identity, mu=[-1,0,1],
+sbeta=1, rho=1.5. The symmetric-ZCA sphere is sign/order-invariant, so
+"A=identity in sphered space" is a genuinely identical start for both. Fortran
+was fed the init via the built-in `load_A`/`load_mu`/`load_beta`/`load_rho` file
+path (fix_init=1 segfaults in the amica15_linux build; load path is equivalent).
+Both ran 2000 iters, do_newton on, matched config. Scripts + W's on hallu
+`/mnt/local/taskB/fixinit/`.
+
+## Result (Hungarian-matched |corr|, 70 components)
+
+| comparison                              | mean   | min    | n<0.9 |
+|-----------------------------------------|--------|--------|-------|
+| **torch-from-A=I vs Fortran-from-A=I**  | 0.9974 | 0.9475 | 0/70  |
+| Fortran-from-A=I vs random Fortran ref  | 0.9999 | 0.9988 | 0/70  |
+| within-Fortran (two random inits)       | 0.9997 | 0.9983 | 0/70  |
+| torch-from-A=I vs random torch seed 42  | 0.948  | 0.53   | 9/70  |
+| torch-from-A=I vs random torch seed 7   | 0.993  | 0.928  | 0/70  |
+| torch-from-A=I vs random torch seed 13  | 0.998  | 0.981  | 0/70  |
+
+## Verdict: init-basin sensitivity, NOT a dynamics bug
+
+- **From an identical init, torch and Fortran agree** (0.9974, 0/70 collapsed).
+  The residual ~0.003 gap vs within-Fortran (0.9997) is float summation-order /
+  BLAS noise between the two implementations accumulated over 2000 iters on the
+  weak (flat-likelihood) components - NOT a basin difference and NOT a collapse.
+- **Fortran-from-A=I == the random Fortran refs at 0.9999**, proving (a) A=identity
+  is a normal, non-special init, and (b) Fortran is init-robust (any init -> the
+  same basin).
+- **The only collapse is torch's random seed 42** (0.948, 9/70): that specific
+  random init sends torch into a different, equal-or-higher-LL basin. The same
+  deterministic init does not. So the collapse is triggered by particular random
+  initializations, to which torch is more sensitive than Fortran.
+
+This corroborates the diagnostic (near-singular Hessian refuted; Newton math
+algebraically identical to amica15.f90; no minhess damping lever). There is no
+per-step dynamics divergence to fix: identical start -> matching answer.
+
+## Recommended resolution
+Document, do not "fix" the optimizer:
+- Report the do_newton=0 single-model conformity number (0.998, reproducible end
+  to end) as the parity claim - already done in paper/docs (#144).
+- Disclose the do_newton=1 weak-component spread as init-basin sensitivity on
+  under-determined components (torch more init-sensitive than Fortran), the same
+  posture as multi-model non-identifiability (#27) and the best-iterate safeguard
+  (#51).
+- OPTIONAL enhancement (follow-up, not a parity fix): improve torch's
+  init-robustness via best-of-N restarts (extending #51 keep_best across seeds) so
+  a single fit is less likely to land in the seed-42-style basin.

--- a/.context/issue-145/setup_and_config.md
+++ b/.context/issue-145/setup_and_config.md
@@ -1,0 +1,99 @@
+# Issue #145 -- diagnostic setup and pre-diagnostic facts
+
+Goal: root-cause why `AMICATorchNG` (do_newton=1) diverges from Fortran on a
+handful of weak components by 2000 iters on data-adequate real EEG (seed 42
+collapses: 10-11/70 comps < 0.9 vs Fortran; seeds 7/13 match at ~0.99). Fortran
+is self-consistent (within-Fortran 0.9997), so it is a valid oracle here.
+
+## Reproduction is confirmed (matches team-lead numbers)
+Full ds002718 sub-002, 70ch x 747,750 frames, k=152.6. CUDA float64, 2000 iters.
+- within-Fortran (2 runs): mean 0.9997, min 0.9983
+- seed 7 vs Fortran:  mean 0.9956, min 0.955, 0/70 < 0.9   (MATCH)
+- seed 13 vs Fortran: mean 0.9931, min 0.866, 1/70 < 0.9   (MATCH)
+- seed 42 vs Fortran: mean 0.9429, min 0.485, 10-11/70 < 0.9 (COLLAPSE)
+- All seeds: n_newton_fallbacks = 0 (collapse happens inside ACCEPTED posdef
+  Newton steps, never via the natural-gradient fallback).
+- seed 42 final LL -3.6975 is marginally HIGHER than 7/13 (-3.6978): basin
+  selection, not worse convergence. keep_best faithfully preserves the wrong
+  (but higher-LL) basin.
+
+## Clue from the reproduction log (torch.log)
+- seed 42 ended `end_newtrate=0.25`; seeds 7/13 ended `end_newtrate=1`.
+  newtrate is halved by the LL-decrease ratchet (core.py:1856-1861) after
+  `maxdecs` decreases. So seed 42 suffered repeated Newton OVERSHOOTS (LL
+  non-monotonicity) that 7/13 did not -- consistent with accepted-huge-step.
+
+## Config is NOT the mismatch (verified)
+Reference Fortran run input.param (/tmp/ds002718_full_parity_d03rs2rm/run_0)
+uses EXACTLY the torch fit config: newtrate=1.0, newt_start=50, newt_ramp=10,
+lratefact=0.5, max_decs=3, lrate=0.05, rholrate=0.05, rholratefact=0.5,
+rho0=1.5, do_newton=1, do_reject=0, num_mix=3, block_size=512, doscaling=1
+scalestep=1, do_mean/do_sphere/doPCA=1 pcakeep=70. Both take full (newtrate=1.0)
+Newton steps on an identical schedule. So the divergence is purely numerical.
+
+## Newton math is algebraically identical to Fortran (verified by source read)
+- Accumulation (core.py:1072-1076 vs amica15.f90:1423-1490): dsigma2=sum v*b^2,
+  dkappa=sum(ufp*fp)*sbeta^2, dlambda=sum u*(fp*y-1)^2. Identical.
+- Finalization (core.py:_finalize_newton_stats vs amica15.f90:1650-1662): the
+  baralpha/denominator masses cancel, leaving sigma2=dsigma2/dgm,
+  kappa=sum_j dkappa/dgm, lambda=sum_j(dlambda + dkappa*mu^2)/dgm. Identical.
+- 2x2 solve + guard (core.py:_newton_direction vs amica15.f90:1703-1718):
+  H[i,i]=dA[i,i]/lambda[i]; sk1=sigma2[i]*kappa[k], sk2=sigma2[k]*kappa[i];
+  H[i,k]=(sk1*dA[i,k]-dA[k,i])/(sk1*sk2-1) if sk1*sk2>1 else posdef=False.
+  BYTE-identical guard (prod>1.0). NumPy backend (numpy_impl/core.py:1206-1225)
+  is identical too.
+- Any torch-vs-Fortran difference is float64 summation-ORDER noise (~1e-9),
+  which is exactly what the near-singular-amplification hypothesis needs.
+
+## `minhess` is dead code
+amica15_header.f90:73 declares `minhess = 1.0e-5` but it is NEVER referenced in
+amica15.f90 or amica17.f90 (like Spinv2 / do_choose_pdfs moment buffers). So
+there is NO Fortran Hessian floor to port -- Fortran uses the raw prod>1 guard.
+
+## Key conditioning identity (for attribution)
+prod[i,k] = sk1*sk2 = (sigma2[i]*kappa[i]) * (sigma2[k]*kappa[k]). Define
+p_i = sigma2[i]*kappa[i]. A pair (i,k) is near-singular (prod -> 1+) exactly when
+p_i*p_k -> 1. So the components with the SMALLEST p_i drive the boundary; the
+diagnostic reconstructs per-component p_i from saved sigma2,kappa to attribute
+near-singular pairs to specific (collapsing?) components.
+
+## Tests that must stay green (bit-exact #24 parity)
+- tests/torch_tests/test_ng_backend.py: test_newton_stats_match_numpy_reference,
+  test_newton_mstep_matches_numpy_reference, test_newton_direction_matches_formula
+  (asserts posdef True on a well-conditioned dA, posdef False on tiny
+  sigma2/kappa). Any guard/margin change must keep the well-conditioned case
+  posdef=True and the NumPy<->NG paths bit-identical.
+
+## Sample-data (32ch #24 fixture) Newton conditioning -- the margin CEILING
+Ran the exact test_end_to_end_correlation_vs_fortran config (32ch, block_size=512,
+do_newton, newt_start=50, newtrate=1.0, lrate=0.05, 100 iters, CPU float64):
+- n_newton_fallbacks=0, final_ll=-3.41125 (matches #24)
+- Newton fires iters 50-99; min ACCEPTED (prod-1) over ALL of them = **2.09**
+  (prod >= 3.1), min p_i=sigma2*kappa = 1.73, n_marginal(<1.05)=0 every iter.
+=> The sample data is VERY well-conditioned. ANY posdef-guard margin up to ~2.0
+is a complete no-op there (every pair has prod-1 >= 2.09 >> margin), so
+n_newton_fallbacks stays 0 and the #24 correlation stays bit-exact. Generous
+headroom for a margin; the binding constraint is the full-70ch FLOOR (seed 42's
+danger-zone denom vs seed 7's min denom), which the diagnostic supplies.
+
+## Diagnostic OUTCOME: near-singular hypothesis REFUTED (see diagnostic.md)
+Ran the instrumented DiagNG subclass (per-iteration min(prod-1) over off-diag
+pairs, min accepted denom, n_marginal, max|H_off|, per-column A step, and
+per-component sigma2/kappa/lambda/mu/beta/alpha/rho) for seed 42 (collapser) and
+seed 7 (matcher) to 2000 iters, CUDA float64, from the a6b967f baseline extracted
+read-only to /mnt/local/diag145. Result: the Hessian NEVER approaches singular
+(min(p_i*p_k)-1 stays 2.24 -> 0.68; zero marginal pairs at every iteration; the
+collapsed components are well-conditioned, p_i*p_k = 1.6-2.7). The collapse is
+BASIN SELECTION on the ~7 weakest components via well-conditioned Newton steps,
+not a conditioning pathology. Full evidence in `diagnostic.md`.
+
+### Consequence for the notes above
+The margin/posdef-threshold fix reasoned about here (and the sample-data CEILING
+of 2.09) is MOOT: with zero marginal pairs on the full data there is nothing for
+a conditioning guard to catch, so any threshold/step-cap change is a pure no-op.
+The source-read facts above (config identical to Fortran, Newton math
+algebraically identical, minhess dead code, sample data well-conditioned) stand
+and CORROBORATE the refutation -- there is no Fortran damping lever to port and no
+numerical near-singular event to stabilize. Next step (team-lead directed): a
+same-init torch-vs-Fortran trajectory comparison to localize the divergence.
+Held pending that instruction; no further long hallu runs launched.


### PR DESCRIPTION
Documentation of the #145 investigation (now closed as init-basin sensitivity, not a dynamics bug). No code change.

Adds `.context/issue-145/`:
- `diagnostic.md` -- near-singular-Hessian hypothesis refuted (Newton well-conditioned throughout; math algebraically identical to amica15.f90; no minhess damping lever).
- `full_data_reproduction.md` -- the do_newton=1 collapse reproduced on full 70ch/k=152 data (seed-dependent).
- `same_init_result.md` -- the decisive same-init test: torch and Fortran agree (0.9974, 0/70 collapsed) from an identical A=identity start; the collapse is specific random-seed init-basin sensitivity.

Resolution and the optional init-robustness follow-up (#198) are recorded in the #145 close comment.