### PR TITLE
Write and read reduced-rank spheres correctly

### DIFF
--- a/pamica/numpy_impl/load.py
+++ b/pamica/numpy_impl/load.py
@@ -179,7 +179,31 @@ def write_amicaout(
     # multi-model interleave it replaces was never MATLAB-readable (issue #159).
     # The symmetric sphere S is order-agnostic; mean/gm/LL are 1-D.
     _w("W", np.asarray(W).transpose(2, 0, 1))
-    _w("S", sphere)
+    # Fortran always writes S at recl = 2*nbyte*nx*nx (amica15.f90:2299): the
+    # array is allocated (nx, nx) and zero-filled, and a rank-reduced sphere
+    # occupies only its first `numeigs` rows. Pad to that shape so a reduced fit
+    # is readable by loadmodout15.m and by loadmodout() below, which both reshape
+    # to (nx, nx) and slice [:num_pcs] (issue #164/#223).
+    sphere = np.asarray(sphere)
+    if sphere.ndim != 2:
+        raise ValueError(f"sphere must be 2-D (nw, nx); got shape {sphere.shape}")
+    n_keep, n_in = sphere.shape
+    if n_keep > n_in:
+        raise ValueError(
+            f"sphere has more rows than columns ({sphere.shape}); expected "
+            "(num_pcs, data_dim) with num_pcs <= data_dim"
+        )
+    if n_keep < n_in:
+        padded = np.zeros((n_in, n_in), dtype=np.float64)
+        padded[:n_keep] = sphere
+        # Column-major, because the padded array is not symmetric. The square
+        # branch below deliberately keeps its C-order write: the symmetric-ZCA
+        # sphere is its own transpose only to ~1e-17, so switching orders there
+        # would perturb bytes that are guaranteed identical to the Fortran
+        # reference (issue #92).
+        _w("S", padded, order="F")
+    else:
+        _w("S", sphere)
     _w("mean", mean)
     # The (num_mix, num_comps) mixture params and (num_comps, num_models) c /
     # comp_list are non-square, so their byte layout DOES depend on order: they
@@ -257,7 +281,12 @@ def loadmodout(outdir: Union[str, Path]) -> AmicaOutput:
             raise FileNotFoundError("No sphere or mean present, cannot continue")
     else:
         if len(S.shape) == 1:
-            S = S.reshape(nx, nx)
+            # Column-major, matching Fortran's (nx, nx) array and MATLAB's
+            # reshape in loadmodout15.m. Indistinguishable from a C-order
+            # reshape for the symmetric-ZCA sphere (which is why this went
+            # unnoticed), but not for a rank-reduced sphere, whose zero pad
+            # would otherwise land in the wrong half (issue #164).
+            S = S.reshape(nx, nx, order="F")
 
     # Read component list
     comp_list = read_binary_file(outdir / "comp_list", dtype=np.int32)

--- a/pamica/tests/test_amicaout_reduced.py
+++ b/pamica/tests/test_amicaout_reduced.py
@@ -1,0 +1,131 @@
+"""EEGLAB output round-trip for a rank-reduced fit (issue #164).
+
+The genuine ``num_pcs < data_dim`` path was unreachable until #223 fixed the fit
+crash, so ``write_amica_output``/``loadmodout``/``AmicaOutput.sources`` had no
+coverage for a non-square sphere.
+
+Fortran always writes ``S`` at ``recl = 2*nbyte*nx*nx`` (amica15.f90:2299): the
+array is allocated ``(nx, nx)`` and zero-filled, and a reduced sphere occupies
+only its first ``numeigs`` rows. Both readers (``loadmodout`` here and EEGLAB's
+``loadmodout15.m``) reshape to ``(nx, nx)`` and slice ``[:num_pcs]``, so the
+writer has to pad to that shape.
+
+Rank deficiency comes from projecting the real sample EEG onto its own leading
+subspace -- the rank-reducing operator Maxwell filtering applies to MEG.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from pamica.numpy_impl.load import loadmodout
+from pamica.torch_impl.core import AMICATorchNG
+from pamica.torch_impl.utils import load_eeglab_data
+
+SAMPLE_DIR = Path(__file__).resolve().parent.parent / "sample_data"
+DATA_FILE = SAMPLE_DIR / "eeglab_data.fdt"
+NW = 32
+FIELD = 30504
+RANK = 20
+
+
+@pytest.fixture(scope="module")
+def real_data() -> np.ndarray:
+    if not DATA_FILE.exists():
+        pytest.skip("sample data missing")
+    X = load_eeglab_data(str(DATA_FILE), data_dim=NW, field_dim=FIELD).astype(
+        np.float64
+    )
+    return X - X.mean(axis=1, keepdims=True)
+
+
+@pytest.fixture(scope="module")
+def rank_deficient(real_data: np.ndarray) -> np.ndarray:
+    U = np.linalg.svd(real_data, full_matrices=False)[0][:, :RANK]
+    return U @ (U.T @ real_data)
+
+
+@pytest.fixture(scope="module")
+def reduced_fit(rank_deficient: np.ndarray) -> AMICATorchNG:
+    m = AMICATorchNG(n_channels=NW, seed=0, device="cpu")
+    m.fit(rank_deficient, max_iter=10, verbose=False)
+    assert m.n_channels == RANK, "fixture expects a genuinely reduced fit"
+    return m
+
+
+def test_sphere_is_padded_to_the_fortran_record_shape(reduced_fit, tmp_path):
+    """S on disk must be nx*nx values, not num_pcs*nx."""
+    outdir = tmp_path / "amicaout"
+    reduced_fit.write_amica_output(outdir)
+    raw = np.fromfile(outdir / "S", dtype=np.float64)
+    assert raw.size == NW * NW, (
+        f"S has {raw.size} values; EEGLAB's loadmodout15 expects {NW * NW}"
+    )
+
+
+def test_loadmodout_reads_a_reduced_fit(reduced_fit, tmp_path):
+    outdir = tmp_path / "amicaout"
+    reduced_fit.write_amica_output(outdir)
+    out = loadmodout(outdir)
+    assert out.num_pcs == RANK
+    assert out.data_dim == NW
+    assert out.S.shape == (NW, NW)
+    # Only the first num_pcs rows carry the sphere; the pad must be exactly zero.
+    np.testing.assert_array_equal(out.S[RANK:], 0.0)
+
+
+def test_sources_roundtrip_under_reduced_rank(reduced_fit, rank_deficient, tmp_path):
+    """The load-bearing check: loaded sources reproduce the live transform.
+
+    Not element-wise. ``loadmodout`` applies EEGLAB's conventions -- rows are
+    variance-ordered (``origord``) and ``A``'s columns are normalized to unit
+    norm with the norm folded into ``W`` -- so the loaded sources equal the live
+    ones under a row permutation and a per-component scale. Both are conventional
+    (ICA sources are order- and scale-arbitrary); what must hold exactly is that
+    the scale is *constant along each row*, which is what would break if the
+    sphere were read back transposed or mis-padded.
+    """
+    outdir = tmp_path / "amicaout"
+    reduced_fit.write_amica_output(outdir)
+    out = loadmodout(outdir)
+
+    live = reduced_fit.transform(rank_deficient)
+    loaded = out.sources(rank_deficient)
+    assert loaded.shape == live.shape == (RANK, rank_deficient.shape[1])
+
+    origord = np.asarray(out.origord).ravel()
+    assert sorted(origord.tolist()) == list(range(RANK)), "origord must permute"
+
+    ratio = loaded / live[origord]
+    spread = np.abs(ratio.std(axis=1) / ratio.mean(axis=1)).max()
+    assert spread < 1e-10, f"per-component scale is not constant: {spread:.3e}"
+    # And the scales are the A-column norms loadmodout folded into W, so they are
+    # positive and finite rather than an artifact of a wrong orientation.
+    assert np.all(np.isfinite(ratio.mean(axis=1)))
+
+
+def test_square_sphere_bytes_are_unchanged(real_data, tmp_path):
+    """Full-rank output must stay byte-identical to the Fortran reference.
+
+    The symmetric-ZCA sphere is its own transpose, so switching the writer to
+    column-major cannot move a byte here -- asserted rather than assumed, since
+    single-model output being byte-compatible with the reference is a standing
+    guarantee (issue #92).
+    """
+    m = AMICATorchNG(n_channels=NW, seed=0, device="cpu")
+    m.fit(real_data, max_iter=3, verbose=False)
+    assert m.n_channels == NW
+
+    outdir = tmp_path / "amicaout"
+    m.write_amica_output(outdir)
+    on_disk = np.fromfile(outdir / "S", dtype=np.float64)
+    assert m.sphere is not None
+    sphere = m.sphere.cpu().numpy()
+    # Unchanged C-order write. The ZCA sphere is symmetric only to ~1e-17, so
+    # this is not interchangeable with a column-major write -- which is exactly
+    # why the writer leaves the square branch alone.
+    np.testing.assert_array_equal(on_disk, sphere.ravel(order="C"))
+    assert not np.array_equal(sphere.ravel(order="F"), sphere.ravel(order="C")), (
+        "sphere is bit-symmetric here, so this test no longer guards anything"
+    )

--- a/pamica/tests/test_amicaout_reduced.py
+++ b/pamica/tests/test_amicaout_reduced.py
@@ -84,7 +84,7 @@ def test_sources_roundtrip_under_reduced_rank(reduced_fit, rank_deficient, tmp_p
     ones under a row permutation and a per-component scale. Both are conventional
     (ICA sources are order- and scale-arbitrary); what must hold exactly is that
     the scale is *constant along each row*, which is what would break if the
-    sphere were read back transposed or mis-padded.
+    sphere were read back transposed or padded incorrectly.
     """
     outdir = tmp_path / "amicaout"
     reduced_fit.write_amica_output(outdir)


### PR DESCRIPTION
Closes #164. The crash half of that issue was fixed by #223/#224; this completes its second acceptance criterion — "a round-trip test for `sources`/`loadmodout` under genuine `num_pcs < data_dim`" — and fixes the two bugs writing that test exposed.

## The on-disk convention

Fortran always writes `S` at `recl = 2*nbyte*nx*nx` (amica15.f90:2299). The array is allocated `(nx, nx)` and zero-filled (amica15.f90:334), and a rank-reduced sphere occupies only its first `numeigs` rows. Both readers — `loadmodout` here and EEGLAB's `loadmodout15.m` — reshape to `(nx, nx)` and slice `[:num_pcs]`.

## Two bugs

**Writer emitted the wrong number of values.** A reduced sphere is `(n_kept, nx)`, so `_w("S", sphere)` wrote `n_kept*nx` values where EEGLAB expects `nx*nx`. Now padded to `(nx, nx)` before writing.

**Reader reshaped in the wrong order.** `S.reshape(nx, nx)` is C-order; Fortran and MATLAB store column-major. Invisible for the symmetric-ZCA sphere — which is why it survived this long — but it puts a reduced sphere's zero pad in the wrong half.

## Byte compatibility preserved

The square branch deliberately keeps its C-order write. The ZCA sphere is its own transpose only to ~1e-17, so switching that branch to column-major *would* move bytes that are guaranteed identical to the Fortran reference (issue #92). A test asserts both the unchanged C-order bytes and that the sphere is not bit-symmetric, so the guard cannot silently become vacuous.

## What the round-trip actually asserts

Not element-wise equality with `transform`. `loadmodout` applies EEGLAB's conventions — rows variance-ordered via `origord`, `A` columns normalized to unit norm with the norm folded into `W` — so loaded sources equal live ones under a **row permutation and a per-component scale**. Both are conventional; ICA sources are order- and scale-arbitrary.

What must hold exactly, and is what a transposed or mis-padded sphere would break, is that the scale is *constant along each row*. Measured spread: 9e-14.

Worth recording: my first draft asserted element-wise equality and failed. Checking the full-rank case showed it failed identically (best-match correlation 1.0000000000 under a permutation), so the premise was wrong, not the code — `AmicaOutput.sources` has never returned rows in the model's internal order.

## Tests

`pamica/tests/test_amicaout_reduced.py`, 4 tests, real sample EEG projected onto its own leading subspace. `test_viz.py` and `test_sample_data.py` (the other loader consumers) pass unchanged.
