### PR TITLE
Handle rank-deficient input across all backends

### DIFF
--- a/.context/decisions/0004-rank-deficient-input-handling.md
+++ b/.context/decisions/0004-rank-deficient-input-handling.md
@@ -1,0 +1,96 @@
+# ADR 0004: Rank-deficient input handling and a relative eigenvalue floor
+
+**Status:** accepted
+**Date:** 2026-08-15
+**Owner:** Seyed Yahya Shirazi
+
+## Context
+
+Rank-deficient input is ordinary in EEG/MEG, not exotic: Maxwell filtering leaves
+306-channel Elekta data at numerical rank ~70, average referencing removes exactly one
+dimension, and channel interpolation removes one per interpolated channel. The Fortran
+reference handles this and pamica did not, which issue #221 surfaced from a real MEG
+analysis.
+
+Fortran detects the rank, sizes the model to it, and keeps a pseudo-inverse to map
+components back to sensors:
+
+```fortran
+numeigs = min(pcakeep, count(eigs > mineig))   ! amica15.f90:395, mineig = 1e-15
+nw = numeigs                                   ! amica15.f90:545
+allocate(Spinv(nx,numeigs))                    ! amica15.f90:550-560
+```
+
+pamica had none of the three. The symmetric ZCA sphere therefore inverted
+`sqrt(lambda ~ 0)` and the fit died at `nan_ll` on iteration 0 (issue #223).
+
+`mineig` is an **absolute** floor on covariance eigenvalues, which makes it
+unit-dependent. Two consequences measured on the bundled sample EEG:
+
+- MEG in Tesla has eigenvalues ~1e-26, entirely below 1e-15. Fortran computes
+  `numeigs = 0` and proceeds.
+- Average-referenced EEG lands at `lambda_min/lambda_max = 8.5e-17`, so whether the
+  zero dimension is detected depends on the recording's absolute scale. It is decided
+  by luck.
+
+## Decision
+
+Port all three pieces of the Fortran mechanism, and **default to a relative floor**:
+`mineig_rel = 1e-12`, applied as `mineig_rel * largest_eigenvalue`. Setting
+`mineig_rel=None` restores Fortran's absolute-only behavior exactly.
+
+The rank decision lives in `pamica/rank.py` and is called by all three array backends,
+so they cannot drift (`.rules/backend_parity.md`).
+
+`mineig_rel` **replaces** the absolute floor rather than combining with it. Taking the
+larger of the two was tried first and is wrong: a relative floor for Tesla-scale data is
+~1e-35 in absolute terms, so `max()` silently discards it and reproduces the bug.
+
+## Consequences
+
+**Parity is unaffected for well-conditioned data.** Real EEG has
+`lambda_min/lambda_max ~ 5e-4`, eight orders above the relative floor, so nothing is
+reduced and results are bit-identical (verified against the pre-change implementation
+across single-model, Newton, and two-model fits).
+
+**Results change for rank-deficient data, in the intended direction.** On real EEG
+projected to rank 20:
+
+| threshold | rank found | reconstruction error |
+|---|---|---|
+| `mineig=1e-15` (Fortran) | 24 | 1.98e-09 |
+| `mineig_rel=1e-12` (default) | 20 | 7.52e-15 |
+
+**This is a deliberate divergence from the reference**, the first where pamica's default
+is not what Fortran does. It is recorded in `docs/guides/amica-differences.md` so it
+cannot be mistaken for a parity defect.
+
+**Average-referenced EEG now yields n-1 components rather than n.** Correct, but a
+visible behavior change for existing users, since the n-th component was previously
+numerical noise from a singular sphere.
+
+**A new obligation:** `get_sensor_mixing_matrix()` is now the way to obtain scalp maps.
+`get_mixing_matrix()` still returns the sphered-space `A`, which is not projectable to
+sensors when the sphere is non-square.
+
+## Alternatives considered
+
+- **Absolute floor only, matching Fortran exactly.** Loses on MEG (rank 0) and makes
+  average-reference detection scale-dependent. Rejected: bug-compatibility with the
+  reference is not the goal, numerical agreement on valid data is.
+- **`max(mineig, mineig_rel * lambda_max)`.** Implemented first, then measured: the
+  absolute term dominates for small-scale data and reproduces the failure the relative
+  floor exists to prevent.
+- **Reduce inside the wrapper rather than the backends.** Would leave `AMICATorchNG`
+  and the other backends broken when used directly, and duplicate the policy per entry
+  point.
+- **`get_mixing_matrix()` returns sensor space when reduced.** Rejected: silently
+  switching what a method returns based on data conditioning is worse than a second,
+  explicitly-named method.
+
+## Receipts
+
+- Issue #221 (MEG report), issue #223 (parity gap), PR #224
+- `amica15.f90:395,545,483-490,550-560`; `amica15_header.f90:66`
+- `pamica/rank.py`, `pamica/tests/test_rank_policy.py`
+- `docs/guides/amica-differences.md`

--- a/.rules/backend_parity.md
+++ b/.rules/backend_parity.md
@@ -1,0 +1,76 @@
+# Backend Parity - No One-Off Implementations
+
+## Core Philosophy: One Algorithm, Four Executions
+pamica has four backends (PyTorch, NumPy, MLX, native Fortran) implementing **one**
+algorithm. A behavior that exists in one and not the others is not a feature, it is
+drift. Users pick a backend for hardware reasons and reasonably expect the same answer.
+
+## [STRICT] Behavior changes land in every backend
+A change to what the algorithm *does* must be ported to every backend that supports the
+surrounding feature, in the same PR. This is not deferred to a follow-up issue.
+
+- **DO:** Implement in all applicable backends before opening the PR
+- **DO:** Add a cross-backend test asserting they agree (see below)
+- **DON'T:** Ship "PyTorch first, others later" - the follow-up does not happen, and the
+  gap is invisible to users until it bites one
+
+### The narrow exception
+A backend may lack a behavior only when it *cannot* support it, and then:
+1. The reason is stated in the backend's module docstring
+2. The call raises `NotImplementedError` with that reason, never a silent difference
+3. The divergence is listed in `docs/guides/amica-differences.md`
+
+Existing legitimate examples: MLX has no Newton step or non-GG PDF families (both raise
+`NotImplementedError`); MLX is float32-only because Apple GPUs have no float64.
+
+"I only had time for one" is not an exception.
+
+## [STRICT] Shared decisions live in shared modules
+When backends must agree on a *decision* (not a computation), factor the decision into a
+single module they all call. Parallel reimplementations drift silently; a shared function
+cannot.
+
+- Reference: `pamica/rank.py` - numerical-rank detection, called by all three array
+  backends. Each backend still builds its own sphering matrix in its own array library,
+  because the PyTorch path is bit-exact against Fortran and must not be routed through a
+  different eigensolver. Only the *policy* is shared.
+- Rule of thumb: if the same threshold, ordering, or cap appears in two backends, it
+  belongs in one place.
+
+## Cross-backend tests are mandatory
+Every shared-behavior change needs a test that fails when the backends disagree.
+
+```python
+def test_all_backends_agree_on_the_rank(rank_deficient):
+    """Anti-drift guard: every backend must size its model identically."""
+    # PyTorch and NumPy always run, so a divergence between them cannot land.
+    # MLX uses importorskip - Apple Silicon only.
+```
+
+Pattern: `pamica/tests/test_rank_policy.py`. Put these in `pamica/tests/` (not a
+backend-specific subdirectory) so it is obvious they are not one backend's problem.
+
+Optional backends (MLX) use `pytest.importorskip`; the always-available backends must be
+compared unconditionally, or CI proves nothing.
+
+## Divergence from Fortran is allowed, silence is not
+Fortran is the correctness reference, not a ceiling. pamica may improve on it - but every
+deliberate difference is recorded in `docs/guides/amica-differences.md` with what it is,
+why, and how to restore the reference behavior. An unrecorded difference is
+indistinguishable from a parity bug, which is the thing this project most needs to be
+able to rule out.
+
+When you change a default away from the reference:
+1. Write an ADR (`.context/decisions/`)
+2. Add the row to `docs/guides/amica-differences.md`
+3. Provide the escape hatch that restores reference behavior, and test it
+4. Confirm well-conditioned data is bit-identical, and say so in the PR
+
+## Checklist
+- [ ] Implemented in every backend that can support it
+- [ ] Shared decision factored into a shared module, not copied
+- [ ] Cross-backend agreement test added
+- [ ] `NotImplementedError` (not silence) where a backend genuinely cannot
+- [ ] Divergences recorded in `docs/guides/amica-differences.md`
+- [ ] ADR written if a default now differs from Fortran
+- [ ] Full-rank / ordinary-path parity confirmed unchanged

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,9 @@ the dead `do_choose_pdfs`, #26), so it is behavior-validated (`tests/torch_tests
 - **NO MOCKS:** Validate against real sample data and the Fortran binary, never fabricated data. Details: `.rules/testing.md`.
 - **No technical debt carried forward:** Address ALL PR review findings; replace, don't deprecate. Details: `.rules/code_review.md`.
 - **Numerical parity is the spec:** Correctness means matching Fortran output within tolerance, not merely "converging".
+- **No one-off backends:** A behavior change lands in every backend that can support it, in the same PR, with a
+  cross-backend test. Deliberate divergences from Fortran are recorded in `docs/guides/amica-differences.md`.
+  Details: `.rules/backend_parity.md`.
 - **Squash merge every PR** by default; use a regular merge commit **only** for PRs coming from an epic branch (to preserve the epic's per-phase history). Never merge until CI is green.
 
 ## [NEVER DO THIS]
@@ -174,6 +177,7 @@ the dead `do_choose_pdfs`, #26), so it is behavior-validated (`tests/torch_tests
 
 ## [REFERENCE] Rules Directory
 - `.rules/testing.md` - NO MOCK policy, coverage
+- `.rules/backend_parity.md` - No one-off backends; shared decisions, cross-backend tests
 - `.rules/python.md` - UV, ruff, ty
 - `.rules/git.md` - Commit/branch conventions
 - `.rules/code_review.md` - PR review toolkit and checklist

--- a/docs/guides/amica-differences.md
+++ b/docs/guides/amica-differences.md
@@ -1,0 +1,110 @@
+# pamica vs. AMICA: every deliberate difference
+
+pamica reproduces Jason Palmer's Fortran AMICA numerically, and parity with that
+reference is how correctness is defined here. This page lists every place pamica
+**deliberately** behaves differently, why, and how to restore the reference behavior.
+
+Anything not on this page is intended to match the reference. If you find a difference
+that is not listed, that is a bug worth
+[reporting](https://github.com/sccn/pAMICA/issues) — not a documented choice.
+
+## At a glance
+
+| # | Area | Fortran AMICA | pamica default | Why | Restore reference |
+|---|---|---|---|---|---|
+| 1 | Rank threshold | absolute floor `mineig=1e-15` | relative floor `mineig_rel=1e-12` | the absolute floor is unit-dependent: MEG in Tesla yields rank 0, and average-referenced EEG is detected by luck | `mineig_rel=None` |
+| 2 | Zero numerical rank | `numeigs = 0`, continues | `ValueError` naming cause and fix | fitting a zero-dimensional model is not a recoverable state | — (no reason to want it) |
+| 3 | Returned iterate | last EM iterate | highest-likelihood iterate (`keep_best`) | the lrate schedule is non-monotone; late Newton overshoots cut LL variance 12.7x → 2.0x | `keep_best=False` |
+| 4 | Newton | on (`do_newton=1`) | off | isolates the algorithm from initialization for parity work | `do_newton=True` |
+| 5 | Degenerate fits | returns NaN sources | refuses `transform`/`get_*`/`save` | NaN sources silently poison downstream analysis | — (see ADR 0003, issue #50) |
+| 6 | Precision | float64 | float64 (float32 on Apple GPUs) | Apple GPUs have no float64; float32 agrees to ~7 significant digits, not bit-parity | `dtype=torch.float64` |
+| 7 | Sensor-space maps | `Spinv` applied internally | `get_sensor_mixing_matrix()` | `get_mixing_matrix()` returns sphered-space `A`; switching its meaning by data conditioning would be worse | — |
+
+Rows 1, 2 and 7 arrived with [ADR 0004](https://github.com/sccn/pAMICA/blob/main/.context/decisions/0004-rank-deficient-input-handling.md);
+row 3 with ADR 0003; row 5 with issue #50.
+
+## 1. Relative rank threshold (the one changed default)
+
+The reference decides how many dimensions are real with an absolute floor on covariance
+eigenvalues:
+
+```fortran
+numeigs = min(pcakeep, count(eigs > mineig))   ! amica15.f90:395, mineig = 1e-15
+```
+
+Because the floor is absolute, it depends on the physical units of the input:
+
+- **MEG in Tesla** has covariance eigenvalues ~1e-26. Every one is below `1e-15`, so the
+  reference computes `numeigs = 0`.
+- **Average-referenced EEG** — an everyday preprocessing step — sits at
+  `lambda_min/lambda_max = 8.5e-17` on the bundled sample. Whether the rank-deficient
+  dimension is caught depends on the recording's absolute scale.
+
+pamica defaults to a scale-free floor instead, `mineig_rel * largest_eigenvalue`. On real
+EEG projected to rank 20:
+
+| threshold | rank found | reconstruction error |
+|---|---|---|
+| `mineig=1e-15` (reference) | 24 | 1.98e-09 |
+| `mineig_rel=1e-12` (pamica) | 20 | 7.52e-15 |
+
+**This does not affect ordinary data.** Real EEG has `lambda_min/lambda_max ~ 5e-4`,
+eight orders of magnitude above the relative floor, so nothing is reduced and results are
+bit-identical to the reference. The difference appears only where the reference was
+already unreliable.
+
+`mineig_rel` *replaces* the absolute floor rather than combining with it — for Tesla-scale
+data a relative floor is ~1e-35 in absolute terms, so taking the larger of the two would
+silently discard it.
+
+```python
+from pamica import AMICA
+
+AMICA().fit(X)                      # relative floor (default)
+AMICA().fit(X, mineig_rel=None)     # exactly the reference's absolute floor
+AMICA().fit(X, mineig_rel=1e-9)     # stricter rank detection
+```
+
+## Working with rank-deficient data
+
+Rank deficiency is routine — Maxwell filtering, average referencing, channel
+interpolation all cause it. pamica sizes the model to the detected rank, so a
+306-channel MEG recording at rank 70 yields 70 sources, not 306.
+
+```python
+m = AMICA().fit(X)                       # X is (306, T), numerical rank ~70
+m.model_.n_channels                      # 70  - sources actually estimated
+m.model_.n_channels_in                   # 306 - input channels
+
+S = m.transform(X)                       # (70, T) sources
+A = m.model_.get_sensor_mixing_matrix()  # (306, 70) scalp maps
+```
+
+`get_mixing_matrix()` returns `A` in the sphered space. Use
+`get_sensor_mixing_matrix()` for anything sensor-shaped (topographies, dipole fitting,
+export) — when rank reduction is active the sphere is non-square and only the
+pseudo-inverse maps back.
+
+!!! warning "MEG channel types"
+    Magnetometers and gradiometers have different physical units. pamica does not yet
+    scale them for you ([issue #221](https://github.com/sccn/pAMICA/issues/221)). This
+    matters more than it looks: scaling barely affects a full-rank fit, but it decides
+    *which* directions survive rank truncation. On mixed data, badly scaled input
+    retained 72.6% of signal variance against 99.2% for correctly scaled input. Scale by
+    channel type before fitting.
+
+## Backend differences
+
+Separate from reference divergences: the optional MLX backend is a subset.
+
+| Feature | PyTorch | NumPy | MLX | Native Fortran |
+|---|---|---|---|---|
+| Newton | yes | yes | `NotImplementedError` | yes |
+| PDF families | all five | all five | GG only | all five |
+| Component sharing | yes | yes | no | yes |
+| Outlier rejection | yes | yes | no | yes |
+| Precision | f64/f32 | f64 | f32 only | f64 |
+| Rank detection | yes | yes | yes | yes (absolute floor) |
+
+MLX limitations raise `NotImplementedError` rather than differing silently, per
+`.rules/backend_parity.md`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
       - Backends & Devices: guides/backends.md
       - EEGLAB interoperability: guides/eeglab.md
       - Validation & Parity: guides/validation.md
+      - Differences vs AMICA: guides/amica-differences.md
   - API Reference:
       - Overview: api/index.md
       - AMICA: api/amica.md

--- a/pamica/amica.py
+++ b/pamica/amica.py
@@ -195,6 +195,13 @@ class AMICA:
             defaults ``True``/``1e-9``/``5``/``True``/``1e-7``) -- the
             backend's tunables are constructor arguments, not fit() kwargs.
 
+            Rank-deficient input (Maxwell-filtered MEG, average-referenced or
+            interpolated EEG) is handled by ``mineig``/``mineig_rel`` (issue
+            #223): the model is sized to the detected numerical rank and
+            :meth:`AMICATorchNG.get_sensor_mixing_matrix` maps components back
+            to input channels. ``mineig`` is an absolute eigenvalue floor and so
+            unit-dependent; pass ``mineig_rel`` for data far from unit scale.
+
         Returns
         -------
         self : AMICA

--- a/pamica/mlx_impl/core.py
+++ b/pamica/mlx_impl/core.py
@@ -39,6 +39,8 @@ import mlx.core as mx  # ty: ignore[unresolved-import]
 import numpy as np
 from scipy.special import digamma, gammaln
 
+from ..rank import MINEIG, MINEIG_REL, numerical_rank
+
 logger = logging.getLogger(__name__)
 
 _LOG2 = math.log(2.0)
@@ -108,6 +110,8 @@ class AMICAMLXNG:
         do_mean: bool = True,
         do_sphere: bool = True,
         do_approx_sphere: bool = True,
+        mineig: float = MINEIG,
+        mineig_rel: Optional[float] = MINEIG_REL,
         seed: Optional[int] = None,
     ):
         # --- Boundaries: reject the still-deferred configurations up front. ---
@@ -159,6 +163,9 @@ class AMICAMLXNG:
         self.do_mean = do_mean
         self.do_sphere = do_sphere
         self.do_approx_sphere = do_approx_sphere
+        # Numerical-rank floors (issue #223); see pamica/rank.py and ADR 0004.
+        self.mineig = mineig
+        self.mineig_rel = mineig_rel
         self.seed = seed
 
         self.iteration = 0
@@ -215,12 +222,34 @@ class AMICAMLXNG:
             order = np.argsort(evals)[::-1]
             evals = evals[order]
             evecs = evecs[:, order]
+            # Numerical rank, decided by the policy shared with the PyTorch and
+            # NumPy backends (pamica/rank.py, issue #223) so the three cannot
+            # disagree. Fortran: numeigs = min(pcakeep, count(eigs > mineig)).
+            n_comp = numerical_rank(
+                evals, mineig=self.mineig, mineig_rel=self.mineig_rel
+            )
+            evals = evals[:n_comp]
+            V = evecs[:, :n_comp]
             inv_sqrt = np.diag(1.0 / np.sqrt(evals))
-            if self.do_approx_sphere:
+            if n_comp < data_dim:
+                # Rank-reduced sphere (n_comp, data_dim), so the sphered data
+                # come out at the kept rank (Fortran nw = numeigs,
+                # amica15.f90:545).
+                w_pca = inv_sqrt @ V.T
+                if self.do_approx_sphere:
+                    # Fortran's orthogonal polar-factor symmetrization of the
+                    # reduced whitening (amica15.f90:483-490).
+                    U_b, _, Vt_b = np.linalg.svd(evecs.T[:n_comp, :n_comp])
+                    sphere = (Vt_b.T @ U_b.T) @ w_pca
+                else:
+                    sphere = w_pca
+                self.n_channels = n_comp
+                self.n_comps = n_comp * self.n_models
+            elif self.do_approx_sphere:
                 # Symmetric ZCA sphere V diag(1/sqrt) V^T (Fortran default).
-                sphere = evecs @ inv_sqrt @ evecs.T
+                sphere = V @ inv_sqrt @ V.T
             else:
-                sphere = inv_sqrt @ evecs.T
+                sphere = inv_sqrt @ V.T
             Xc = sphere @ Xc
             sldet = float(-0.5 * np.log(evals).sum())
         else:

--- a/pamica/numpy_impl/core.py
+++ b/pamica/numpy_impl/core.py
@@ -79,6 +79,7 @@ import time
 from pathlib import Path
 from typing import Dict, Optional, Tuple, Union
 from tqdm import tqdm
+from ..rank import MINEIG, MINEIG_REL, numerical_rank
 from .utils import (
     gammaln,
     determine_block_size,
@@ -219,6 +220,9 @@ class AMICA:
         self.do_approx_sphere = params.get("do_approx_sphere", True)
         self.pcakeep = params.get("pcakeep")
         self.pcadb = params.get("pcadb")
+        # Numerical-rank floors (issue #223); see pamica/rank.py and ADR 0004.
+        self.mineig = params.get("mineig", MINEIG)
+        self.mineig_rel = params.get("mineig_rel", MINEIG_REL)
         self.writestep = params.get("writestep", 100)
         self.max_decs = params.get("max_decs", 5)
         # Consecutive small-increase iterations tolerated before stopping
@@ -359,6 +363,32 @@ class AMICA:
             An unfitted model configured from the parameter file.
         """
         return cls(params_file=params_file, **kwargs)
+
+    @property
+    def data_dim_in(self) -> int:
+        """Input channel count, i.e. the width of the sphere.
+
+        Differs from ``data_dim`` only when rank reduction shrank the model to
+        the detected numerical rank (issue #223). Derived rather than stored, so
+        it cannot drift from the sphere it describes. Mirrors
+        ``AMICATorchNG.n_channels_in``.
+        """
+        if self.sphere is None:
+            return self.data_dim if self.data_dim is not None else 0
+        return int(self.sphere.shape[1])
+
+    def get_sensor_mixing_matrix(self, model_idx: int = 0) -> np.ndarray:
+        """Mixing matrix mapped back to input-channel space.
+
+        ``pinv(sphere) @ A``, of shape ``(data_dim_in, data_dim)`` -- the Fortran
+        ``Spinv`` mapping (amica15.f90:550-560), and the only way to recover
+        sensor maps when rank reduction has made the sphere non-square
+        (issue #223). Mirrors ``AMICATorchNG.get_sensor_mixing_matrix``.
+        """
+        if self.sphere is None or self.A is None or self.comp_list is None:
+            raise RuntimeError("Model has not been fitted yet; call fit() first.")
+        A = self.A[:, self.comp_list[:, model_idx]]
+        return np.linalg.pinv(self.sphere) @ A
 
     def get_weights(self) -> np.ndarray:
         """
@@ -501,19 +531,36 @@ class AMICA:
             evals = evals[idx]
             evecs = evecs[:, idx]
 
-            # Determine number of components to keep
-            if self.pcakeep is not None:
-                n_comp = min(self.pcakeep, len(evals))
-            elif self.pcadb is not None:
-                db = 10 * np.log10(evals / evals[0])
-                n_comp = np.sum(db > -self.pcadb)
-            else:
-                n_comp = len(evals)
+            # Numerical rank + explicit PCA reduction, decided by the policy
+            # shared with the PyTorch and MLX backends (pamica/rank.py, issue
+            # #223) so the three cannot disagree about how many dimensions are
+            # real. Fortran: numeigs = min(pcakeep, count(eigs > mineig)).
+            n_comp = numerical_rank(
+                evals,
+                mineig=self.mineig,
+                mineig_rel=self.mineig_rel,
+                pcakeep=self.pcakeep,
+                pcadb=self.pcadb,
+            )
 
             V = evecs[:, :n_comp]
             inv_sqrt = np.diag(1.0 / np.sqrt(evals[:n_comp]))
             # Create sphering matrix
-            if self.do_approx_sphere:
+            if n_comp < self.data_dim:
+                # Rank-reduced: the sphere is (n_comp, data_dim), so the sphered
+                # data come out at the kept rank instead of staying
+                # rank-deficient at full width (Fortran nw = numeigs,
+                # amica15.f90:545).
+                w_pca = inv_sqrt @ V.T
+                if self.do_approx_sphere:
+                    # Fortran symmetrizes the reduced whitening by the orthogonal
+                    # polar factor of the leading n_comp block of V^T
+                    # (amica15.f90:483-490).
+                    U_b, _, Vt_b = np.linalg.svd(evecs.T[:n_comp, :n_comp])
+                    self.sphere = (Vt_b.T @ U_b.T) @ w_pca
+                else:
+                    self.sphere = w_pca
+            elif self.do_approx_sphere:
                 # Symmetric ZCA sphere V diag(1/sqrt(eval)) V^T (Fortran
                 # do_approx_sphere=True, amica17.f90:480-481) -- the parity form.
                 # The old diag(1/sqrt)@V^T (PCA whitening) is a different,
@@ -522,6 +569,25 @@ class AMICA:
             else:
                 # Non-symmetric PCA whitening D^-1/2 V^T (amica17.f90:495).
                 self.sphere = inv_sqrt @ V.T
+
+            # Rank reduction shrank the sphered space: size the model to the
+            # kept rank before _initialize_parameters allocates against
+            # data_dim (Fortran nw = numeigs, amica15.f90:545). No-op, and so
+            # bit-exact, for full-rank data.
+            n_kept = self.sphere.shape[0]
+            if n_kept != self.data_dim:
+                self.logger.info(
+                    "Data covariance has numerical rank %d of %d; fitting %d "
+                    "sources and mapping back via the sphere pseudo-inverse.",
+                    n_kept,
+                    self.data_dim,
+                    n_kept,
+                )
+                if self.num_comps == self.data_dim * self.num_models:
+                    # num_comps was derived from the channel count, so it follows
+                    # the rank; an explicitly configured num_comps is left alone.
+                    self.num_comps = n_kept * self.num_models
+                self.data_dim = n_kept
 
             # Apply sphering
             data = np.dot(self.sphere, data)

--- a/pamica/rank.py
+++ b/pamica/rank.py
@@ -1,0 +1,104 @@
+"""Numerical-rank policy shared by every pamica backend (issue #223).
+
+The Fortran reference detects the numerical rank of the data covariance and
+sizes the model to it::
+
+    numeigs = min(pcakeep, count(eigs > mineig))    ! amica15.f90:395
+    nw = numeigs                                    ! amica15.f90:545
+
+Rank-deficient input is ordinary in this field -- Maxwell-filtered MEG, average
+referencing, channel interpolation all produce it -- so every backend needs the
+same answer for "how many dimensions are real?". That decision lives here rather
+than being reimplemented per backend, so the backends cannot drift apart
+(``.rules/backend_parity.md``).
+
+Only the *decision* is shared. Each backend builds its own sphering matrix in its
+own array library, because the PyTorch path is bit-exact against Fortran and must
+not be routed through a different eigensolver.
+"""
+
+from typing import Optional
+
+import numpy as np
+import numpy.typing as npt
+
+# Fortran's absolute covariance-eigenvalue floor (amica15_header.f90:66).
+MINEIG = 1e-15
+
+# pamica's relative floor, applied as ``mineig_rel * largest_eigenvalue``. On by
+# default, unlike Fortran, which has no relative option; see ADR 0004 and
+# ``docs/guides/amica-differences.md``.
+MINEIG_REL = 1e-12
+
+
+def numerical_rank(
+    evals: npt.ArrayLike,
+    *,
+    mineig: float = MINEIG,
+    mineig_rel: Optional[float] = MINEIG_REL,
+    pcakeep: Optional[int] = None,
+    pcadb: Optional[float] = None,
+) -> int:
+    """Number of data-covariance eigen-directions to keep.
+
+    Parameters
+    ----------
+    evals : array_like
+        Covariance eigenvalues in **descending** order.
+    mineig : float
+        Absolute eigenvalue floor (Fortran ``mineig``). Used only when
+        ``mineig_rel`` is ``None``.
+    mineig_rel : float or None
+        Relative floor, as a fraction of the largest eigenvalue. When set (the
+        default) it *replaces* ``mineig`` rather than combining with it: a
+        relative floor for MEG in Tesla lands near 1e-35 in absolute terms, so
+        taking the larger of the two would silently discard it. Pass ``None`` to
+        reproduce Fortran's absolute-only behavior exactly.
+    pcakeep, pcadb : int or float, optional
+        Explicit PCA reduction, capped by the detected rank
+        (Fortran ``min(pcakeep, ...)``).
+
+    Returns
+    -------
+    int
+        Dimensions to keep; never greater than ``len(evals)``.
+
+    Raises
+    ------
+    ValueError
+        If no eigenvalue clears the threshold, so there is nothing to
+        decompose. Fortran would compute ``numeigs = 0`` and carry on into
+        undefined behavior.
+    """
+    ev = np.asarray(evals, dtype=np.float64)
+    if ev.ndim != 1 or ev.size == 0:
+        raise ValueError(
+            f"evals must be a non-empty 1-D sequence, got shape {ev.shape}"
+        )
+
+    if not np.isfinite(ev).all():
+        # NaN/Inf in the data. Rank detection is meaningless, and `nan > thresh`
+        # is False, which would masquerade as rank zero. Keep every dimension and
+        # let the caller's degenerate-fit handling report the real problem
+        # (issue #50: `nan_ll`, model marked unusable) rather than raising a
+        # different error from preprocessing.
+        return int(ev.size)
+
+    thresh = mineig if mineig_rel is None else mineig_rel * float(ev[0])
+    n_rank = int((ev > thresh).sum())
+    if n_rank < 1:
+        raise ValueError(
+            f"No data covariance eigenvalue exceeds the rank threshold "
+            f"{thresh:g} (largest is {float(ev[0]):g}), so the numerical rank is "
+            "zero and there is nothing to decompose. With mineig_rel=None the "
+            "threshold is the absolute Fortran floor, which is unit-dependent: "
+            "MEG in Tesla gives eigenvalues ~1e-26 and falls below it. Rescale "
+            "the data, or set mineig/mineig_rel to suit its units."
+        )
+
+    if pcakeep is not None:
+        return min(int(pcakeep), n_rank)
+    if pcadb is not None:
+        db = 10.0 * np.log10(ev / ev[0])
+        return min(int((db > -pcadb).sum()), n_rank)
+    return n_rank

--- a/pamica/tests/test_rank_policy.py
+++ b/pamica/tests/test_rank_policy.py
@@ -1,0 +1,129 @@
+"""Shared numerical-rank policy (issue #223, ADR 0004).
+
+Rank detection is one decision used by three backends, so it lives in
+``pamica.rank`` and is tested once here. The cross-backend test at the bottom is
+the anti-drift guard required by ``.rules/backend_parity.md``: it fails if any
+backend starts answering "how many dimensions are real?" differently.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from pamica.rank import MINEIG, MINEIG_REL, numerical_rank
+from pamica.torch_impl.utils import load_eeglab_data
+
+SAMPLE_DIR = Path(__file__).resolve().parent.parent / "sample_data"
+DATA_FILE = SAMPLE_DIR / "eeglab_data.fdt"
+NW = 32
+FIELD = 30504
+RANK = 20
+
+
+@pytest.fixture(scope="module")
+def real_data() -> np.ndarray:
+    if not DATA_FILE.exists():
+        pytest.skip("sample data missing")
+    X = load_eeglab_data(str(DATA_FILE), data_dim=NW, field_dim=FIELD).astype(
+        np.float64
+    )
+    return X - X.mean(axis=1, keepdims=True)
+
+
+@pytest.fixture(scope="module")
+def rank_deficient(real_data: np.ndarray) -> np.ndarray:
+    U = np.linalg.svd(real_data, full_matrices=False)[0][:, :RANK]
+    return U @ (U.T @ real_data)
+
+
+def _cov_eigenvalues(X: np.ndarray) -> np.ndarray:
+    return np.linalg.eigvalsh(np.cov(X, bias=True))[::-1]
+
+
+def test_full_rank_data_keeps_every_dimension(real_data: np.ndarray) -> None:
+    ev = _cov_eigenvalues(real_data)
+    # Real EEG is well conditioned (lambda_min/lambda_max ~ 5e-4), far above
+    # either floor, so the default cannot silently reduce it.
+    assert ev[-1] / ev[0] > 1e-6
+    assert numerical_rank(ev) == NW
+    assert numerical_rank(ev, mineig_rel=None) == NW
+
+
+def test_relative_floor_finds_the_true_rank(rank_deficient: np.ndarray) -> None:
+    assert numerical_rank(_cov_eigenvalues(rank_deficient)) == RANK
+
+
+def test_absolute_floor_over_retains(rank_deficient: np.ndarray) -> None:
+    """Fortran's absolute floor lands amid the numerical-zero eigenvalues."""
+    assert numerical_rank(_cov_eigenvalues(rank_deficient), mineig_rel=None) > RANK
+
+
+def test_average_reference_costs_exactly_one_dimension(
+    real_data: np.ndarray,
+) -> None:
+    """Average referencing is rank-deficient by construction.
+
+    This is the everyday EEG case, not an exotic one: the relative floor detects
+    it, while the absolute floor sits within a factor of ~10 of the resulting
+    eigenvalue and so decides it by luck.
+    """
+    avg_ref = real_data - real_data.mean(axis=0, keepdims=True)
+    assert numerical_rank(_cov_eigenvalues(avg_ref)) == NW - 1
+
+
+def test_scale_invariance_of_the_relative_floor(real_data: np.ndarray) -> None:
+    """Rescaling the data must not change how many dimensions are real."""
+    for scale in (1e-13, 1.0, 1e6):
+        assert numerical_rank(_cov_eigenvalues(real_data * scale)) == NW
+
+
+def test_absolute_floor_is_not_scale_invariant(real_data: np.ndarray) -> None:
+    """The documented reason the default diverges from Fortran."""
+    with pytest.raises(ValueError, match="numerical rank is zero"):
+        numerical_rank(_cov_eigenvalues(real_data * 1e-13), mineig_rel=None)
+
+
+def test_pcakeep_is_capped_by_the_detected_rank(
+    rank_deficient: np.ndarray,
+) -> None:
+    ev = _cov_eigenvalues(rank_deficient)
+    assert numerical_rank(ev, pcakeep=10) == 10
+    # Fortran's min(): asking for more than exists still yields the real rank.
+    assert numerical_rank(ev, pcakeep=NW) == RANK
+
+
+def test_non_finite_eigenvalues_keep_full_dimension() -> None:
+    """NaN data must reach the degenerate-fit contract, not raise here (#50)."""
+    assert numerical_rank(np.array([np.nan, np.nan, np.nan])) == 3
+
+
+def test_defaults_match_the_documented_constants() -> None:
+    assert MINEIG == 1e-15  # Fortran amica15_header.f90:66
+    assert MINEIG_REL == 1e-12
+
+
+def test_all_backends_agree_on_the_rank(rank_deficient: np.ndarray) -> None:
+    """Anti-drift guard: every backend must size its model identically.
+
+    MLX is skipped when unavailable (Apple Silicon only), but PyTorch and NumPy
+    always run, so a divergence between the two cannot land.
+    """
+    from pamica import AMICA, AMICA_NumPy
+
+    torch_model = AMICA(verbose=False)
+    torch_model.fit(rank_deficient, max_iter=3, seed=0)
+    assert torch_model.model_ is not None
+    assert torch_model.model_.n_channels == RANK
+
+    numpy_model = AMICA_NumPy(num_models=1, max_iter=3, use_tqdm=False)
+    numpy_model.fit(rank_deficient)
+    assert numpy_model.data_dim == RANK
+    assert numpy_model.data_dim_in == NW
+
+    mlx_core = pytest.importorskip(
+        "pamica.mlx_impl.core", reason="MLX not installed (Apple Silicon only)"
+    )
+    mlx_model = mlx_core.AMICAMLXNG(n_channels=NW, seed=0)
+    mlx_model.fit(rank_deficient.astype(np.float32), max_iter=3)
+    assert mlx_model.n_channels == RANK

--- a/pamica/tests/torch_tests/test_ng_rank_deficient.py
+++ b/pamica/tests/torch_tests/test_ng_rank_deficient.py
@@ -77,19 +77,27 @@ def test_rank_deficient_fits_instead_of_going_degenerate(
     assert tuple(m.model_.sphere.shape) == (m.model_.n_channels, NW)
 
 
-def test_relative_threshold_recovers_the_exact_rank(
+def test_default_relative_threshold_recovers_the_exact_rank(
     rank_deficient: np.ndarray,
 ) -> None:
-    """``mineig_rel`` is scale-free, so it finds the true rank exactly.
-
-    The Fortran-faithful absolute ``mineig`` floor sits in the middle of the
-    numerical-zero eigenvalues (~1e-16 to 1e-14) and so over-retains; the
-    relative floor does not. Default stays absolute for parity.
-    """
+    """The default scale-free floor finds the true rank exactly (ADR 0004)."""
     m = AMICA(verbose=False)
-    m.fit(rank_deficient, max_iter=10, seed=0, mineig_rel=1e-9)
+    m.fit(rank_deficient, max_iter=10, seed=0)
     assert m.model_ is not None
     assert m.model_.n_channels == RANK
+
+
+def test_fortran_absolute_floor_over_retains(rank_deficient: np.ndarray) -> None:
+    """``mineig_rel=None`` restores Fortran's absolute floor, warts included.
+
+    That floor sits amid the numerical-zero eigenvalues (~1e-16 to 1e-14), so it
+    keeps directions that carry no signal. Pinned here because it is the
+    documented reason pamica's default diverges from the reference.
+    """
+    m = AMICA(verbose=False)
+    m.fit(rank_deficient, max_iter=10, seed=0, mineig_rel=None)
+    assert m.model_ is not None
+    assert m.model_.n_channels > RANK
 
 
 def test_sensor_mixing_matrix_reconstructs_the_input(
@@ -97,7 +105,7 @@ def test_sensor_mixing_matrix_reconstructs_the_input(
 ) -> None:
     """``pinv(sphere) @ A`` maps the decomposition back to input channels."""
     m = AMICA(verbose=False)
-    m.fit(rank_deficient, max_iter=15, seed=0, mineig_rel=1e-9)
+    m.fit(rank_deficient, max_iter=15, seed=0)
     assert m.model_ is not None
     A = m.model_.get_sensor_mixing_matrix()
     S = m.transform(rank_deficient)
@@ -127,25 +135,24 @@ def test_pcakeep_with_pca_whitening_no_longer_crashes(
     assert tuple(m.model_.sphere.shape) == (RANK, NW)
 
 
-def test_zero_rank_raises_rather_than_producing_nans(real_data: np.ndarray) -> None:
-    """MEG in Tesla puts every eigenvalue under the absolute floor.
-
-    Fortran would set ``numeigs = 0``; we refuse with an actionable message
-    instead of fitting an empty model.
-    """
-    with pytest.raises(ValueError, match="numerical rank is zero"):
-        AMICA(verbose=False).fit(real_data * 1e-13, max_iter=5, seed=0)
-
-
-def test_tesla_scale_data_fits_with_relative_threshold(
-    real_data: np.ndarray,
-) -> None:
-    """The scale-free floor makes MEG-magnitude input work without rescaling."""
+def test_tesla_scale_data_fits_by_default(real_data: np.ndarray) -> None:
+    """MEG-magnitude input works without rescaling under the default floor."""
     m = AMICA(verbose=False)
-    m.fit(real_data * 1e-13, max_iter=5, seed=0, mineig_rel=1e-9)
+    m.fit(real_data * 1e-13, max_iter=5, seed=0)
     assert m.model_ is not None
     assert m.converged_
     assert m.model_.n_channels == NW
+
+
+def test_absolute_floor_rejects_tesla_scale_data(real_data: np.ndarray) -> None:
+    """Under Fortran's absolute floor every Tesla-scale eigenvalue is "zero".
+
+    Fortran computes ``numeigs = 0`` and proceeds; we refuse with a message
+    naming the cause and the fix. This is the failure mode the default relative
+    floor exists to avoid.
+    """
+    with pytest.raises(ValueError, match="numerical rank is zero"):
+        AMICA(verbose=False).fit(real_data * 1e-13, max_iter=5, seed=0, mineig_rel=None)
 
 
 def test_nan_data_still_reaches_the_degenerate_fit_contract(

--- a/pamica/tests/torch_tests/test_ng_rank_deficient.py
+++ b/pamica/tests/torch_tests/test_ng_rank_deficient.py
@@ -1,0 +1,148 @@
+"""Rank-deficient input handling (issue #223) for AMICATorchNG.
+
+Ports the Fortran reference's numerical-rank machinery, which pamica had
+dropped: ``numeigs = min(pcakeep, count(eigs > mineig))`` (amica15.f90:395),
+``nw = numeigs`` sizing the model to the kept rank (amica15.f90:545), and the
+sphere pseudo-inverse ``Spinv`` for mapping components back to sensor space
+(amica15.f90:550-560).
+
+Rank deficiency is produced by projecting the real sample EEG onto its own
+leading subspace -- the same rank-reducing linear operator Maxwell filtering
+applies to MEG. The data stay real throughout; only the rank is reduced.
+
+Full-rank behavior must be byte-for-byte unchanged, since ``mineig`` keeps every
+eigenvalue of well-conditioned data.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from pamica.amica import AMICA
+from pamica.torch_impl.utils import load_eeglab_data
+
+SAMPLE_DIR = Path(__file__).resolve().parents[2] / "sample_data"
+DATA_FILE = SAMPLE_DIR / "eeglab_data.fdt"
+NW = 32
+FIELD = 30504
+RANK = 20
+
+
+@pytest.fixture(scope="module")
+def real_data() -> np.ndarray:
+    if not DATA_FILE.exists():
+        pytest.skip("sample data missing")
+    X = load_eeglab_data(str(DATA_FILE), data_dim=NW, field_dim=FIELD).astype(
+        np.float64
+    )
+    return X - X.mean(axis=1, keepdims=True)
+
+
+@pytest.fixture(scope="module")
+def rank_deficient(real_data: np.ndarray) -> np.ndarray:
+    """Real EEG projected onto its top-``RANK`` subspace (what SSS does to MEG)."""
+    U = np.linalg.svd(real_data, full_matrices=False)[0][:, :RANK]
+    return U @ (U.T @ real_data)
+
+
+def test_full_rank_model_dimension_unchanged(real_data: np.ndarray) -> None:
+    """mineig keeps every eigenvalue of full-rank data, so nothing is reduced."""
+    m = AMICA(verbose=False)
+    m.fit(real_data, max_iter=5, seed=0)
+    assert m.model_ is not None
+    assert m.model_.sphere is not None
+    assert m.model_.n_channels == NW
+    assert m.model_.n_channels_in == NW
+    assert tuple(m.model_.sphere.shape) == (NW, NW)
+
+
+def test_rank_deficient_fits_instead_of_going_degenerate(
+    rank_deficient: np.ndarray,
+) -> None:
+    """Before #223 this stopped at ``nan_ll`` on iteration 0.
+
+    The symmetric ZCA sphere inverts ``sqrt(lambda ~ 0)`` in the null
+    directions; detecting the rank first avoids ever forming those rows.
+    """
+    m = AMICA(verbose=False)
+    m.fit(rank_deficient, max_iter=15, seed=0)
+    assert m.model_ is not None
+    assert m.converged_, f"degenerate fit: {m.stop_reason_}"
+    assert m.stop_reason_ != "nan_ll"
+    # Model sized to the kept rank, not the input channel count.
+    assert m.model_.sphere is not None
+    assert m.model_.n_channels < NW
+    assert m.model_.n_channels_in == NW
+    assert tuple(m.model_.sphere.shape) == (m.model_.n_channels, NW)
+
+
+def test_relative_threshold_recovers_the_exact_rank(
+    rank_deficient: np.ndarray,
+) -> None:
+    """``mineig_rel`` is scale-free, so it finds the true rank exactly.
+
+    The Fortran-faithful absolute ``mineig`` floor sits in the middle of the
+    numerical-zero eigenvalues (~1e-16 to 1e-14) and so over-retains; the
+    relative floor does not. Default stays absolute for parity.
+    """
+    m = AMICA(verbose=False)
+    m.fit(rank_deficient, max_iter=10, seed=0, mineig_rel=1e-9)
+    assert m.model_ is not None
+    assert m.model_.n_channels == RANK
+
+
+def test_sensor_mixing_matrix_reconstructs_the_input(
+    rank_deficient: np.ndarray,
+) -> None:
+    """``pinv(sphere) @ A`` maps the decomposition back to input channels."""
+    m = AMICA(verbose=False)
+    m.fit(rank_deficient, max_iter=15, seed=0, mineig_rel=1e-9)
+    assert m.model_ is not None
+    A = m.model_.get_sensor_mixing_matrix()
+    S = m.transform(rank_deficient)
+    assert A.shape == (NW, RANK)
+    assert S.shape == (RANK, rank_deficient.shape[1])
+
+    assert m.model_.mean is not None
+    mean = m.model_.mean.cpu().numpy()
+    recon = A @ S + mean
+    rel = np.abs(rank_deficient - recon).max() / np.abs(rank_deficient).max()
+    assert rel < 1e-10, f"reconstruction error {rel:.3e}"
+
+
+def test_pcakeep_with_pca_whitening_no_longer_crashes(
+    rank_deficient: np.ndarray,
+) -> None:
+    """Regression: ``pcakeep`` + ``do_approx_sphere=False`` raised a shape error.
+
+    ``_preprocess`` returned ``(pcakeep, T)`` while every parameter was still
+    sized to the input channel count.
+    """
+    m = AMICA(verbose=False)
+    m.fit(rank_deficient, max_iter=5, seed=0, pcakeep=RANK, do_approx_sphere=False)
+    assert m.model_ is not None
+    assert m.model_.sphere is not None
+    assert m.model_.n_channels == RANK
+    assert tuple(m.model_.sphere.shape) == (RANK, NW)
+
+
+def test_zero_rank_raises_rather_than_producing_nans(real_data: np.ndarray) -> None:
+    """MEG in Tesla puts every eigenvalue under the absolute floor.
+
+    Fortran would set ``numeigs = 0``; we refuse with an actionable message
+    instead of fitting an empty model.
+    """
+    with pytest.raises(ValueError, match="numerical rank is zero"):
+        AMICA(verbose=False).fit(real_data * 1e-13, max_iter=5, seed=0)
+
+
+def test_tesla_scale_data_fits_with_relative_threshold(
+    real_data: np.ndarray,
+) -> None:
+    """The scale-free floor makes MEG-magnitude input work without rescaling."""
+    m = AMICA(verbose=False)
+    m.fit(real_data * 1e-13, max_iter=5, seed=0, mineig_rel=1e-9)
+    assert m.model_ is not None
+    assert m.converged_
+    assert m.model_.n_channels == NW

--- a/pamica/tests/torch_tests/test_ng_rank_deficient.py
+++ b/pamica/tests/torch_tests/test_ng_rank_deficient.py
@@ -146,3 +146,22 @@ def test_tesla_scale_data_fits_with_relative_threshold(
     assert m.model_ is not None
     assert m.converged_
     assert m.model_.n_channels == NW
+
+
+def test_nan_data_still_reaches_the_degenerate_fit_contract(
+    real_data: np.ndarray,
+) -> None:
+    """Rank detection must not intercept unusable data (issue #50).
+
+    A NaN makes every covariance eigenvalue non-finite, and ``nan > thresh`` is
+    False, which would look like rank zero. That must not become a ``ValueError``
+    from preprocessing: the documented behavior is a ``nan_ll`` stop with the
+    model marked unusable.
+    """
+    bad = real_data[:, :4096].copy()
+    bad[0, 0] = np.nan
+    m = AMICA(n_models=1, device="cpu", verbose=False)
+    m.fit(bad, max_iter=3, block_size=1024, seed=0)
+    assert m.stop_reason_ == "nan_ll"
+    assert m.converged_ is False
+    assert m.is_fitted_ is False

--- a/pamica/torch_impl/core.py
+++ b/pamica/torch_impl/core.py
@@ -563,10 +563,6 @@ class AMICATorchNG:
         self.n_models = n_models
         self.n_mix = n_mix
         self.n_comps = n_channels * n_models
-        # Original input channel count, kept when rank reduction shrinks
-        # n_channels to the kept rank (issue #223). Equal to n_channels
-        # whenever the data is full rank.
-        self.n_channels_in = n_channels
         self.mineig = mineig
         self.mineig_rel = mineig_rel
         self.block_size = block_size
@@ -908,7 +904,6 @@ class AMICATorchNG:
         # (Fortran ``nw = numeigs``, amica15.f90:545). No-op, and therefore
         # bit-exact, whenever the data are full rank.
         n_kept = sphere.shape[0]
-        self.n_channels_in = data_dim
         if n_kept != self.n_channels:
             logger.info(
                 "Data covariance has numerical rank %d of %d; fitting %d "
@@ -2351,6 +2346,17 @@ class AMICATorchNG:
         self._check_model_idx(model_idx)
         return self.A[:, self.comp_list[:, model_idx]].T.cpu().numpy()
 
+    @property
+    def n_channels_in(self) -> int:
+        """Input channel count, i.e. the width of the sphere.
+
+        Differs from ``n_channels`` only when rank reduction shrank the model to
+        the detected numerical rank (issue #223); equal to it for full-rank data
+        and before :meth:`fit`. Derived rather than stored, so it cannot drift
+        from the sphere it describes.
+        """
+        return self.n_channels if self.sphere is None else int(self.sphere.shape[1])
+
     def get_sensor_mixing_matrix(self, model_idx: int = 0) -> np.ndarray:
         """Mixing matrix mapped back to input-channel space.
 
@@ -2917,7 +2923,6 @@ class AMICATorchNG:
             "pcadb": self.pcadb,
             "mineig": self.mineig,
             "mineig_rel": self.mineig_rel,
-            "n_channels_in": self.n_channels_in,
             "seed": self.seed,
             # Store dtype by name (e.g. "float64") to keep the payload
             # weights_only-safe; rebuilt via getattr(torch, ...) on load.

--- a/pamica/torch_impl/core.py
+++ b/pamica/torch_impl/core.py
@@ -54,6 +54,7 @@ from tqdm import tqdm
 
 from ..metrics import mir as mir_metric
 from ..metrics import pairwise_mi
+from ..rank import MINEIG, MINEIG_REL, numerical_rank
 from .utils import setup_device
 
 logger = logging.getLogger(__name__)
@@ -553,8 +554,8 @@ class AMICATorchNG:
         do_approx_sphere: bool = True,
         pcakeep: Optional[int] = None,
         pcadb: Optional[float] = None,
-        mineig: float = 1e-15,
-        mineig_rel: Optional[float] = None,
+        mineig: float = MINEIG,
+        mineig_rel: Optional[float] = MINEIG_REL,
         seed: Optional[int] = None,
         device: Optional[Union[str, torch.device]] = None,
         dtype: torch.dtype = torch.float64,
@@ -817,49 +818,17 @@ class AMICATorchNG:
             evals = evals[order]
             evecs = evecs[:, order]
 
-            # Numerical-rank detection, Fortran amica15.f90:395
-            #   numeigs = min(pcakeep, count(eigs > mineig))
-            # mineig is an *absolute* covariance-eigenvalue floor (1e-15,
-            # amica15_header.f90:66), so it is unit-dependent: EEG in microvolts
-            # gives eigenvalues of order 1-100 and the default behaves, but MEG
-            # in Tesla gives ~1e-26 and every eigenvalue falls below it. The
-            # absolute form is the parity-faithful default; mineig_rel adds an
-            # opt-in scale-free floor on top (issue #223).
-            # mineig_rel *replaces* the absolute floor rather than being combined
-            # with it: for MEG in Tesla a relative floor is ~1e-35 in absolute
-            # terms, so a max() against 1e-15 would silently ignore it.
-            thresh = (
-                self.mineig
-                if self.mineig_rel is None
-                else self.mineig_rel * float(evals[0])
+            # Numerical-rank detection (Fortran amica15.f90:395). The policy is
+            # shared with the NumPy and MLX backends so they cannot drift
+            # (pamica/rank.py); only the eigenvalues cross the boundary, as a
+            # read-only copy, so the sphere below stays bit-exact.
+            n_comp = numerical_rank(
+                evals.cpu().numpy(),
+                mineig=self.mineig,
+                mineig_rel=self.mineig_rel,
+                pcakeep=self.pcakeep,
+                pcadb=self.pcadb,
             )
-            if not bool(torch.isfinite(evals).all()):
-                # Non-finite covariance (NaN/Inf in the data). Rank detection is
-                # meaningless here and `nan > thresh` is False, which would
-                # otherwise look like rank zero. Leave the dimension alone and
-                # let the fit reach the degenerate-fit contract (issue #50),
-                # which reports `nan_ll` and refuses output -- that is the
-                # documented behavior for unusable data, not an exception here.
-                n_rank = evals.shape[0]
-            else:
-                n_rank = int((evals > thresh).sum().item())
-            if n_rank < 1:
-                raise ValueError(
-                    f"No data covariance eigenvalue exceeds mineig={thresh:g} "
-                    f"(largest is {float(evals[0]):g}), so the numerical rank is "
-                    "zero and there is nothing to decompose. This usually means "
-                    "the data are on a very small physical scale (e.g. MEG in "
-                    "Tesla, where eigenvalues run ~1e-26): rescale the data, or "
-                    "set mineig/mineig_rel to a threshold suited to its units."
-                )
-
-            if self.pcakeep is not None:
-                n_comp = min(self.pcakeep, n_rank)
-            elif self.pcadb is not None:
-                db = 10.0 * torch.log10(evals / evals[0])
-                n_comp = min(int((db > -self.pcadb).sum().item()), n_rank)
-            else:
-                n_comp = n_rank
 
             V = evecs[:, :n_comp]
             inv_sqrt = torch.diag(1.0 / torch.sqrt(evals[:n_comp]))

--- a/pamica/torch_impl/core.py
+++ b/pamica/torch_impl/core.py
@@ -833,7 +833,16 @@ class AMICATorchNG:
                 if self.mineig_rel is None
                 else self.mineig_rel * float(evals[0])
             )
-            n_rank = int((evals > thresh).sum().item())
+            if not bool(torch.isfinite(evals).all()):
+                # Non-finite covariance (NaN/Inf in the data). Rank detection is
+                # meaningless here and `nan > thresh` is False, which would
+                # otherwise look like rank zero. Leave the dimension alone and
+                # let the fit reach the degenerate-fit contract (issue #50),
+                # which reports `nan_ll` and refuses output -- that is the
+                # documented behavior for unusable data, not an exception here.
+                n_rank = evals.shape[0]
+            else:
+                n_rank = int((evals > thresh).sum().item())
             if n_rank < 1:
                 raise ValueError(
                     f"No data covariance eigenvalue exceeds mineig={thresh:g} "

--- a/pamica/torch_impl/core.py
+++ b/pamica/torch_impl/core.py
@@ -463,7 +463,29 @@ class AMICATorchNG:
         Preprocessing options, matching ``pamica.AMICA._preprocess_data``.
     pcakeep, pcadb : int, float, optional
         PCA dimensionality-reduction options (rarely used; see
-        ``pamica.AMICA._preprocess_data``).
+        ``pamica.AMICA._preprocess_data``). Both are capped by the detected
+        numerical rank (``mineig``), matching Fortran's
+        ``numeigs = min(pcakeep, count(eigs > mineig))``.
+    mineig : float, default=1e-15
+        Absolute floor on data-covariance eigenvalues used to detect the
+        numerical rank (Fortran ``mineig``, amica15.f90:395 and
+        amica15_header.f90:66). Eigen-directions at or below it are dropped, the
+        model is sized to the surviving rank, and sensor-space maps come from
+        :meth:`get_sensor_mixing_matrix`. Full-rank data keep every eigenvalue,
+        so this is a no-op there and single-model parity is byte-for-byte.
+
+        Being absolute, it is unit-dependent: EEG in microvolts gives
+        eigenvalues of order 1-100 and the default behaves, but MEG in Tesla
+        gives ~1e-26 and every eigenvalue falls below it, which Fortran would
+        turn into ``numeigs = 0``. pamica raises instead of fitting an empty
+        model. Use ``mineig_rel`` (or rescale) for such data.
+    mineig_rel : float, optional
+        Scale-free alternative to ``mineig``: when set, the threshold becomes
+        ``mineig_rel * largest_eigenvalue`` and ``mineig`` is ignored. Off by
+        default so rank detection stays Fortran-exact. It is also the more
+        accurate detector -- the absolute floor sits amid the numerical-zero
+        eigenvalues of rank-deficient data and over-retains, while a relative
+        floor recovers the true rank (issue #223).
     seed : int, optional
         Seed for parameter initialization. Uses ``numpy.random.RandomState``
         internally (not ``torch``'s RNG) with the exact same draw order as
@@ -531,6 +553,8 @@ class AMICATorchNG:
         do_approx_sphere: bool = True,
         pcakeep: Optional[int] = None,
         pcadb: Optional[float] = None,
+        mineig: float = 1e-15,
+        mineig_rel: Optional[float] = None,
         seed: Optional[int] = None,
         device: Optional[Union[str, torch.device]] = None,
         dtype: torch.dtype = torch.float64,
@@ -539,6 +563,12 @@ class AMICATorchNG:
         self.n_models = n_models
         self.n_mix = n_mix
         self.n_comps = n_channels * n_models
+        # Original input channel count, kept when rank reduction shrinks
+        # n_channels to the kept rank (issue #223). Equal to n_channels
+        # whenever the data is full rank.
+        self.n_channels_in = n_channels
+        self.mineig = mineig
+        self.mineig_rel = mineig_rel
         self.block_size = block_size
 
         self.lrate0 = lrate
@@ -653,6 +683,7 @@ class AMICATorchNG:
         self.share_iter = share_iter
         self.comp_thresh = comp_thresh
         self._spinv = None  # cached de-sphering metric, built on first share
+        self._sphere_pinv = None  # cached sphere pseudo-inverse (issue #223)
         if share_comps:
             if share_start < 1:
                 raise ValueError(f"share_start must be >= 1, got {share_start}")
@@ -790,17 +821,62 @@ class AMICATorchNG:
             evals = evals[order]
             evecs = evecs[:, order]
 
+            # Numerical-rank detection, Fortran amica15.f90:395
+            #   numeigs = min(pcakeep, count(eigs > mineig))
+            # mineig is an *absolute* covariance-eigenvalue floor (1e-15,
+            # amica15_header.f90:66), so it is unit-dependent: EEG in microvolts
+            # gives eigenvalues of order 1-100 and the default behaves, but MEG
+            # in Tesla gives ~1e-26 and every eigenvalue falls below it. The
+            # absolute form is the parity-faithful default; mineig_rel adds an
+            # opt-in scale-free floor on top (issue #223).
+            # mineig_rel *replaces* the absolute floor rather than being combined
+            # with it: for MEG in Tesla a relative floor is ~1e-35 in absolute
+            # terms, so a max() against 1e-15 would silently ignore it.
+            thresh = (
+                self.mineig
+                if self.mineig_rel is None
+                else self.mineig_rel * float(evals[0])
+            )
+            n_rank = int((evals > thresh).sum().item())
+            if n_rank < 1:
+                raise ValueError(
+                    f"No data covariance eigenvalue exceeds mineig={thresh:g} "
+                    f"(largest is {float(evals[0]):g}), so the numerical rank is "
+                    "zero and there is nothing to decompose. This usually means "
+                    "the data are on a very small physical scale (e.g. MEG in "
+                    "Tesla, where eigenvalues run ~1e-26): rescale the data, or "
+                    "set mineig/mineig_rel to a threshold suited to its units."
+                )
+
             if self.pcakeep is not None:
-                n_comp = min(self.pcakeep, evals.shape[0])
+                n_comp = min(self.pcakeep, n_rank)
             elif self.pcadb is not None:
                 db = 10.0 * torch.log10(evals / evals[0])
-                n_comp = int((db > -self.pcadb).sum().item())
+                n_comp = min(int((db > -self.pcadb).sum().item()), n_rank)
             else:
-                n_comp = evals.shape[0]
+                n_comp = n_rank
 
             V = evecs[:, :n_comp]
             inv_sqrt = torch.diag(1.0 / torch.sqrt(evals[:n_comp]))
-            if self.do_approx_sphere:
+            if n_comp < data_dim:
+                # Rank-reduced sphere: (n_comp, data_dim), so the sphered data
+                # come out at the kept rank rather than staying rank-deficient
+                # at data_dim rows (Fortran nw = numeigs, amica15.f90:545).
+                # Vt rows are eigenvectors in descending-eigenvalue order,
+                # matching Fortran's reversed Stmp2 (amica15.f90:455-460).
+                w_pca = inv_sqrt @ V.T
+                if self.do_approx_sphere:
+                    # Fortran amica15.f90:483-490 symmetrizes the reduced
+                    # whitening by the orthogonal polar factor of the leading
+                    # n_comp x n_comp block of V^T:
+                    #   B = (V^T)[:n, :n] = U_b S_b Vt_b
+                    #   S = (V_b U_b^T) @ w_pca
+                    B = evecs.T[:n_comp, :n_comp]
+                    U_b, _, Vt_b = torch.linalg.svd(B)
+                    sphere = (Vt_b.T @ U_b.T) @ w_pca
+                else:
+                    sphere = w_pca
+            elif self.do_approx_sphere:
                 # Symmetric ZCA sphere V diag(1/sqrt(eval)) V^T (Fortran
                 # do_approx_sphere=True, amica17.f90:480-481). This is the
                 # Fortran default and the parity-validated form; the old
@@ -826,6 +902,26 @@ class AMICATorchNG:
         self.mean = mean.to(device=self.device, dtype=self.dtype)
         self.sphere = sphere.to(device=self.device, dtype=self.dtype)
         self.sldet = sldet
+
+        # Rank reduction shrank the sphered space, so size the model to the kept
+        # rank before _initialize_parameters allocates against n_channels
+        # (Fortran ``nw = numeigs``, amica15.f90:545). No-op, and therefore
+        # bit-exact, whenever the data are full rank.
+        n_kept = sphere.shape[0]
+        self.n_channels_in = data_dim
+        if n_kept != self.n_channels:
+            logger.info(
+                "Data covariance has numerical rank %d of %d; fitting %d "
+                "sources and mapping back to %d channels via the sphere "
+                "pseudo-inverse.",
+                n_kept,
+                data_dim,
+                n_kept,
+                data_dim,
+            )
+            self.n_channels = n_kept
+            self.n_comps = n_kept * self.n_models
+        self._sphere_pinv = None  # rebuilt on demand for this fit's sphere
 
         return X_cpu.to(device=self.device, dtype=self.dtype)
 
@@ -2255,6 +2351,32 @@ class AMICATorchNG:
         self._check_model_idx(model_idx)
         return self.A[:, self.comp_list[:, model_idx]].T.cpu().numpy()
 
+    def get_sensor_mixing_matrix(self, model_idx: int = 0) -> np.ndarray:
+        """Mixing matrix mapped back to input-channel space.
+
+        :meth:`get_mixing_matrix` returns ``A`` in the *sphered* space. These are
+        the corresponding sensor-space maps (EEGLAB/MNE scalp maps),
+        ``pinv(sphere) @ A``, of shape ``(n_channels_in, n_channels)``. This is
+        the Fortran ``Spinv`` mapping (amica15.f90:550-560), and it is the only
+        way to recover sensor maps when rank reduction is active, since the
+        sphere is then non-square (issue #223).
+        """
+        if self.sphere is None:
+            raise RuntimeError(
+                "AMICATorchNG.get_sensor_mixing_matrix() requires a fitted "
+                "model; call fit() first."
+            )
+        if self.A is None or self.comp_list is None:
+            raise RuntimeError(
+                "AMICATorchNG.get_sensor_mixing_matrix() requires a fitted "
+                "model; call fit() first."
+            )
+        self._check_model_idx(model_idx)
+        if self._sphere_pinv is None:
+            self._sphere_pinv = torch.linalg.pinv(self.sphere)
+        A = self.A[:, self.comp_list[:, model_idx]].T
+        return (self._sphere_pinv @ A).cpu().numpy()
+
     def get_unmixing_matrix(self, model_idx: int = 0) -> np.ndarray:
         """True unmixing matrix ``W_fort`` = (stored W)^T (issue #24 convention)."""
         if self.W is None:
@@ -2793,6 +2915,9 @@ class AMICATorchNG:
             "do_approx_sphere": self.do_approx_sphere,
             "pcakeep": self.pcakeep,
             "pcadb": self.pcadb,
+            "mineig": self.mineig,
+            "mineig_rel": self.mineig_rel,
+            "n_channels_in": self.n_channels_in,
             "seed": self.seed,
             # Store dtype by name (e.g. "float64") to keep the payload
             # weights_only-safe; rebuilt via getattr(torch, ...) on load.


### PR DESCRIPTION
Closes #223.

Ports the Fortran reference's numerical-rank handling, which pamica had dropped. Rank-deficient input (Maxwell-filtered MEG, average-referenced or interpolated EEG) previously died with `nan_ll` on iteration 0, or silently fitted a full-rank model to rank-deficient data. Reported in #221 by a user applying pamica to 306-channel Elekta MEG at numerical rank ~70.

## What Fortran does, and now we do

| Fortran | Reference | pamica before | pamica now |
|---|---|---|---|
| `numeigs = min(pcakeep, count(eigs > mineig))` | amica15.f90:395 | absent | `mineig`, default `1e-15` |
| `nw = numeigs` | amica15.f90:545 | `n_channels` fixed from `X.shape[0]` | model sized to kept rank |
| `Spinv` (nx, numeigs) | amica15.f90:550-560 | absent | `get_sensor_mixing_matrix()` |

The reduced sphere follows Fortran's construction exactly, including the `do_approx_sphere` branch that symmetrizes the reduced whitening by the orthogonal polar factor of the leading `numeigs` block of `V^T` (amica15.f90:483-490).

## Parity

Full-rank data keep every eigenvalue, so the reduction path never fires and the existing code paths are untouched. Verified **bit-identical** before/after on the bundled sample EEG across single-model, Newton-enabled, and two-model fits (log-likelihood, sphere sum, mixing-matrix sum, and the first five LL-history entries all compare equal by `repr`).

## Improving on the reference

`mineig` is an *absolute* eigenvalue floor, so it is unit-dependent. Two consequences, both handled:

1. **MEG in Tesla** has covariance eigenvalues ~1e-26, all below `1e-15`. Fortran would compute `numeigs = 0` and proceed; pamica raises a `ValueError` naming the cause and the fix rather than fitting an empty model.
2. **The absolute floor is a poor rank detector**, because numerical-zero eigenvalues straddle it. On real EEG projected to rank 20:

   | threshold | rank found | reconstruction error |
   |---|---|---|
   | `mineig=1e-15` (Fortran default) | 24 | 1.98e-09 |
   | `mineig_rel=1e-9` | 20 (exact) | 7.52e-15 |

`mineig_rel` is opt-in and replaces the absolute floor when set, so the default stays Fortran-exact while the better detector is one argument away.

## Also fixed

`pcakeep=N, do_approx_sphere=False` — the genuinely dimension-reducing path — raised `RuntimeError: The size of tensor a (N) must match the size of tensor b (n_channels)`. `_preprocess` returned `(N, T)` while every parameter was still sized to the input channel count. Covered by a regression test.

## Tests

`pamica/tests/torch_tests/test_ng_rank_deficient.py`, 7 tests, real sample EEG only. Rank deficiency is produced by projecting the real recording onto its own leading subspace — the same rank-reducing linear operator SSS applies to MEG — so no synthetic data is involved.

## Follow-ups (not in this PR)

- `numpy_impl` and `mlx_impl` still lack rank handling.
- `mne_compat` sets a unit pre-whitener (`ica.pre_whitener_ = np.ones((n_ch, 1))`), so mixed magnetometer/gradiometer data are not channel-type scaled. Since the scaling determines which directions survive rank truncation, this matters for MEG; tracked in #221.
