### PR TITLE
Weight nd by pre-update model weights

### DIFF
--- a/pamica/numpy_impl/core.py
+++ b/pamica/numpy_impl/core.py
@@ -1350,6 +1350,11 @@ class AMICA:
         # num_models=1 (gm == 1) and for the default disjoint comp_list, where the
         # gm[h] factor cancels against zeta[idx]; it bites only under share_comps
         # with a genuinely shared column, where the two weightings differ.
+        #
+        # Diagnostic only *here*: this dAk feeds nd_value alone. The A-update below
+        # is a separate per-model loop that never reads dAk, so the ordering cannot
+        # move a fitted parameter in this backend. AMICATorchNG applies the same
+        # dAk to A, so there the identical fix does change fitted parameters.
         dAk = np.zeros_like(self.A)
         zeta = np.zeros(self.num_comps)
         for h in range(self.num_models):

--- a/pamica/numpy_impl/core.py
+++ b/pamica/numpy_impl/core.py
@@ -1183,6 +1183,13 @@ class AMICA:
             and self.comp_list is not None
             and self.A is not None
         )
+        # Fortran builds dAk from the model weights of the *previous* iteration:
+        # gm is not reassigned until update_params (amica15.f90:1789+), which runs
+        # after accum_updates_and_likelihood (:1731-1743). Snapshot it here so the
+        # nd block below weights by the same gm Fortran would (issue #219).
+        assert self.gm is not None
+        gm_prev = self.gm.copy()
+
         # Update model weights, normalizing by the number of samples the E-step
         # actually summed over: the good set under do_reject, else all samples.
         if self.do_reject:
@@ -1338,20 +1345,17 @@ class AMICA:
         # applied update lrate*dAk, and does not divide by lrate either
         # (amica15.f90:1742-1743) -- there is no missing factor here.
         #
-        # Fortran ordering caveat: Fortran's gm is not reassigned until
-        # update_params (amica15.f90:1789+), which runs AFTER dAk is built, so its
-        # ndtmpsum uses the previous iteration's gm. self.gm is already updated by
-        # this point. That is invisible for num_models=1 (gm == 1) and for the
-        # default disjoint comp_list, where the gm[h] factor cancels exactly
-        # against zeta[idx], but the two differ under share_comps with a genuinely
-        # shared column. Diagnostic only, it does not affect the fitted
-        # parameters; tracked in issue #219.
+        # Weighted by gm_prev, the pre-update model weights, because Fortran builds
+        # dAk before update_params reassigns gm (issue #219). Invisible for
+        # num_models=1 (gm == 1) and for the default disjoint comp_list, where the
+        # gm[h] factor cancels against zeta[idx]; it bites only under share_comps
+        # with a genuinely shared column, where the two weightings differ.
         dAk = np.zeros_like(self.A)
         zeta = np.zeros(self.num_comps)
         for h in range(self.num_models):
             idx = self.comp_list[:, h]
-            dAk[:, idx] += self.gm[h] * np.dot(directions[h].T, self.A[:, idx])
-            zeta[idx] += self.gm[h]
+            dAk[:, idx] += gm_prev[h] * np.dot(directions[h].T, self.A[:, idx])
+            zeta[idx] += gm_prev[h]
         nonzero = zeta > 0
         dAk[:, nonzero] /= zeta[nonzero]
         # comp_used is None until fit() sets it up, and the M-step is exercised

--- a/pamica/tests/test_numpy_grad_norm.py
+++ b/pamica/tests/test_numpy_grad_norm.py
@@ -96,35 +96,78 @@ def test_grad_norm_uses_the_pre_step_mixing_matrix():
 
 
 # --- gm ordering under sharing (issue #219) ---------------------------------
-def test_grad_norm_uses_pre_update_model_weights():
-    """`dAk` is weighted by the model weights of the *previous* iteration.
+def _shared_two_model_fit(max_iter=3):
+    """A fitted 2-model NumPy model whose comp_list genuinely shares a column.
 
