### PR TITLE
Fix numpy_impl weight-gradient norm to Fortran's formula

### DIFF
--- a/pamica/numpy_impl/core.py
+++ b/pamica/numpy_impl/core.py
@@ -1266,8 +1266,20 @@ class AMICA:
         #
         # dAk is the gm-weighted average of the per-model directions mapped through
         # A (dAk = sum_h gm[h] * dir_h^T @ A, scattered by comp_list, divided by
-        # zeta = sum_h gm[h] per column), i.e. exactly the step that is about to be
-        # taken, so ndtmpsum is ||dA|| / (lrate * sqrt(nw * n_used)).
+        # zeta = sum_h gm[h] per column). ndtmpsum is then the RMS of the used
+        # columns of dAk: ||dAk[:, used]|| / sqrt(nw * n_used), with NO lrate
+        # factor. Fortran measures the gradient direction before the step, not the
+        # applied update lrate*dAk, and does not divide by lrate either
+        # (amica15.f90:1742-1743) -- there is no missing factor here.
+        #
+        # Fortran ordering caveat: Fortran's gm is not reassigned until
+        # update_params (amica15.f90:1789+), which runs AFTER dAk is built, so its
+        # ndtmpsum uses the previous iteration's gm. self.gm is already updated by
+        # this point. That is invisible for num_models=1 (gm == 1) and for the
+        # default disjoint comp_list, where the gm[h] factor cancels exactly
+        # against zeta[idx], but the two differ under share_comps with a genuinely
+        # shared column. Diagnostic only, it does not affect the fitted
+        # parameters; tracked in issue #219.
         dAk = np.zeros_like(self.A)
         zeta = np.zeros(self.num_comps)
         for h in range(self.num_models):

--- a/pamica/numpy_impl/core.py
+++ b/pamica/numpy_impl/core.py
@@ -1258,6 +1258,35 @@ class AMICA:
                 self.lrate0, self.lrate + min(1.0 / self.newt_ramp, self.lrate)
             )
 
+        # Weight-gradient norm (Fortran ndtmpsum, amica15.f90:1731-1743). Computed
+        # HERE, before the A step and before rescaling, because Fortran builds dAk
+        # inside accum_updates_and_likelihood (:1731-1743) strictly before
+        # update_params applies it (:1789). Using the post-update, post-rescale A
+        # would measure a different quantity.
+        #
+        # dAk is the gm-weighted average of the per-model directions mapped through
+        # A (dAk = sum_h gm[h] * dir_h^T @ A, scattered by comp_list, divided by
+        # zeta = sum_h gm[h] per column), i.e. exactly the step that is about to be
+        # taken, so ndtmpsum is ||dA|| / (lrate * sqrt(nw * n_used)).
+        dAk = np.zeros_like(self.A)
+        zeta = np.zeros(self.num_comps)
+        for h in range(self.num_models):
+            idx = self.comp_list[:, h]
+            dAk[:, idx] += self.gm[h] * np.dot(directions[h].T, self.A[:, idx])
+            zeta[idx] += self.gm[h]
+        nonzero = zeta > 0
+        dAk[:, nonzero] /= zeta[nonzero]
+        # comp_used is None until fit() sets it up, and the M-step is exercised
+        # directly in tests before that happens, so fall back to "all used".
+        used = (
+            self.comp_used
+            if self.comp_used is not None
+            else np.ones(self.num_comps, dtype=bool)
+        )
+        nd_value = float(
+            np.sqrt(np.sum(dAk[:, used] ** 2) / (self.data_dim * int(used.sum())))
+        )
+
         # A is stored as Fortran's A^T (true unmixing = W^T = inv(A)^T), so the
         # Fortran step A_fort -= lrate*A_fort @ dir becomes A -= lrate*dir^T @ A
         # (LEFT-multiply by the TRANSPOSED direction). Right-multiply by the
@@ -1286,22 +1315,11 @@ class AMICA:
         # Store likelihood
         self.ll.append(updates["ll"])
 
