### PR TITLE
Raise block_size default to 8192

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,13 @@ computes in float64 for Fortran parity, which MPS cannot represent, so parity ru
 (the `AMICA` wrapper falls back to CPU automatically when a device is not pinned).
 
 **Performance (#63, `.context/issue-63/perf_findings.md`, `benchmarks/benchmark_gpu.py`):** the E-step
-pow-dedup (dropping the unused `dpdf`) is ~-35% and bit-identical; `block_size` default is 512 (was
-128, ~-18%). CUDA float64 is ~4.5x over a 16-thread CPU (RTX 4090, warmed) and agrees with the CPU LL
+pow-dedup (dropping the unused `dpdf`) is ~-35% and bit-identical. **`block_size` default is 8192
+(#216, raised from 512).** Every backend is dispatch-bound at small blocks, making this the single
+largest throughput knob: ~6x on CPU float64 for the bundled sample (217 -> 36 ms/it). 8192 rather
+than larger because peak block memory scales with it and 8192 stays safe at high channel counts.
+Runs compared bit-for-bit against the Fortran binary must set `block_size` on both sides (the
+bundled `input.param` uses 512); the trajectory shifts ~1e-6 with it, inside parity tolerance.
+CUDA float64 is ~4.5x over a 16-thread CPU (RTX 4090, warmed) and agrees with the CPU LL
 to 5 sig digits (auto-selected by the wrapper). float32 now converges reliably on
 full-size data across seeds (#75 guarded the one float32-only divide-by-zero: a sample rounding an
 activation to exactly 0 gave `0/0` in the mu denominator; not a summation-precision problem, so it

--- a/pamica/mlx_impl/core.py
+++ b/pamica/mlx_impl/core.py
@@ -89,7 +89,7 @@ class AMICAMLXNG:
         n_channels: int,
         n_models: int = 1,
         n_mix: int = 3,
-        block_size: int = 512,
+        block_size: int = 8192,
         lrate: float = 0.1,
         minlrate: float = 1e-12,
         lratefact: float = 0.5,

--- a/pamica/numpy_impl/core.py
+++ b/pamica/numpy_impl/core.py
@@ -205,7 +205,7 @@ class AMICA:
         self.do_history = params.get("do_history", False)
         self.histstep = params.get("histstep", 10)
         self.do_opt_block = params.get("do_opt_block", True)
-        self.block_size = params.get("block_size", 128)
+        self.block_size = params.get("block_size", 8192)
         self.blk_min = params.get("blk_min", 128)
         self.blk_max = params.get("blk_max", 1024)
         self.blk_step = params.get("blk_step", 128)

--- a/pamica/tests/torch_tests/test_ng_pdf_families.py
+++ b/pamica/tests/torch_tests/test_ng_pdf_families.py
@@ -125,10 +125,15 @@ def test_log_pdf_only_matches_log_pdf_and_deriv(code):
     assert torch.equal(az_rho, _Y.abs().pow(_RHO))
 
 
-def test_block_size_default_is_512():
-    """Pin the issue #63 default so a revert/typo is caught (the block-size
-    invariance tests would still pass at any finite block size)."""
-    assert AMICATorchNG(n_channels=NW, device="cpu").block_size == 512
+def test_block_size_default_is_8192():
+    """Pin the issue #216 default so a revert/typo is caught (the block-size
+    invariance tests would still pass at any finite block size).
+
+    Raised from 512, which left every backend dispatch-bound: ~6x on CPU float64
+    for the bundled sample. Chosen over a larger value because peak block memory
+    scales with it and 8192 stays safe at high channel counts.
+    """
+    assert AMICATorchNG(n_channels=NW, device="cpu").block_size == 8192
 
 
 def test_pdtype_h_is_none_only_for_gg():

--- a/pamica/torch_impl/core.py
+++ b/pamica/torch_impl/core.py
@@ -285,17 +285,22 @@ class AMICATorchNG:
         Number of ICA mixture models.
     n_mix : int, default=3
         Number of mixture components per source.
-    block_size : int, default=512
+    block_size : int, default=8192
         Number of samples processed per accumulation block. Peak memory
         during the E-step scales with this, not with the total sample count.
         Larger blocks give bigger tensor ops (less Python/dispatch overhead,
-        better threading/GPU utilization) at higher memory. 512 is a fixed
-        choice inside Fortran's ``do_opt_block`` auto-tune range (128-1024, step
-        128); the Fortran *header* default is 128 and it auto-tunes per host, so
-        this does not track a single reference value. A single iteration's
-        sufficient statistics are block-size-independent to ~1e-8
-        (``test_blocking_invariance``), but the (chaotic) multi-iteration
-        trajectory shifts at the ~1e-6 level as this changes.
+        better threading/GPU utilization) at higher memory. Every backend is
+        dispatch-bound at small blocks, making this the largest throughput knob:
+        raising it from 512 to 8192 is ~6x on CPU float64 for the bundled sample
+        (issue #216). 8192 rather than larger because peak block memory scales
+        with it and 8192 stays near 240 MB even at 256 channels.
+
+        Fortran pins no comparable value (header default 128, auto-tuned over
+        128-1024 via ``do_opt_block``). Per-iteration sufficient statistics are
+        block-size-independent to ~1e-8 (``test_blocking_invariance``); the
+        multi-iteration trajectory shifts ~1e-6, inside parity tolerance but
+        enough that a bit-for-bit Fortran comparison must match ``block_size`` on
+        both sides (the bundled ``input.param`` uses 512).
     lrate : float, default=0.1
         Initial/maximum natural-gradient learning rate (``lrate0`` in NumPy).
     minlrate : float, default=1e-12
@@ -512,7 +517,7 @@ class AMICATorchNG:
         n_channels: int,
         n_models: int = 1,
         n_mix: int = 3,
-        block_size: int = 512,
+        block_size: int = 8192,
         lrate: float = 0.1,
         minlrate: float = 1e-12,
         lratefact: float = 0.5,


### PR DESCRIPTION
Partially addresses #216: the default itself. Measured on the bundled 32-channel sample, this machine (Apple Silicon), 20 iterations, seed 42.

| block_size | torch-CPU f64 | torch-CPU f32 | torch-MPS f32 |
|---:|---:|---:|---:|
| 512 (old default) | 217.4 ms | 196.1 | 1758.0 |
| **8192 (new)** | **36.1** | **39.0** | **299.5** |
| 16384 | 30.3 | 28.5 | 235.5 |
| single block | 32.1 | 27.3 | 187.7 |

~6x on CPU float64. 8192 rather than the fastest value because peak block memory scales with it: at 256 channels 8192 costs ~240 MB per model against ~960 MB for a single block, and the default has to stay safe on large recordings. 16384 is 16% quicker for double the memory, which is not a good trade for a default.

Changed in all three array backends (PyTorch, MLX, NumPy — the last was still on 128) per `.rules/backend_parity.md`.

## Parity

`block_size` shifts the multi-iteration trajectory ~1e-6 — well inside parity tolerance, and per-iteration sufficient statistics stay block-size-independent to 1e-8 (`test_blocking_invariance`). It is not free, though: a bit-for-bit comparison against the binary must set the same value on both sides. The parity harness already does (`sample_params.json` and `input.param` both pin 512), and the docstring and AGENTS.md now say so.

## Not included

The rest of #216 — correcting the published MPS claims in `paper.md`, `AGENTS.md` and `docs/guides/backends.md` — is deliberately left out. My MPS numbers disagree with the ones in the issue by ~14x (187 ms vs 13.5 at single block; MPS never beats CPU here), so the correct figures are not established, and rewriting performance claims in a paper under review on unreconciled measurements would be worse than leaving them. The CPU result above reproduces on both machines and stands on its own.

## Note

`test_end_to_end_correlation_vs_fortran_from_sample_params_json` fails in full-suite runs on this branch. It fails identically on unmodified `main` and passes in isolation both with and without this change: the reference binary is not reproducible run-to-run. Tracked as #228, not caused here.
