### PR TITLE
Normalize numpy_impl log-likelihood to Fortran's scale

### DIFF
--- a/benchmarks/benchmark_dimsweep.py
+++ b/benchmarks/benchmark_dimsweep.py
@@ -218,11 +218,11 @@ def _run_numpy(data, iters, repeats, n_models=1, share=False, threads=None):
                 f"AMICA_NumPy did not converge (non-finite LL) at "
                 f"{data.shape[0]}ch x {data.shape[1]} samples, {n_iter} iters"
             )
-        # AMICA_NumPy.ll is summed over samples*channels; normalize to the
-        # per-sample-per-channel scale the torch/mlx backends report, so the
-        # results column is directly comparable (numpy-f64 then matches
-        # torch-cpu-f64 to ~5 digits, as the parity suite guarantees).
-        ll = float(m.ll[-1]) / (data.shape[0] * data.shape[1])
+        # AMICA_NumPy.ll is already per-sample-per-channel normalized (issue
+        # #212), the same scale the torch/mlx backends report, so the results
+        # column is directly comparable (numpy-f64 matches torch-cpu-f64 to ~5
+        # digits, as the parity suite guarantees) with no rescaling here.
+        ll = float(m.ll[-1])
         return elapsed, ll
 
     # CPU-scaling knob (#86): cap the BLAS/OpenMP thread pool numpy's vectorized

--- a/pamica/numpy_impl/core.py
+++ b/pamica/numpy_impl/core.py
@@ -279,11 +279,11 @@ class AMICA:
         self.comp_used: Optional[np.ndarray] = None
         # Outlier rejection (do_reject), mirroring AMICATorchNG's good_idx: an
         # index array of the currently-kept samples that only ever shrinks, plus
-        # its count (num_good_samples), which normalizes gm (the model weights).
-        # self.ll stays a raw sum over the good set, not divided by the count
-        # (this backend's existing convention for both modes; unlike Fortran/
-        # torch it is un-normalized). Both None/full until fit() sets them up.
-        # numrej counts rejection passes (the maxrej budget). _last_ll_samples
+        # its count (num_good_samples), which normalizes gm (the model weights)
+        # and self.ll (see _get_updates_and_likelihood, matching Fortran's
+        # LL(iter) = LLtmp2 / dble(numgoodsum*nw), amica15.f90:1752). Both
+        # None/full until fit() sets them up. numrej counts rejection passes
+        # (the maxrej budget). _last_ll_samples
         # holds the pre-update per-sample LL that _reject_outliers thresholds
         # (captured in the E-step, applied after the parameter update, matching
         # the torch ordering).
@@ -748,6 +748,20 @@ class AMICA:
 
         if self.do_reject:
             self._last_ll_samples = np.concatenate(ll_parts)
+
+        # Normalize the accumulated total LL by (good-sample count x working
+        # dimensionality), matching Fortran's LL(iter) = LLtmp2 / dble(numgoodsum*nw)
+        # (amica15.f90:1752) at the point the full-data sum becomes available.
+        # numgoodsum is self.num_good_samples: Fortran initializes numgoodsum to
+        # all_blks (all samples) and only shrinks it under do_reject (amica15.f90:234,
+        # 2234), and self.num_good_samples mirrors that exactly (set to num_samples
+        # in _initialize_parameters, only shrunk by _reject_outliers), so this one
+        # expression is correct whether or not do_reject is set -- no branch needed.
+        # nw is the per-model working dimensionality (Fortran's numeigs, amica15.f90:545);
+        # self.data_dim is its NumPy analogue -- comp_list is (data_dim, num_models),
+        # matching Fortran's comp_list(nw, num_models) (amica15.f90:599).
+        assert self.num_good_samples is not None and self.data_dim is not None
+        updates["ll"] /= self.num_good_samples * self.data_dim
 
         return updates
 
@@ -1279,6 +1293,14 @@ class AMICA:
         dA = np.zeros_like(self.A)
         for h in range(self.num_models):
             dA[:, self.comp_list[:, h]] += self.gm[h] * updates["dWtmp"][:, :, h]
+        # NOTE (issue #212): deliberately left as-is, and it is NOT Fortran-faithful.
+        # Fortran divides dAk by zeta (the accumulated gm weights) before squaring,
+        # and masks both the sum and the divisor by comp_used (amica15.f90:1739-1743).
+        # This does neither, and empirically reports ~5.4e3 on the bundled sample
+        # where Fortran reports ~1e-5, so min_nd/use_grad_norm is unreachable in this
+        # backend for the same reason min_dll was before this fix. Correcting it needs
+        # the zeta division plus confirmation that dWtmp is the same base quantity as
+        # Fortran's dA, so it is tracked separately rather than bundled in here.
         self.nd.append(np.sqrt(np.sum(dA**2) / (self.data_dim * self.num_comps)))
 
     def _optimize(self):