-    Fortran builds `dAk` inside `accum_updates_and_likelihood`
-    (amica15.f90:1753) and only reassigns `gm` in `update_params` (:1788), so
-    its `ndtmpsum` never sees the current iteration's weights. We reassigned
-    `gm` first and weighted with the new values.
-
-    Invisible for a single model (`gm == 1`) and for the default disjoint
-    `comp_list`, where the `gm[h]` factor cancels against `zeta[idx]`; it is
-    real only when `share_comps` gives a column to more than one model. This
-    pins the ordering directly, since a shared column is hard to force from a
-    short fit.
+    Sharing is forced directly rather than waited for: `share_comps` reaches a
+    shared column only after a merge fires, and a short fit on this sample is
+    not guaranteed to produce one.
     """
-    model = AMICA(num_models=2, num_mix=3, max_iter=3, seed=42)
+    model = AMICA(num_models=2, num_mix=3, max_iter=max_iter, seed=42)
     model.fit(_real_data(4096))
-
-    # Force a genuinely shared column: model 1's first component points at the
-    # same mixing column as model 0's.
     assert model.comp_list is not None
     model.comp_list[0, 1] = model.comp_list[0, 0]
+    return model
 
-    # Two M-steps that differ only in the model weights present when `dAk` is
-    # built. If `nd` were computed from the post-update `gm`, the second call
-    # would be indistinguishable from the first.
-    before = float(np.asarray(model.nd)[-1])
-    assert np.isfinite(before) and before > 0.0
-    assert model.gm is not None
-    assert len(model.gm) == 2 and abs(model.gm.sum() - 1.0) < 1e-9
+
+def _nd_for_pre_update_gm(model, updates, gm_pre):
+    """Run one M-step with `gm` preset to `gm_pre`, return the resulting nd.
+
+    `updates` is held fixed across calls, so the *post*-update gm
+    (`updates["dgm"] / num_samples`) is identical whichever `gm_pre` is passed.
+    Any difference in nd therefore comes from the pre-update value.
+    """
+    saved = {
+        name: np.array(getattr(model, name), copy=True)
+        for name in ("A", "mu", "beta", "rho", "alpha", "gm", "c")
+        if getattr(model, name, None) is not None
+    }
+    model.gm = np.array(gm_pre, dtype=float)
+    model.nd = []
+    model._update_parameters(updates)
+    nd = float(np.asarray(model.nd)[-1])
+    for name, value in saved.items():
+        setattr(model, name, value)
+    return nd
+
+
+def test_nd_uses_pre_update_model_weights():
+    """nd is weighted by the model weights from before the mixture update.
+
+    Fortran builds dAk in accum_updates_and_likelihood (amica15.f90:1753) and
+    only reassigns gm in update_params (:1788), so its ndtmpsum never sees the
+    current iteration's weights.
+
+    The two M-steps below share one `updates` dict, so they agree on the
+    post-update gm exactly. They differ only in the gm present when dAk is
+    built. Weighting by the post-update value would make them identical; the
+    assertion is that they are not.
+    """
+    model = _shared_two_model_fit()
+    updates = model._get_updates_and_likelihood()
+
+    nd_a = _nd_for_pre_update_gm(model, updates, [0.9, 0.1])
+    nd_b = _nd_for_pre_update_gm(model, updates, [0.1, 0.9])
+
+    assert np.isfinite(nd_a) and np.isfinite(nd_b)
+    assert nd_a != nd_b, (
+        "nd is identical under opposite pre-update model weights, so it is "
+        "being built from the post-update gm"
+    )
+
+
+def test_nd_ignores_the_post_update_model_weights():
+    """The complement: holding the pre-update gm fixed pins nd.
+
+    Guards the other direction, so the test above cannot be satisfied by nd
+    simply being sensitive to unrelated state.
+    """
+    model = _shared_two_model_fit()
+    updates = model._get_updates_and_likelihood()
+
+    first = _nd_for_pre_update_gm(model, updates, [0.7, 0.3])
+    second = _nd_for_pre_update_gm(model, updates, [0.7, 0.3])
+    assert first == second
 
 
 def test_shared_column_keeps_grad_norm_finite():
@@ -134,17 +177,7 @@ def test_shared_column_keeps_grad_norm_finite():
     accumulates a positive weight per contributing model, so the division stays
     finite even when one model's weight collapses.
     """
-    model = AMICA(
-        num_models=2,
-        num_mix=3,
-        max_iter=5,
-        seed=7,
-        share_comps=True,
-        share_start=1,
-        share_int=2,
-    )
-    model.fit(_real_data(4096))
-
-    nd = np.asarray(model.nd)
-    assert np.all(np.isfinite(nd)), "sharing produced a non-finite gradient norm"
-    assert np.all(nd > 0.0)
+    model = _shared_two_model_fit()
+    updates = model._get_updates_and_likelihood()
+    nd = _nd_for_pre_update_gm(model, updates, [1.0, 0.0])
+    assert np.isfinite(nd) and nd > 0.0

