### PR TITLE
Forward all supported params to the Fortran run

### DIFF
--- a/pamica/tests/test_fortran_param_forwarding.py
+++ b/pamica/tests/test_fortran_param_forwarding.py
@@ -1,0 +1,107 @@
+"""Parity-harness parameter forwarding (issue #228).
+
+Both arms of a parity run must be configured identically. The writer previously
+rewrote six hardcoded keys and left everything else at the template's value while
+the Python side honored it, which silently makes the comparison uncontrolled.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from validate_implementations import (  # noqa: E402
+    fortran_accepted_keys,
+    write_fortran_param_file,
+)
+
+TEMPLATE = ROOT / "pamica" / "sample_data" / "input.param"
+SOURCE = ROOT / "pamica" / "amica15.f90"
+
+pytestmark = pytest.mark.skipif(
+    not TEMPLATE.exists() or not SOURCE.exists(),
+    reason="reference param template or Fortran source missing",
+)
+
+
+def _written(tmp_path, params, overrides=None):
+    dest = tmp_path / "input.param"
+    write_fortran_param_file(
+        TEMPLATE.read_text().splitlines(keepends=True), dest, params, overrides
+    )
+    lines = [ln for ln in dest.read_text().splitlines() if ln.split()]
+    out = dict(ln.split(None, 1) for ln in lines)
+    assert len(out) == len(lines), "a key was written more than once"
+    return {k: v.strip() for k, v in out.items()}
+
+
+def test_accepted_keys_come_from_the_reference_source():
+    keys = fortran_accepted_keys(SOURCE)
+    assert keys is not None
+    # Spot-check across the parser rather than pinning the whole set, which
+    # would just restate the source.
+    for key in ("do_newton", "block_size", "do_approx_sphere", "max_decs", "lrate"):
+        assert key in keys, f"{key} should be parsed out of amica15.f90"
+
+
+def test_missing_source_disables_filtering():
+    assert fortran_accepted_keys(Path("does-not-exist.f90")) is None
+
+
+def test_do_newton_is_forwarded(tmp_path):
+    """The regression that motivated #228: this key was silently dropped, so
+    ``params['do_newton'] = False`` configured Python without Newton and left the
+    reference running with it."""
+    assert _written(tmp_path, {"do_newton": False})["do_newton"] == "0"
+    assert _written(tmp_path, {"do_newton": True})["do_newton"] == "1"
+
+
+def test_block_size_is_forwarded(tmp_path):
+    """Needed since the default moved to 8192 (#229) while the template says 512."""
+    assert _written(tmp_path, {"block_size": 8192})["block_size"] == "8192"
+
+
+def test_aliased_names_are_translated(tmp_path):
+    got = _written(tmp_path, {"num_mix": 4, "share_int": 50, "maxrej": 7})
+    assert got["num_mix_comps"] == "4"
+    assert got["share_iter"] == "50"
+    assert got["numrej"] == "7"
+
+
+def test_keys_absent_from_the_template_are_appended(tmp_path):
+    """The binary accepts more keywords than the shipped template lists."""
+    assert "do_approx_sphere" not in TEMPLATE.read_text()
+    assert _written(tmp_path, {"do_approx_sphere": True})["do_approx_sphere"] == "1"
+
+
+def test_overrides_beat_params(tmp_path):
+    """The harness's paths must win over whatever params.json carries."""
+    got = _written(
+        tmp_path,
+        {"files": ["some/other/path.fdt"], "outdir": "./elsewhere/"},
+        overrides={"files": "./eeglab_data.fdt", "outdir": "./fortran_output/"},
+    )
+    assert got["files"] == "./eeglab_data.fdt"
+    assert got["outdir"] == "./fortran_output/"
+
+
+def test_untouched_template_values_survive(tmp_path):
+    got = _written(tmp_path, {"max_iter": 300})
+    assert got["max_iter"] == "300"
+    assert got["data_dim"] == "32"  # not in params, must keep the template's value
+
+
+def test_unsupported_key_is_reported(tmp_path, capsys):
+    """A setting the reference cannot honor must never be dropped in silence."""
+    _written(tmp_path, {"mineig_rel": 1e-12})
+    assert "mineig_rel" in capsys.readouterr().out
+
+
+def test_python_only_keys_are_not_reported(tmp_path, capsys):
+    """``device``/``seed`` configure our side only, so their absence is expected."""
+    _written(tmp_path, {"device": "cpu", "seed": 42})
+    out = capsys.readouterr().out
+    assert "device" not in out and "seed" not in out

--- a/validate_implementations.py
+++ b/validate_implementations.py
@@ -9,6 +9,7 @@ from the same initialization and random seed.
 import numpy as np
 import json
 import os
+import re
 import subprocess
 import torch
 import inspect
@@ -80,6 +81,85 @@ def load_sample_data() -> Tuple[np.ndarray, Dict]:
     return data, params
 
 
+# params.json spellings that differ from the Fortran keyword of the same setting.
+_FORTRAN_ALIASES = {
+    "num_mix": "num_mix_comps",
+    "share_int": "share_iter",
+    "maxrej": "numrej",
+}
+
+# params.json keys that configure the Python side only, so having no Fortran
+# keyword is expected rather than a dropped setting.
+_PYTHON_ONLY_KEYS = {"device", "seed", "outdir", "files", "dtype"}
+
+
+def fortran_accepted_keys(
+    source: Path = Path("pamica/amica15.f90"),
+) -> Optional[set]:
+    """Keywords the reference binary's parameter parser accepts.
+
+    Read from its own ``case('...')`` arms rather than hardcoded, so this cannot
+    drift from the binary being run. Returns ``None`` if the source is
+    unavailable, which callers treat as "forward everything and do not warn".
+    """
+    if not source.exists():
+        return None
+    return set(re.findall(r"^\s*case\('([^']+)'\)", source.read_text(), re.MULTILINE))
+
+
+def write_fortran_param_file(
+    template_lines,
+    dest: Path,
+    params: Dict,
+    overrides: Optional[Dict] = None,
+) -> None:
+    """Write ``dest`` with every setting in ``params`` the binary understands.
+
+    The Fortran and Python arms of a parity run must be configured identically.
+    Rewriting only a hardcoded handful of keys (as this did before issue #228)
+    left the rest at the template's values while the Python side honored them,
+    which silently turns a parity comparison into an uncontrolled one.
+
+    Keys absent from the template are appended, since the binary accepts more
+    keywords than the shipped ``input.param`` lists. Keys it does not accept are
+    reported, so a setting can never be dropped in silence.
+    """
+    accepted = fortran_accepted_keys()
+    wanted, unsupported = {}, []
+    for key, value in params.items():
+        fortran_key = _FORTRAN_ALIASES.get(key, key)
+        if accepted is not None and fortran_key not in accepted:
+            if key not in _PYTHON_ONLY_KEYS:
+                unsupported.append(key)
+            continue
+        # Fortran parses logicals as 0/1 integers.
+        wanted[fortran_key] = int(value) if isinstance(value, bool) else value
+
+    # Last, so the harness's own paths win over whatever params.json carries.
+    wanted.update(overrides or {})
+
+    if unsupported:
+        print(
+            "WARNING: params with no Fortran keyword are left at the template's "
+            f"value for the reference run: {sorted(unsupported)}. The Python run "
+            "may honor them, so the comparison would not be controlled."
+        )
+
+    written, out = set(), []
+    for line in template_lines:
+        key = line.split()[0] if line.split() else None
+        if key in wanted:
+            out.append(f"{key} {wanted[key]}\n")
+            written.add(key)
+        else:
+            out.append(line)
+    for key, value in wanted.items():
+        if key not in written:
+            out.append(f"{key} {value}\n")
+
+    dest.write_text("".join(out))
+
+
 def run_fortran_amica(
     data: np.ndarray,
     params: Dict,
@@ -120,23 +200,12 @@ def run_fortran_amica(
     with open(sample_param_file, "r") as f:
         param_lines = f.readlines()
 
-    # Update parameter file with our settings
-    with open(working_param_file, "w") as f:
-        for line in param_lines:
-            if line.startswith("files"):
-                f.write("files ./eeglab_data.fdt\n")
-            elif line.startswith("outdir"):
-                f.write("outdir ./fortran_output/\n")
-            elif line.startswith("max_iter"):
-                f.write(f"max_iter {params.get('max_iter', 100)}\n")
-            elif line.startswith("lrate"):
-                f.write(f"lrate {params.get('lrate', 0.05)}\n")
-            elif line.startswith("pdftype"):
-                f.write(f"pdftype {params.get('pdftype', 0)}\n")
-            elif line.startswith("num_mix_comps"):
-                f.write(f"num_mix_comps {params.get('num_mix', 3)}\n")
-            else:
-                f.write(line)
+    write_fortran_param_file(
+        param_lines,
+        working_param_file,
+        params,
+        overrides={"files": "./eeglab_data.fdt", "outdir": "./fortran_output/"},
+    )
 
     # Create output directory
     fortran_output = fortran_dir / "fortran_output"


### PR DESCRIPTION
Fixes the harness half of #228. The gate-design half (what to do about a non-reproducible reference) is separate and still open.

## Problem

`run_fortran_amica` rewrote six hardcoded keys — `files`, `outdir`, `max_iter`, `lrate`, `pdftype`, `num_mix_comps` — and passed every other line of the template through untouched. Any other setting in the caller's `params` was honored on the Python side and silently ignored on the Fortran side.

`params["do_newton"] = False` therefore ran Python without Newton against a reference still using it. The harness already warns about params the *NG backend* cannot honor; the reverse direction was unguarded, and it is the direction that quietly makes a comparison uncontrolled. It bit me while investigating #228: an experiment I ran to rule out Newton was invalid and I did not notice until reading the writer.

This also matters now that `block_size` defaults to 8192 (#229) while the template says 512.

## Fix

`write_fortran_param_file` forwards every param the binary accepts, rewriting the template line or appending when the template lacks it — the binary accepts 88 keywords, the shipped `input.param` lists 74.

The accepted set is parsed from `amica15.f90`'s own `case('...')` arms rather than hardcoded, so it cannot drift from the binary being run. If the source is unavailable the filter disables itself rather than dropping settings.

Anything the binary does not accept is reported by name. `device`/`seed`/`dtype` configure our side only and are exempt, so the warning stays meaningful.

Three params.json spellings differ from the Fortran keyword and are aliased: `num_mix`→`num_mix_comps`, `share_int`→`share_iter`, `maxrej`→`numrej`. Booleans become 0/1.

## Two bugs in my first cut, caught by testing

- Params clobbered the harness's own `files`/`outdir`, pointing the reference run at the path from params.json. Overrides are now applied last.
- I aliased `max_decs`→`maxdecs`, which is wrong: `max_decs` is the keyword, `maxdecs` only the internal variable. The alias made a supported key look unsupported.

Both are covered by tests.

## Tests

`pamica/tests/test_fortran_param_forwarding.py`, 10 tests: `do_newton` and `block_size` forwarding (the two that motivated this), alias translation, appending keys absent from the template, overrides winning, untouched template values surviving, unsupported keys being reported, and Python-only keys staying quiet.

## Note

This does not make the reference reproducible — it has no seed parameter, and that is the rest of #228.