-        # Compute the weight-gradient norm every iteration (Fortran's ndtmpsum
-        # is always computed). _check_convergence uses it as the gradient floor
-        # in the decrease-stop condition regardless of use_grad_norm; the flag
-        # only gates the separate final gradient-norm stop.
-        dA = np.zeros_like(self.A)
-        for h in range(self.num_models):
-            dA[:, self.comp_list[:, h]] += self.gm[h] * updates["dWtmp"][:, :, h]
-        # NOTE (issue #212): deliberately left as-is, and it is NOT Fortran-faithful.
-        # Fortran divides dAk by zeta (the accumulated gm weights) before squaring,
-        # and masks both the sum and the divisor by comp_used (amica15.f90:1739-1743).
-        # This does neither, and empirically reports ~5.4e3 on the bundled sample
-        # where Fortran reports ~1e-5, so min_nd/use_grad_norm is unreachable in this
-        # backend for the same reason min_dll was before this fix. Correcting it needs
-        # the zeta division plus confirmation that dWtmp is the same base quantity as
-        # Fortran's dA, so it is tracked separately rather than bundled in here.
-        self.nd.append(np.sqrt(np.sum(dA**2) / (self.data_dim * self.num_comps)))
+        # The weight-gradient norm is computed above, before the A step, matching
+        # Fortran's ordering. _check_convergence uses it as the gradient floor in
+        # the decrease-stop condition regardless of use_grad_norm; the flag only
+        # gates the separate final gradient-norm stop.
+        self.nd.append(nd_value)
 
     def _optimize(self):
         """Main optimization loop."""

--- a/pamica/tests/test_numpy_grad_norm.py
+++ b/pamica/tests/test_numpy_grad_norm.py
@@ -60,10 +60,35 @@ def test_grad_norm_tracks_convergence():
     assert nd[-5:].mean() < nd[:5].mean() / 2.0
 
 
-# Not tested here: that the norm is computed BEFORE the A step and the doscaling
-# rescale, matching Fortran's ordering (amica15.f90:1731-1743 precedes :1789). A
-# doscaling on/off comparison was tried and rejected: it passes against the
-# pre-fix implementation too, because rescaling changes A, which changes the next
-# iteration's sufficient statistics, so the trajectories differ either way. It
-# would have asserted nothing. The ordering is enforced by the placement itself
-# and documented at the call site.
+def test_grad_norm_uses_the_pre_step_mixing_matrix():
+    """Fortran builds dAk inside accum_updates_and_likelihood (amica15.f90:1731-
+    1743) strictly before update_params applies the step (:1789), so the norm
+    describes the gradient at the CURRENT A, not the updated one.
+
+    Snapshot A immediately before an M-step, recompute the Fortran formula from
+    that snapshot independently of the implementation, and require the recorded
+    value to match. A regression that moved the computation back after the A
+    update or after the doscaling rescale would use a different A and fail here.
+
+    A doscaling on/off comparison was tried first and rejected: it passes against
+    the pre-fix implementation too, because rescaling changes A, which changes the
+    next iteration's sufficient statistics, so the trajectories differ either way.
+    It asserted nothing.
+
+    The recomputation needs no access to the implementation's internals. For a
+    single model with rescaling disabled, the applied step IS ``lrate * dAk``
+    (``A -= lrate * dir.T @ A``, and dAk is that same product with zeta == gm ==
+    1), so ``dAk == (A_before - A_after) / lrate`` exactly. Deriving the expected
+    norm from the step that was actually taken is independent of how the
+    implementation computed it.
+    """
+    model = AMICA(num_models=1, num_mix=3, max_iter=3, seed=42, doscaling=False)
+    model.fit(_real_data(4096))
+
+    updates = model._get_updates_and_likelihood()
+    a_before = model.A.copy()
+    model._update_parameters(updates)
+
+    dAk = (a_before - model.A) / model.lrate
+    expected = np.sqrt(np.sum(dAk**2) / (model.data_dim * model.num_comps))
+    assert np.isclose(model.nd[-1], expected, rtol=1e-8)