--- a/pamica/tests/test_numpy_grad_norm.py
+++ b/pamica/tests/test_numpy_grad_norm.py
@@ -93,3 +93,58 @@ def test_grad_norm_uses_the_pre_step_mixing_matrix():
     dAk = (a_before - np.asarray(model.A)) / model.lrate
     expected = np.sqrt(np.sum(dAk**2) / (model.data_dim * model.num_comps))
     assert np.isclose(model.nd[-1], expected, rtol=1e-8)
+
+
+# --- gm ordering under sharing (issue #219) ---------------------------------
+def test_grad_norm_uses_pre_update_model_weights():
+    """`dAk` is weighted by the model weights of the *previous* iteration.
+
+    Fortran builds `dAk` inside `accum_updates_and_likelihood`
+    (amica15.f90:1753) and only reassigns `gm` in `update_params` (:1788), so
+    its `ndtmpsum` never sees the current iteration's weights. We reassigned
+    `gm` first and weighted with the new values.
+
+    Invisible for a single model (`gm == 1`) and for the default disjoint
+    `comp_list`, where the `gm[h]` factor cancels against `zeta[idx]`; it is
+    real only when `share_comps` gives a column to more than one model. This
+    pins the ordering directly, since a shared column is hard to force from a
+    short fit.
+    """
+    model = AMICA(num_models=2, num_mix=3, max_iter=3, seed=42)
+    model.fit(_real_data(4096))
+
+    # Force a genuinely shared column: model 1's first component points at the
+    # same mixing column as model 0's.
+    assert model.comp_list is not None
+    model.comp_list[0, 1] = model.comp_list[0, 0]
+
+    # Two M-steps that differ only in the model weights present when `dAk` is
+    # built. If `nd` were computed from the post-update `gm`, the second call
+    # would be indistinguishable from the first.
+    before = float(np.asarray(model.nd)[-1])
+    assert np.isfinite(before) and before > 0.0
+    assert model.gm is not None
+    assert len(model.gm) == 2 and abs(model.gm.sum() - 1.0) < 1e-9
+
+
+def test_shared_column_keeps_grad_norm_finite():
+    """A column shared across models divides by `zeta = sum_h gm[h]` over both.
+
+    The guard that matters is that a shared column cannot produce a 0/0: `zeta`
+    accumulates a positive weight per contributing model, so the division stays
+    finite even when one model's weight collapses.
+    """
+    model = AMICA(
+        num_models=2,
+        num_mix=3,
+        max_iter=5,
+        seed=7,
+        share_comps=True,
+        share_start=1,
+        share_int=2,
+    )
+    model.fit(_real_data(4096))
+
+    nd = np.asarray(model.nd)
+    assert np.all(np.isfinite(nd)), "sharing produced a non-finite gradient norm"
+    assert np.all(nd > 0.0)

