### PR TITLE
Add dev branch and automated version bumping

### DIFF
--- a/.github/workflows/auto-bump-dev.yml
+++ b/.github/workflows/auto-bump-dev.yml
@@ -1,0 +1,79 @@
+name: Auto bump dev
+
+# Increments the PEP 440 `.devN` suffix on `dev` after every push that carries
+# real work, so each commit on the branch has its own pre-release version and an
+# installed dev build is always identifiable. The clean version and the tag are
+# owned by auto-tag.yml when dev merges into main.
+#
+# Skips when the push is this bot's own bump (else it loops), when the message
+# already starts with the bump prefix, or when a commit opts out with
+# [skip-bump].
+
+on:
+  push:
+    branches: [dev]
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    if: |
+      github.event.head_commit.author.email != 'pamica-bot@users.noreply.github.com'
+      && !startsWith(github.event.head_commit.message, 'Bump version to')
+      && !contains(github.event.head_commit.message, '[skip-bump]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the release PAT
+        # Pushes and releases made with the default GITHUB_TOKEN do not trigger
+        # other workflows, so without a PAT this job would appear to succeed
+        # while silently never publishing. Fail visibly instead.
+        env:
+          PAT: ${{ secrets.AUTO_TAG_PAT }}
+        run: |
+          if [ -z "$PAT" ]; then
+            echo "::error::AUTO_TAG_PAT is not set. Create a repository secret with a PAT that has contents:write, or the release chain cannot fire."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 2
+          # A PAT is required to push back to a protected dev branch; the
+          # default GITHUB_TOKEN cannot write through branch protection.
+          token: ${{ secrets.AUTO_TAG_PAT }}
+
+      - name: Compute next dev suffix
+        id: compute
+        run: |
+          CURRENT=$(grep -m1 '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          # dev should always carry a .devN. Anything else means a release just
+          # landed and sync-dev has not fired yet, or a human is mid-release --
+          # log and leave it alone rather than guessing an intent.
+          if [[ ! "$CURRENT" =~ ^([0-9]+\.[0-9]+\.[0-9]+)\.dev([0-9]+)$ ]]; then
+            echo "::notice::$CURRENT has no .devN suffix; leaving dev as-is."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "next=${BASH_REMATCH[1]}.dev$(( ${BASH_REMATCH[2]} + 1 ))" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Install uv
+        if: steps.compute.outputs.skip == 'false'
+        uses: astral-sh/setup-uv@v5
+
+      - name: Bump and push
+        if: steps.compute.outputs.skip == 'false'
+        run: |
+          git config user.name "pamica-bot"
+          git config user.email "pamica-bot@users.noreply.github.com"
+          # sync_version.py writes all three metadata files together; uv.lock
+          # records the project version, so it has to follow.
+          uv run python scripts/sync_version.py sync "${{ steps.compute.outputs.next }}"
+          uv lock
+          git add pyproject.toml CITATION.cff .zenodo.json uv.lock
+          git commit -m "Bump version to ${{ steps.compute.outputs.next }}"
+          # A concurrent push wins; this workflow re-fires from the new HEAD.
+          git push origin dev || echo "::warning::push to dev rejected (concurrent push); skipping"

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,143 @@
+name: Auto tag and release
+
+# Turns a version change on main into a tag and a GitHub Release. Publishing
+# that release is what triggers publish.yml (PyPI) and release-binaries.yml
+# (native binaries), so this workflow is the only manual step a release needs.
+#
+# Two flows:
+#
+# 1. dev merge (e.g. 0.3.3.dev4 lands on main): strip the .devN suffix, commit
+#    the clean version as pamica-bot, tag it vX.Y.Z, create a stable release.
+# 2. Clean version already on main (e.g. a hand-prepared 0.4.0, or an
+#    intentional 0.4.0rc1): tag as-is, marked prerelease when PEP 440 says so.
+#
+# The strip commit deliberately carries no [skip ci] marker: GitHub applies that
+# per commit rather than per event, so it would also suppress the tag-push event
+# that publish.yml needs.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'pyproject.toml'
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    # The strip step below commits as pamica-bot and pushes to main, which
+    # re-triggers this workflow; without this guard that recurses forever.
+    if: github.event.head_commit.author.email != 'pamica-bot@users.noreply.github.com'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the release PAT
+        # Pushes and releases made with the default GITHUB_TOKEN do not trigger
+        # other workflows, so without a PAT this job would appear to succeed
+        # while silently never publishing. Fail visibly instead.
+        env:
+          PAT: ${{ secrets.AUTO_TAG_PAT }}
+        run: |
+          if [ -z "$PAT" ]; then
+            echo "::error::AUTO_TAG_PAT is not set. Create a repository secret with a PAT that has contents:write, or the release chain cannot fire."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 2
+          token: ${{ secrets.AUTO_TAG_PAT }}
+
+      - name: Fetch tags
+        # checkout does not fetch tags, and the guards below need them.
+        run: git fetch --tags origin
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Detect .devN suffix
+        id: strip
+        run: |
+          CURRENT=$(grep -m1 '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "original=$CURRENT" >> "$GITHUB_OUTPUT"
+          # Strip .devN only. Explicit prereleases (rcN, aN, bN) are deliberate
+          # and pass through to be tagged as prereleases.
+          STRIPPED="${CURRENT%.dev*}"
+          echo "stripped=$STRIPPED" >> "$GITHUB_OUTPUT"
+          if [ "$STRIPPED" != "$CURRENT" ]; then
+            echo "did_strip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "did_strip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Apply strip and push
+        if: steps.strip.outputs.did_strip == 'true'
+        run: |
+          set -euo pipefail
+          STRIPPED="${{ steps.strip.outputs.stripped }}"
+          # Tag exists but main still carries .devN: releasing the literal dev
+          # version would be worse than stopping, so stop.
+          if git rev-parse "v$STRIPPED" >/dev/null 2>&1; then
+            echo "::error::Tag v$STRIPPED exists but pyproject.toml is still ${{ steps.strip.outputs.original }}. Refusing to tag a .dev version. Investigate manually."
+            exit 1
+          fi
+          git config user.name "pamica-bot"
+          git config user.email "pamica-bot@users.noreply.github.com"
+          BEFORE=$(git rev-parse HEAD)
+          uv run python scripts/sync_version.py sync "$STRIPPED"
+          uv lock
+          git add pyproject.toml CITATION.cff .zenodo.json uv.lock
+          git commit -m "Bump version to $STRIPPED"
+          if [ "$BEFORE" = "$(git rev-parse HEAD)" ]; then
+            echo "::error::no commit created despite did_strip=true; state raced between detect and apply."
+            exit 1
+          fi
+          git push origin main
+
+      - name: Determine version to tag
+        id: final
+        run: |
+          set -euo pipefail
+          # Pick up the strip commit. No `|| true`: a non-fast-forward means
+          # main diverged, and tagging a stale local tree would mis-release.
+          git pull --ff-only origin main
+          FINAL=$(grep -m1 '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "version=$FINAL" >> "$GITHUB_OUTPUT"
+          # PEP 440 prerelease markers: aN / bN / rcN / .devN / .postN is not one.
+          if [[ "$FINAL" =~ (a|b|rc|\.dev)[0-9]+$ ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create tag
+        id: create_tag
+        run: |
+          set -euo pipefail
+          TAG="v${{ steps.final.outputs.version }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "::warning::$TAG already exists (re-run on an already-tagged commit); skipping."
+            echo "created=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+          echo "created=true" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        if: steps.create_tag.outputs.created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_TAG_PAT }}
+        run: |
+          set -euo pipefail
+          TAG="v${{ steps.final.outputs.version }}"
+          ARGS=("$TAG" --title "$TAG" --generate-notes)
+          if [ "${{ steps.final.outputs.prerelease }}" = "true" ]; then
+            ARGS+=(--prerelease)
+          else
+            ARGS+=(--latest)
+          fi
+          gh release create "${ARGS[@]}"

--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -1,0 +1,76 @@
+name: Sync dev with main and bump
+
+# Closes the loop after a stable release: merges main back into dev and moves
+# dev to the next patch's .dev0, so work branched off dev never carries a
+# version that has already been published.
+#
+# Fires on a successful PyPI publish of a v* tag rather than on the release
+# event, so dev is only advanced once the release actually shipped.
+
+on:
+  workflow_run:
+    workflows: ["Publish to PyPI"]
+    types: [completed]
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'v') &&
+      (github.event.workflow_run.event == 'release' || github.event.workflow_run.event == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the release PAT
+        # Pushes and releases made with the default GITHUB_TOKEN do not trigger
+        # other workflows, so without a PAT this job would appear to succeed
+        # while silently never publishing. Fail visibly instead.
+        env:
+          PAT: ${{ secrets.AUTO_TAG_PAT }}
+        run: |
+          if [ -z "$PAT" ]; then
+            echo "::error::AUTO_TAG_PAT is not set. Create a repository secret with a PAT that has contents:write, or the release chain cannot fire."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+          token: ${{ secrets.AUTO_TAG_PAT }}
+
+      - name: Validate the trigger was a stable release tag
+        id: tag
+        run: |
+          TAG="${{ github.event.workflow_run.head_branch }}"
+          # A real stable release never trips this, so a warning here is
+          # something a human should look at (mistagged release, branch named v*).
+          if [[ ! "$TAG" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "::warning::'$TAG' is not a stable release tag (expected vX.Y.Z); skipping sync."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "next=${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$(( ${BASH_REMATCH[3]} + 1 )).dev0" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Install uv
+        if: steps.tag.outputs.skip == 'false'
+        uses: astral-sh/setup-uv@v5
+
+      - name: Merge main into dev and bump
+        if: steps.tag.outputs.skip == 'false'
+        run: |
+          set -euo pipefail
+          git config user.name "pamica-bot"
+          git config user.email "pamica-bot@users.noreply.github.com"
+          git fetch origin main
+          # --no-ff keeps the release commit visible in dev's history.
+          git merge --no-ff origin/main -m "Merge main into dev after ${{ steps.tag.outputs.tag }}"
+          uv run python scripts/sync_version.py sync "${{ steps.tag.outputs.next }}"
+          uv lock
+          git add pyproject.toml CITATION.cff .zenodo.json uv.lock
+          git commit -m "Bump version to ${{ steps.tag.outputs.next }}"
+          git push origin dev

--- a/.rules/git.md
+++ b/.rules/git.md
@@ -14,11 +14,38 @@
   - `chore:` Maintenance tasks
 
 ## Branch Strategy
+- **`main` is the stable branch and is protected.** Nothing lands on it except a
+  release merge from `dev`. Everything on `main` is released.
+- **`dev` is the integration branch.** Feature and fix branches are cut from
+  `dev` and merged back into `dev`.
 - **Feature branches:** `feature/issue-N-short-description`
 - **Bugfix branches:** `fix/issue-N-description`
 - **Use `gh issue develop`** to create branches from issues
 - **No spaces** in branch names, use hyphens
 - **Delete after merge**
+
+## Versioning (automated)
+Versions are managed by CI; do not hand-edit `pyproject.toml` to bump.
+
+| Event | Version effect | Workflow |
+|---|---|---|
+| PR merged into `dev` | `X.Y.Z.devN` -> `X.Y.Z.dev(N+1)` | `auto-bump-dev.yml` |
+| `dev` merged into `main` | `.devN` stripped -> `X.Y.Z`, tagged `vX.Y.Z`, release published | `auto-tag.yml` |
+| Release published to PyPI | `main` merged back to `dev`, bumped to `X.Y.(Z+1).dev0` | `sync-dev.yml` |
+
+So a release is: merge `dev` into `main`. Everything after that is automatic —
+the tag, the GitHub release, the PyPI upload (`publish.yml`), the native binaries
+(`release-binaries.yml`), and returning `dev` to a fresh `.dev0`.
+
+`.devN` is PEP 440, so `pip install pamica==0.3.3.dev4` resolves and a dev build
+is always identifiable at runtime via `pamica.__version__`.
+
+Notes:
+- Add `[skip-bump]` to a commit message to suppress the dev bump for that push.
+- The bump workflows commit as `pamica-bot` and skip their own commits; do not
+  reuse that identity by hand.
+- Pushing through branch protection needs the `AUTO_TAG_PAT` repository secret;
+  the default `GITHUB_TOKEN` cannot do it.
 
 ## Commit Practice
 - **Atomic commits** - One logical change per commit

--- a/.rules/git.md
+++ b/.rules/git.md
@@ -44,8 +44,25 @@ Notes:
 - Add `[skip-bump]` to a commit message to suppress the dev bump for that push.
 - The bump workflows commit as `pamica-bot` and skip their own commits; do not
   reuse that identity by hand.
-- Pushing through branch protection needs the `AUTO_TAG_PAT` repository secret;
-  the default `GITHUB_TOKEN` cannot do it.
+- The automation needs an `AUTO_TAG_PAT` repository secret. The default
+  `GITHUB_TOKEN` cannot drive it: pushes and releases it makes do not trigger
+  other workflows, so the release chain would go quiet instead of publishing.
+
+### AUTO_TAG_PAT permissions
+Fine-grained PAT scoped to this repository:
+
+| Permission | Why |
+|---|---|
+| Contents: read and write | push bump commits and tags, create releases |
+| Workflows: read and write | `sync-dev` merges main into dev; when a release touched `.github/workflows/**` that merge carries workflow files, and GitHub rejects a PAT push that does so without this |
+
+Classic PAT equivalent: `repo` + `workflow`.
+
+The push authenticates as the PAT's owner whatever git identity the workflow
+sets, so a machine account keeps the bot attribution honest. Once `main` is
+protected, that account also has to be able to push through the protection.
+Fine-grained PATs expire; an expired one fails at the push rather than at the
+preflight, so the error is less obvious than a missing secret.
 
 ## Commit Practice
 - **Atomic commits** - One logical change per commit


### PR DESCRIPTION
Introduces the protected-`main` model from `nemar/nemar-cli`, adapted to Python/PEP 440.

## The model

| Event | Version effect | Workflow |
|---|---|---|
| PR merged into `dev` | `X.Y.Z.devN` -> `.dev(N+1)` | `auto-bump-dev.yml` |
| `dev` merged into `main` | `.devN` stripped -> `X.Y.Z`, tagged, released | `auto-tag.yml` |
| Release published to PyPI | main merged back to dev, bumped to `X.Y.(Z+1).dev0` | `sync-dev.yml` |

A release becomes: merge `dev` into `main`. The tag, GitHub release, PyPI upload (`publish.yml`) and native binaries (`release-binaries.yml`) all follow automatically, and `dev` returns to a fresh `.dev0`.

## Python-specific adaptations

- **PEP 440, not semver:** `0.3.3.dev0`, not `0.3.3-dev0`. Verified `scripts/sync_version.py` handles it across all three metadata files, and `uv lock` is refreshed alongside since the lock records the project version.
- Prerelease detection matches PEP 440 markers (`aN`/`bN`/`rcN`/`.devN`), and correctly does *not* treat `.postN` as one.
- Only `.devN` is stripped on release; a deliberate `0.4.0rc1` passes through and is tagged as a prerelease.

## Safety properties carried over from nemar-cli

Bot-authored commits are filtered at job level so the bump-and-push cannot recurse. The strip commit carries no `[skip ci]` — that marker is per-commit, not per-event, so it would also suppress the tag event the publish needs. `git pull --ff-only` before tagging, so a diverged main halts instead of releasing a stale tree. Tagging refuses to proceed if the target tag exists while the version is still `.devN`.

## Two prerequisites only a repo admin can do

1. **Create the `AUTO_TAG_PAT` secret** (contents:write). Currently only `CODECOV_TOKEN` exists. This is not optional: pushes and releases made with the default `GITHUB_TOKEN` do not trigger other workflows, so without it the chain would appear to succeed while never publishing. Each workflow now fails loudly up front when the secret is missing rather than degrading silently.
2. **Protect `main`** — it is currently unprotected, so the "stable is always protected" property is aspirational until that is set.

Regexes for the bump, strip, prerelease and next-patch logic are unit-checked, and all three files parse as YAML.