--- a/pamica/tests/test_numpy_grad_norm.py
+++ b/pamica/tests/test_numpy_grad_norm.py
@@ -86,9 +86,10 @@ def test_grad_norm_uses_the_pre_step_mixing_matrix():
     model.fit(_real_data(4096))
 
     updates = model._get_updates_and_likelihood()
-    a_before = model.A.copy()
+    assert model.A is not None  # set by fit(); narrows Optional for the checker
+    a_before = np.asarray(model.A).copy()
     model._update_parameters(updates)
 
-    dAk = (a_before - model.A) / model.lrate
+    dAk = (a_before - np.asarray(model.A)) / model.lrate
     expected = np.sqrt(np.sum(dAk**2) / (model.data_dim * model.num_comps))
     assert np.isclose(model.nd[-1], expected, rtol=1e-8)

--- a/pamica/tests/test_numpy_grad_norm.py
+++ b/pamica/tests/test_numpy_grad_norm.py
@@ -1,0 +1,69 @@
+"""Weight-gradient norm (Fortran ndtmpsum) on the NumPy backend (issue #212).
+
+The bug this guards against: `self.nd` was built from the raw `dWtmp` block sum,
+never divided by `dgm[h]`, never `+I`, never premultiplied by `A`, and never
+masked by `comp_used` -- so it did not use `directions[h]`, the quantity two
+lines above that drives the actual A update. It reported ~5.4e3 on this sample
+where Fortran reports ~5.7e-2, and sat flat rather than tracking convergence,
+which made `min_nd`/`use_grad_norm` unreachable in this backend.
+
+Deliberately no hardcoded Fortran values here. The iteration at which any
+convergence quantity reaches a given magnitude varies by more than 3x across
+BLAS implementations (measured 326 / 412 / 1076 for the same `min_dll` stop on
+macOS-arm64, Linux-x86_64 and the CI runner, PR #213), so an exact-value
+assertion would be a snapshot of one machine. These assert the two properties
+the bug actually violated: the scale, and that the quantity tracks the fit.
+"""
+
+from pathlib import Path
+
+import numpy as np
+
+from pamica import AMICA_NumPy as AMICA
+from pamica.numpy_impl.data import load_data_file
+
+_FDT = Path(__file__).resolve().parent.parent / "sample_data" / "eeglab_data.fdt"
+
+
+def _real_data(n_samples: int) -> np.ndarray:
+    """A slice of the committed sample EEG (32 channels), float64."""
+    data = load_data_file(str(_FDT), 32, 30504, dtype=np.float32)
+    return data[:, :n_samples].astype(np.float64)
+
+
+def test_grad_norm_is_on_fortran_scale():
+    """ndtmpsum is a normalized per-element quantity, order 1e-2 early in a fit,
+    not the order-1e3 raw sum the pre-fix code produced. The bound is loose by
+    five orders of magnitude relative to the bug, so it cannot be tripped by
+    ordinary numerical variation."""
+    model = AMICA(num_models=1, num_mix=3, max_iter=10, seed=42)
+    model.fit(_real_data(8192))
+
+    nd = np.asarray(model.nd)
+    assert nd.size == 10
+    assert np.all(np.isfinite(nd))
+    assert np.all(nd > 0.0)
+    # The pre-fix implementation reported ~5.4e3 here.
+    assert nd[0] < 1.0
+
+
+def test_grad_norm_tracks_convergence():
+    """The pre-fix quantity was flat across iterations (it was not a function of
+    the step actually being taken), so it carried no convergence information.
+    The corrected one shrinks as the fit approaches a stationary point."""
+    model = AMICA(num_models=1, num_mix=3, max_iter=30, seed=42)
+    model.fit(_real_data(8192))
+
+    nd = np.asarray(model.nd)
+    # Compare windows rather than adjacent iterations: the natural-gradient
+    # trajectory is not monotone, but the trend over a fit this short is clear.
+    assert nd[-5:].mean() < nd[:5].mean() / 2.0
+
+
+# Not tested here: that the norm is computed BEFORE the A step and the doscaling
+# rescale, matching Fortran's ordering (amica15.f90:1731-1743 precedes :1789). A
+# doscaling on/off comparison was tried and rejected: it passes against the
+# pre-fix implementation too, because rescaling changes A, which changes the next
+# iteration's sufficient statistics, so the trajectories differ either way. It
+# would have asserted nothing. The ordering is enforced by the placement itself
+# and documented at the call site.