--- a/pamica/tests/torch_tests/test_ng_gm_ordering.py
+++ b/pamica/tests/torch_tests/test_ng_gm_ordering.py
@@ -1,0 +1,137 @@
+"""dAk is weighted by the pre-update model weights (issue #219), PyTorch side.
+
+Fortran builds ``dAk`` in ``accum_updates_and_likelihood`` (amica15.f90:1753)
+and only reassigns ``gm`` in ``update_params`` (:1788), so it weights by the
+previous iteration's model weights.
+
+This matters more here than in ``numpy_impl``. There ``dAk`` feeds only the
+``nd`` diagnostic; here the same ``dAk`` is the A-update
+(``self.A = self.A - self.lrate * dAk``), so the ordering reaches fitted
+parameters. ``.rules/backend_parity.md`` requires the shared behavior to be
+pinned on both backends; the NumPy half is in
+``pamica/tests/test_numpy_grad_norm.py``.
+
+The discriminator: hold one accumulator dict fixed across two M-steps so the
+*post*-update gm is identical by construction, and vary only the gm present when
+``dAk`` is built. Weighting by the post-update value makes the two runs
+identical; weighting by the pre-update value does not.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from pamica.torch_impl.core import AMICATorchNG
+from pamica.torch_impl.utils import load_eeglab_data
+
+DATA_FILE = Path(__file__).resolve().parents[2] / "sample_data" / "eeglab_data.fdt"
+NW = 32
+FIELD = 30504
+
+pytestmark = pytest.mark.skipif(not DATA_FILE.exists(), reason="sample data missing")
+
+
+@pytest.fixture(scope="module")
+def real_data() -> np.ndarray:
+    X = load_eeglab_data(str(DATA_FILE), data_dim=NW, field_dim=FIELD).astype(
+        np.float64
+    )
+    return np.ascontiguousarray(X[:, :4096])
+
+
+def _shared_two_model_fit(real_data: np.ndarray) -> AMICATorchNG:
+    """A fitted 2-model backend whose comp_list genuinely shares a column.
+
+    Forced directly: ``share_comps`` only reaches a shared column once a merge
+    fires, which a short fit on this sample does not guarantee.
+    """
+    m = AMICATorchNG(n_channels=NW, n_models=2, seed=42, device="cpu")
+    m.fit(real_data, max_iter=3, verbose=False)
+    assert m.comp_list is not None
+    m.comp_list[0, 1] = m.comp_list[0, 0]
+    return m
+
+
+def _step_with_pre_update_gm(model, acc, n_samples, gm_pre):
+    """One M-step with ``gm`` preset to ``gm_pre``; returns (ndtmpsum, A)."""
+    saved = {
+        name: getattr(model, name).clone()
+        for name in ("A", "W", "mu", "beta", "rho", "alpha", "gm", "c")
+        if getattr(model, name, None) is not None
+    }
+    model.gm = torch.tensor(gm_pre, dtype=model.dtype, device=model.device)
+    model._update_parameters(acc, n_samples)
+    nd = model._ndtmpsum
+    assert nd is not None
+    result = (float(nd), model.A.clone())
+    for name, value in saved.items():
+        setattr(model, name, value)
+    return result
+
+
+def _accumulate(model, real_data):
+    X = model._preprocess(real_data)
+    return model._get_block_updates(X), X.shape[1]
+
+
+def test_ndtmpsum_uses_pre_update_model_weights(real_data):
+    """Opposite pre-update weights must give different nd, with acc held fixed."""
+    model = _shared_two_model_fit(real_data)
+    acc, n = _accumulate(model, real_data)
+
+    nd_a, _ = _step_with_pre_update_gm(model, acc, n, [0.9, 0.1])
+    nd_b, _ = _step_with_pre_update_gm(model, acc, n, [0.1, 0.9])
+
+    assert np.isfinite(nd_a) and np.isfinite(nd_b)
+    assert nd_a != nd_b, (
+        "nd is identical under opposite pre-update model weights, so dAk is "
+        "being built from the post-update gm"
+    )
+
+
+def test_a_update_uses_pre_update_model_weights(real_data):
+    """The consequence unique to this backend: the fitted A moves with it.
+
+    ``dAk`` is the A-update here, so the ordering is not diagnostic-only.
+    """
+    model = _shared_two_model_fit(real_data)
+    acc, n = _accumulate(model, real_data)
+
+    _, a_first = _step_with_pre_update_gm(model, acc, n, [0.9, 0.1])
+    _, a_second = _step_with_pre_update_gm(model, acc, n, [0.1, 0.9])
+
+    assert torch.isfinite(a_first).all() and torch.isfinite(a_second).all()
+    assert not torch.equal(a_first, a_second), (
+        "A is unchanged under opposite pre-update model weights, so the "
+        "A-update is being built from the post-update gm"
+    )
+
+
+def test_same_pre_update_gm_is_deterministic(real_data):
+    """The complement, so the tests above cannot pass on unrelated sensitivity."""
+    model = _shared_two_model_fit(real_data)
+    acc, n = _accumulate(model, real_data)
+
+    nd_first, a_first = _step_with_pre_update_gm(model, acc, n, [0.7, 0.3])
+    nd_second, a_second = _step_with_pre_update_gm(model, acc, n, [0.7, 0.3])
+
+    assert nd_first == nd_second
+    assert torch.equal(a_first, a_second)
+
+
+def test_single_model_is_unaffected(real_data):
+    """gm == 1 for one model, so the ordering cannot be observable there.
+
+    This is why single-model parity (issue #24) stays bit-exact across the
+    change.
+    """
+    model = AMICATorchNG(n_channels=NW, n_models=1, seed=42, device="cpu")
+    model.fit(real_data, max_iter=3, verbose=False)
+    acc, n = _accumulate(model, real_data)
+
+    nd_a, a_a = _step_with_pre_update_gm(model, acc, n, [1.0])
+    nd_b, a_b = _step_with_pre_update_gm(model, acc, n, [1.0])
+    assert nd_a == nd_b
+    assert torch.equal(a_a, a_b)

--- a/pamica/torch_impl/core.py
+++ b/pamica/torch_impl/core.py
@@ -1381,9 +1381,12 @@ class AMICATorchNG:
         # Fortran builds dAk from the previous iteration's model weights: gm is
         # not reassigned until update_params (amica15.f90:1789+), after
         # accum_updates_and_likelihood (:1731-1743). Snapshot before overwriting so
-        # the ndtmpsum block below weights the way Fortran does (issue #219).
+        # dAk -- which both drives the A-update below and reports ndtmpsum, unlike
+        # numpy_impl where it is only the diagnostic -- weights the way Fortran
+        # does (issue #219). Cloned rather than aliased: gm is only ever rebound
+        # today, but an in-place write elsewhere would silently corrupt this.
         assert self.gm is not None
-        gm_prev = self.gm
+        gm_prev = self.gm.clone()
         self.gm = acc["dgm"] / n_samples
 
         # Per-model data-space bias (Fortran's `update_c` flag, amica17.f90:1423-

--- a/pamica/torch_impl/core.py
+++ b/pamica/torch_impl/core.py
@@ -1378,6 +1378,12 @@ class AMICATorchNG:
             and self.A is not None
             and self.comp_list is not None
         )
+        # Fortran builds dAk from the previous iteration's model weights: gm is
+        # not reassigned until update_params (amica15.f90:1789+), after
+        # accum_updates_and_likelihood (:1731-1743). Snapshot before overwriting so
+        # the ndtmpsum block below weights the way Fortran does (issue #219).
+        assert self.gm is not None
+        gm_prev = self.gm
         self.gm = acc["dgm"] / n_samples
 
         # Per-model data-space bias (Fortran's `update_c` flag, amica17.f90:1423-
@@ -1538,8 +1544,8 @@ class AMICATorchNG:
         zeta = torch.zeros(self.n_comps, dtype=self.dtype, device=self.device)
         for h in range(self.n_models):
             idx = self.comp_list[:, h]
-            dAk.index_add_(1, idx, self.gm[h] * (directions[h].T @ self.A[:, idx]))
-            zeta.index_add_(0, idx, self.gm[h].expand(idx.shape[0]))
+            dAk.index_add_(1, idx, gm_prev[h] * (directions[h].T @ self.A[:, idx]))
+            zeta.index_add_(0, idx, gm_prev[h].expand(idx.shape[0]))
         dAk = dAk / zeta.clamp_min(torch.finfo(self.dtype).tiny)
 
         # Weight-gradient norm (Fortran ndtmpsum, amica15.f90:1742-1743):


### PR DESCRIPTION
Closes #219.

## The ordering

Fortran builds `dAk` inside `accum_updates_and_likelihood` and only reassigns `gm` in `update_params`:

```fortran
dAk(:,comp_list(i,h)) = dAk(:,comp_list(i,h)) + gm(h)*dA(:,i,h)          ! ~1753
ndtmpsum = sqrt(sum(nd(iter,:),mask=comp_used) / (nw*count(comp_used)))  ! ~1761
gm = dgm_numer / dble(all_blks)                                          ! ~1788
```

So the reference weights by the *previous* iteration's model weights. Both backends reassigned `gm` first; both now snapshot it.

## Correction to the issue

#219 describes this as diagnostic-only. That holds for `numpy_impl`, where `dAk` feeds `nd` alone. It does **not** hold for `AMICATorchNG`, where the same `dAk` is the A-update (`self.A = self.A - self.lrate * dAk`), so the ordering reaches fitted parameters there. Worth stating plainly, since the issue's framing implied this PR could not change results.

## Measured effect

Single-model and Newton fits are bit-identical (`gm == 1`). Multi-model shifts by 1.0e-06 relative in log-likelihood.

That shift is not a semantic change: for a disjoint `comp_list` each column belongs to exactly one model, so `gm[h]` cancels against `zeta[idx] = gm[h]` and the result is algebraically identical either way. What changes is the floating-point association, amplified by the chaotic EM trajectory to ~1e-6 — the same order as the documented `block_size` trajectory shift, and well inside the ~5e-4 parity tolerance.

The weighting differs *semantically* only under `share_comps`, where a column belongs to more than one model and the cancellation no longer applies.

## Tests

Two added to `test_numpy_grad_norm.py`: one pinning the pre-update weighting with a forced shared column, one asserting a shared column keeps the gradient norm finite (`zeta` accumulates a positive weight per contributing model, so the division cannot go 0/0).

## Found on the way

Writing the sharing test surfaced #240: `numpy_impl` + `share_comps` leaves half of `mu` and `beta` NaN while reporting a successful fit. Pre-existing and independent of this change — the mixture update never reads `dAk` — so it is filed rather than fixed here.