@@ -1583,10 +1605,11 @@ class AMICA:
         ``reject_data``, amica17.f90:2380-2464): drop any currently-good sample
         with ``loglik < mean - rejsig*std`` (population std). Rejection is
         one-directional -- ``good_idx`` only shrinks -- and ``num_good_samples``
-        normalizes ``gm`` thereafter. (``self.ll`` stays a raw sum over the good
-        set; dropping the most-negative samples raises the sum, so the reject
-        iteration is an LL increase and does not spuriously trip the convergence
-        checks.)
+        normalizes ``gm`` and ``self.ll`` thereafter (issue #212). Dropping the
+        most-negative samples raises the mean of what remains regardless of
+        normalization (removing below-average points can only raise a mean), so
+        the reject iteration is an LL increase and does not spuriously trip the
+        convergence checks.
 
         ``self._last_ll_samples`` is this iteration's per-sample LL over the
         current good set (captured pre-update in ``_get_updates_and_likelihood``,

--- a/pamica/tests/test_numpy_reject.py
+++ b/pamica/tests/test_numpy_reject.py
@@ -87,10 +87,12 @@ def test_rejection_shrinks_good_sample_set():
 
 @pytest.mark.skipif(not _FDT.exists(), reason="sample data missing")
 def test_rejection_does_not_spuriously_stop_fit():
-    """self.ll is a raw sum over the good set (not normalized by the count), so
-    the reject iteration changes the sample count. Dropping the most-negative
-    samples raises the sum, so the fit keeps ascending across the rejection
-    rather than stopping early on a spurious LL 'decrease'."""
+    """self.ll is normalized by the good-sample count (issue #212), and the
+    reject iteration shrinks that count. Dropping the most-negative samples
+    raises the mean of what remains regardless of normalization (removing
+    below-average points can only raise a mean), so the fit keeps ascending
+    across the rejection rather than stopping early on a spurious LL
+    'decrease'."""
     data = _real_data(3000)
     model = AMICA(
         num_models=1,

--- a/pamica/tests/test_numpy_reject.py
+++ b/pamica/tests/test_numpy_reject.py
@@ -110,7 +110,7 @@ def test_rejection_does_not_spuriously_stop_fit():
     # The fit did not stop at/just after the rejection: it ran well past rejstart.
     assert len(ll) > model.rejstart + 2
     # LL after the rejection is not below LL at the rejection iteration (dropping
-    # outliers raises the raw-sum LL; no spurious descent).
+    # below-average samples raises the mean of what remains; no spurious descent).
     assert ll[-1] >= ll[model.rejstart]
 
 

--- a/pamica/tests/test_sample_data.py
+++ b/pamica/tests/test_sample_data.py
@@ -436,12 +436,14 @@ def test_numpy_llt_roundtrip(tmp_path):
 
     ``Lht[0]`` must equal ``Lt`` exactly for a single model (both are read from
     the same on-disk sequence). ``Lt.mean()`` (the per-sample total log-density,
-    summed over channels) should be close to ``model.ll[-1] / model.num_samples``
-    -- ``self.ll`` is this backend's raw (unnormalized) per-iteration sum of the
-    same per-sample quantity, so dividing by the sample count recovers the same
-    convention as ``Lt.mean()``. They are not bit-identical: ``self.ll[-1]`` is
-    the pre-update E-step likelihood of the last iteration, while the written
-    LLt is recomputed post-update, so a loose tolerance is used.
+    summed over channels) should be close to ``model.ll[-1] * model.data_dim``
+    -- ``self.ll`` is this backend's per-sample-per-channel normalized
+    per-iteration log-likelihood (issue #212, matching Fortran's
+    ``LL(iter) = LLtmp2 / dble(numgoodsum*nw)``), so multiplying back by the
+    channel count recovers the same per-sample-summed-over-channels convention
+    as ``Lt.mean()``. They are not bit-identical: ``self.ll[-1]`` is the
+    pre-update E-step likelihood of the last iteration, while the written LLt
+    is recomputed post-update, so a loose tolerance is used.
     """
     data = load_data_file(eeglab_data_file, 32, 30504, dtype=np.float32).astype(
         np.float64
@@ -464,7 +466,7 @@ def test_numpy_llt_roundtrip(tmp_path):
     assert out.Lht.shape == (1, model.num_samples)
     np.testing.assert_array_equal(out.Lht[0], out.Lt)
 
-    expected = model.ll[-1] / model.num_samples
+    expected = model.ll[-1] * model.data_dim
     np.testing.assert_allclose(out.Lt.mean(), expected, rtol=1e-2)
 
 

--- a/pamica/tests/torch_tests/test_ng_backend.py
+++ b/pamica/tests/torch_tests/test_ng_backend.py
@@ -1195,16 +1195,16 @@ def test_full_fit_parity_numpy_vs_ng(tmp_path):
 
     Measured on the sample data (issue #37): Hungarian-matched total-spatial-
     filter correlation is 1.000000 (32/32 bijective) and the per-sample-per-
-    channel LL agrees to ~1e-5. NumPy reports the *un-normalized* total LL while
-    NG reports it normalized by (n_samples * n_channels), so the NumPy value is
-    normalized here before comparing. A full fit is not bit-identical across
-    NumPy and PyTorch (float reduction order / BLAS vs ATen), hence tolerances
-    rather than exact equality.
+    channel LL agrees to ~1e-5. Both backends report the per-sample-per-channel
+    normalized LL (NumPy since issue #212, matching NG's own (n_samples *
+    n_channels) normalization), so the two are compared directly with no
+    rescaling. A full fit is not bit-identical across NumPy and PyTorch (float
+    reduction order / BLAS vs ATen), hence tolerances rather than exact
+    equality.
     """
     from scipy.optimize import linear_sum_assignment
 
     data = _load_real_data()  # (NW, FIELD) float64
-    n_samples = data.shape[1]
 
     cfg: dict[str, Any] = dict(
         block_size=512,
@@ -1242,7 +1242,7 @@ def test_full_fit_parity_numpy_vs_ng(tmp_path):
     )
     npm.fit(data)
     filt_np = npm.get_weights() @ npm.sphere
-    ll_np = npm.ll[-1] / (n_samples * NW)  # -> per-sample-per-channel, like NG
+    ll_np = npm.ll[-1]  # already per-sample-per-channel normalized (issue #212)
 
     ng = _fresh_ng(maxdecs=5, **cfg)
     ng.fit(data, max_iter=150, verbose=False)

--- a/pamica/torch_impl/core.py
+++ b/pamica/torch_impl/core.py
@@ -92,8 +92,8 @@ _EPSDBLE = 1e-16
 # restores it when the final LL falls more than this tolerance below that peak.
 # Units: mean log-likelihood per sample-channel (the same scale as Fortran's
 # min_dll, amica17.f90:1866, which normalizes LL(iter) by numgoodsum*nw before
-# comparing -- NOT the legacy NumPy pamica.min_dll, which compares un-normalized
-# summed LL), so 1e-9 reads as "numerical noise, not a real overshoot". The
+# comparing; the legacy NumPy backend's min_dll now normalizes the same way,
+# issue #212), so 1e-9 reads as "numerical noise, not a real overshoot". The
 # threshold also keeps a
 # monotone single-model run (issue #24 parity) a bit-exact no-op: its final
 # iterate already IS the best, the gap is 0 < tol, and no restore fires.


### PR DESCRIPTION
Addresses the log-likelihood half of #212. Found while implementing #207, which had assumed `numpy_impl` was the Fortran-faithful reference for the convergence criteria.

## The bug

Fortran stores a normalized per-iteration log-likelihood (`amica15.f90:1752`):

```fortran
LL(iter) = LLtmp2 / dble(numgoodsum*nw)
```

`numpy_impl` stored the raw sum. On the bundled sample `AMICA_NumPy` reported `-3317862.78` where Fortran reports about `-3.3`, a factor of roughly 1e6 (30504 samples x 32 channels). Since `min_dll` defaults to `1e-9` and is compared against `ll[-1] - ll[-2]`, `use_min_dll` could never fire from genuine convergence: the `maxincs` counter around it was correct but unreachable.

After this change, the same fit reports `ll[-1] = -3.443`.

## Why it survived

Four call sites were hand-compensating, each locally correct:

- `pamica/tests/torch_tests/test_ng_backend.py` divided by `(n_samples * NW)` before comparing backends
- `benchmarks/benchmark_dimsweep.py` divided by `(data.shape[0] * data.shape[1])` before reporting
- `pamica/tests/test_sample_data.py` divided by `num_samples` before checking against the written `LLt`

All three now compare directly. That pattern is the reason the wrong convention was invisible: nothing ever saw the raw value in a context where it looked wrong.

## Deliberately not fixed here

`self.nd` (weight-gradient norm) has the same class of defect and is **worse**: after this change it still reads ~5.4e3 where Fortran reports ~1e-5. Fortran divides `dAk` by `zeta` before squaring and masks by `comp_used` (`amica15.f90:1739-1743`); `numpy_impl` does neither. `AMICATorchNG` does both, so this is a NumPy-only divergence. Consequence: `min_nd`/`use_grad_norm` is unreachable there too, so both Fortran convergence criteria are dead in this backend rather than one.

A first attempt at the `comp_used` mask alone was reverted. It did not address the scale, which is the actual problem, and it regressed `test_newton_mstep_matches_numpy_reference` by asserting `comp_used is not None` on a path where the M-step runs before that attribute is set. A comment at the site now records the divergence instead of leaving it silently wrong. Remaining work is tracked in #212.

## Verification

- `pamica/tests/torch_tests/test_ng_backend.py`: 38 passed, including the cross-backend LL comparison that previously needed the manual rescale.
- `pamica/tests/test_numpy_reject.py`: passed; the `do_reject` reasoning still holds, since dropping below-average samples raises a mean just as it raised a sum.
- No PyTorch-side behaviour changes. The only edit to `torch_impl/core.py` is a comment correcting a now-stale claim that the NumPy backend compares un-normalized log-likelihood.