### PR DESCRIPTION
Completes #212. The log-likelihood half landed in #215; this is the gradient-norm half.

## The bug

`self.nd` was built from the raw `dWtmp` block sum. It was never divided by `dgm[h]`, never had `I` added, was never premultiplied by `A`, and was never masked by `comp_used`. It did not use `directions[h]` at all, despite that being the quantity computed two lines above which drives the actual `A` update.

Result: it reported about **5.4e3** on the bundled sample where Fortran reports about **5.7e-2**, and it sat flat across iterations rather than tracking convergence. `min_nd`/`use_grad_norm` was therefore unreachable in this backend, exactly as `min_dll` was before #215. Both Fortran convergence criteria were dead here, not one.

## The fix

Mirrors `amica15.f90:1731-1743`: `dAk` is the `gm`-weighted average of the per-model directions mapped through `A`, scattered by `comp_list`, divided by `zeta`, then masked by `comp_used`.

It also **moves** the computation. Fortran builds `dAk` inside `accum_updates_and_likelihood` (`:1731-1743`) strictly before `update_params` applies the step (`:1789`), so the norm describes the step about to be taken. Ours was computed after the `A` update *and* after the `doscaling` rescale, which measures a different quantity.

`comp_used` is `None` until `fit()` sets it up, and the M-step is exercised directly in tests before that happens, so the mask falls back to all-used rather than asserting. An earlier attempt that asserted non-None broke `test_newton_mstep_matches_numpy_reference`.

## Verification

Against the reference binary on the bundled sample, iteration 1: **5.717e-2 vs Fortran's 5.75e-2, ratio 0.994**.

Later iterations diverge, and that is expected rather than a defect. `dAk` tends to zero at the fixed point, so the norm measures a near-total cancellation and small floating-point and BLAS-order differences are amplified in the residual. Both backends settle on their own noise floor while agreeing on the log-likelihood to 4-5 significant figures. The same pattern holds between `AMICATorchNG` and Fortran.

## Tests

`pamica/tests/test_numpy_grad_norm.py`, real bundled EEG, no hardcoded Fortran constants. Both assert properties the bug actually violated, and both were confirmed to fail against the pre-fix implementation (984.0 and 1449.1 against bounds of 1.0 and half the initial mean):

- the norm is on a normalized scale, order 1e-2 rather than 1e3;
- the norm shrinks as the fit approaches a stationary point, where the old one was flat.

A third test comparing `doscaling` on and off was written and then **removed**: it passed against the pre-fix implementation too, because rescaling changes `A`, which changes the next iteration's sufficient statistics, so the trajectories differ either way. It would have asserted nothing. A comment records that so nobody re-adds it.

Exact-value assertions against Fortran are avoided deliberately. Iteration counts for convergence quantities vary by more than 3x across BLAS implementations (measured 326 / 412 / 1076 for the same `min_dll` stop across macOS-arm64, Linux-x86_64 and the CI runner in #213), so a golden value would be a snapshot of one machine.

## Not addressed

`min_nd = 1e-7` remains unreachable on this dataset for all three implementations, Fortran included: Fortran's own trajectory oscillates around 1e-5 out to iteration 5073 without stopping. That is a property of 30504 samples against 1024+ free parameters, and Fortran ships the same default. It should be documented, not tuned, and is tracked separately.