### PR TITLE
Bump version to 0.3.1

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,8 +1,8 @@
 {
   "title": "pAMICA: a Python implementation of Adaptive Mixture ICA",
   "description": "pamica is a Python (PyTorch) implementation of Adaptive Mixture Independent Component Analysis (AMICA) that reproduces the reference Fortran implementation within numerical tolerance, with CPU, NVIDIA GPU (CUDA), and Apple GPU (MLX) support. It targets EEG/EMG blind source separation and provides a scikit-learn-style interface and byte-identical EEGLAB (loadmodout15) output.",
-  "version": "0.3.0",
-  "publication_date": "2026-07-18",
+  "version": "0.3.1",
+  "publication_date": "2026-07-19",
   "upload_type": "software",
   "access_right": "open",
   "license": "bsd-3-clause",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,8 +29,8 @@ authors:
     affiliation:
       name: "Swartz Center for Computational Neuroscience"
       ror: "https://ror.org/01bt2qm76"
-version: 0.3.0
-date-released: "2026-07-18"
+version: 0.3.1
+date-released: "2026-07-19"
 license: BSD-3-Clause
 repository-code: "https://github.com/sccn/pAMICA"
 url: "https://eeglab.org/pAMICA/"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,29 @@
 Release notes are also published on the
 [GitHub releases page](https://github.com/sccn/pAMICA/releases).
 
+## 0.3.1
+
+Rho-rate schedule fixes across all backends and a reproducible-seed option in the
+native binary build.
+
+- Fixed the rho learning-rate (`rholrate`) schedule to match Fortran
+  `amica15.f90`: it is a `maxdecs`-ratcheted ceiling (reset to `rholrate0` each
+  iteration/fit, tightened only after `maxdecs` persistent log-likelihood
+  decreases, gated on `iter > newt_start`), not a per-decrease monotone decay.
+  The previous decay collapsed the rho rate toward ~1e-5 and froze the source
+  shape. Fixed in the PyTorch and NumPy backends (#194, issue #193) and the MLX
+  backend (#197, issue #195).
+- Native binary build: reproducible `seed` option. A `seed <int>` line in
+  `input.param` now seeds the random initialization deterministically (per-rank,
+  no system clock), so a native run is reproducible run to run; without it the
+  default stays clock-random. Also makes `random_seed` portable across compilers
+  via `random_seed(SIZE=...)`. Adopted from sccn/amica PR #54; the released
+  binaries (rebuilt by CI) carry the option (#196).
+- Documented the #145 investigation (Newton-vs-Fortran weak-component divergence
+  at long budgets): resolved as init-basin sensitivity on under-determined
+  components, not a dynamics bug (identical init gives matching results); the
+  optional init-robustness enhancement is tracked in #198.
+
 ## 0.3.0
 
 MNE-Python compatibility layer (epic #139), additive: the scikit-learn-style

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pamica"
-version = "0.3.0"
+version = "0.3.1"
 description = "pAMICA: Python implementation of the Adaptive Mixture ICA algorithm"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1191,7 +1191,7 @@ wheels = [
 
 [[package]]
 name = "pamica"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "json5" },


### PR DESCRIPTION
Release 0.3.1.

## Included since 0.3.0
- rholrate schedule fix (maxdecs-ratcheted ceiling) in PyTorch/NumPy (#194, issue #193) and MLX (#197, issue #195).
- Native binary build: reproducible `seed` option in `input.param` + portable `random_seed(SIZE=)` (#196, from sccn/amica #54).
- #145 investigation documented (init-basin sensitivity, not a dynamics bug); enhancement follow-up #198.

Version synced across pyproject.toml / CITATION.cff / .zenodo.json / uv.lock; changelog updated. Cutting the `v0.3.1` release after merge triggers `release-binaries.yml` (rebuilds + uploads the seed-enabled native binaries) and the PyPI publish.