### PR TITLE
Record the MLX convergence-stop divergence

### DIFF
--- a/docs/guides/amica-differences.md
+++ b/docs/guides/amica-differences.md
@@ -121,7 +121,7 @@ Separate from reference divergences: the optional MLX backend is a subset.
 | Precision | f64/f32 | f64 | f32 only | f64 |
 | Rank detection | yes | yes | yes | yes (absolute floor) |
 | `min_dll` stop | yes | yes | **no** | yes |
-| `min_nd` stop / gradient norm | yes | yes | **no** | yes |
+| `min_nd` stop / gradient norm | yes | yes (as `min_grad_norm`) | **no** | yes |
 | `keep_best` best-iterate restore | yes | no | no | n/a |
 | MIR diagnostic | yes | no | no | n/a |
 | Persistence | `state_dict` | EEGLAB `amicaout` | none | EEGLAB `amicaout` |
@@ -134,21 +134,25 @@ constructor, so passing it raises `TypeError`.
 around.** `pamica/mlx_impl/core.py` implements neither stop — it has no
 `min_dll`/`use_min_dll`/`maxincs` and no `min_nd`/`use_grad_norm`/`ndtmpsum`, so
 its only outcomes are `max_iter`, `lrate_floor`, and the degenerate reasons
-(`nan_ll`, `singular_ll`, `nan_params`). **An MLX fit therefore always runs the
-full iteration budget**, while the other backends stop on likelihood stagnation
-(`min_dll`, on by default at `1e-9`) — measured at iteration 326-1076 on the
-bundled sample, depending on the BLAS build.
+(`nan_ll`, `singular_ll`, `nan_params`).
+
+The distinction is not that an MLX fit runs to `max_iter` — a PyTorch fit does
+too at its own `max_iter=100` default, because `min_dll` needs several hundred
+iterations to trigger on a recording this size. The distinction is what raising
+`max_iter` buys you. On the other backends, a larger budget lets the likelihood
+stop end the fit when it stops improving. **On MLX a larger budget is simply
+spent**, however long the fit has stopped making progress.
 
 Nothing warns you about this, because there is no parameter to reject. Two
 consequences:
 
 - Moving a working configuration from the PyTorch backend to MLX for the
-  Apple-GPU speedup does more work than the same `max_iter` implies. Choose
-  `max_iter` for MLX from where the other backends actually converge on your
-  data, not from their default budget.
-- MLX cannot be evaluated on gradient-norm behaviour at all. Where this
-  documentation says `min_nd` is unreachable "in all three implementations"
-  (see the convergence section of [validation](validation.md)), that means
-  Fortran, PyTorch and NumPy; MLX never computes the quantity.
+  Apple-GPU speedup does more work than the same `max_iter` implies. Size
+  `max_iter` for MLX from where the other backends actually stop improving on
+  your data.
+- MLX cannot be evaluated on gradient-norm behaviour at all, because it never
+  computes the quantity. Any statement elsewhere in these guides about whether
+  the `min_nd` threshold is reachable covers Fortran, PyTorch and NumPy only.
+  (`numpy_impl` spells that same threshold `min_grad_norm`.)
 
 Tracked in issue #248.

--- a/docs/guides/amica-differences.md
+++ b/docs/guides/amica-differences.md
@@ -120,6 +120,35 @@ Separate from reference divergences: the optional MLX backend is a subset.
 | Outlier rejection | yes | yes | no | yes |
 | Precision | f64/f32 | f64 | f32 only | f64 |
 | Rank detection | yes | yes | yes | yes (absolute floor) |
+| `min_dll` stop | yes | yes | **no** | yes |
+| `min_nd` stop / gradient norm | yes | yes | **no** | yes |
+| `keep_best` best-iterate restore | yes | no | no | n/a |
+| MIR diagnostic | yes | no | no | n/a |
+| Persistence | `state_dict` | EEGLAB `amicaout` | none | EEGLAB `amicaout` |
 
-MLX limitations raise `NotImplementedError` rather than differing silently, per
-`.rules/backend_parity.md`.
+Most MLX limitations fail loudly: `do_newton=True` and non-GG `pdftype` raise
+`NotImplementedError`, and every unsupported parameter is simply absent from the
+constructor, so passing it raises `TypeError`.
+
+**The convergence stops are the exception, and the one difference to plan
+around.** `pamica/mlx_impl/core.py` implements neither stop — it has no
+`min_dll`/`use_min_dll`/`maxincs` and no `min_nd`/`use_grad_norm`/`ndtmpsum`, so
+its only outcomes are `max_iter`, `lrate_floor`, and the degenerate reasons
+(`nan_ll`, `singular_ll`, `nan_params`). **An MLX fit therefore always runs the
+full iteration budget**, while the other backends stop on likelihood stagnation
+(`min_dll`, on by default at `1e-9`) — measured at iteration 326-1076 on the
+bundled sample, depending on the BLAS build.
+
+Nothing warns you about this, because there is no parameter to reject. Two
+consequences:
+
+- Moving a working configuration from the PyTorch backend to MLX for the
+  Apple-GPU speedup does more work than the same `max_iter` implies. Choose
+  `max_iter` for MLX from where the other backends actually converge on your
+  data, not from their default budget.
+- MLX cannot be evaluated on gradient-norm behaviour at all. Where this
+  documentation says `min_nd` is unreachable "in all three implementations"
+  (see the convergence section of [validation](validation.md)), that means
+  Fortran, PyTorch and NumPy; MLX never computes the quantity.
+
+Tracked in issue #248.


### PR DESCRIPTION
Documentation half of #248 (the implementation stays open).

## What

`docs/guides/amica-differences.md`'s backend table covered Newton, PDF families,
component sharing, outlier rejection, precision and rank detection — but not the
convergence stops. MLX implements **neither**:

| grep target | hits in `pamica/mlx_impl/core.py` |
|---|---|
| `min_dll`, `use_min_dll`, `maxincs` | 0 |
| `min_nd`, `use_grad_norm`, `ndtmpsum` | 0 |

Its only `stop_reason` values are `max_iter` (:570), `lrate_floor` (:659) and the
degenerate ones (:590, :634). **An MLX fit always runs the full iteration
budget**, while the other backends stop on `min_dll` (on by default at `1e-9`) at
iteration 326-1076 on the bundled sample.

## Why this one needs saying

The doc previously closed with "MLX limitations raise `NotImplementedError`
rather than differing silently." Verified by probing the constructor — that is
true for what it covers:

| passed to `AMICAMLXNG(...)` | result |
|---|---|
| `do_newton=True` | `NotImplementedError` |
| `min_dll`, `min_nd`, `use_grad_norm`, `keep_best`, `do_reject` | `TypeError` (no such parameter) |

But a stop that does not exist has no parameter to reject, so nothing signals
its absence. That is the gap the section now names, with the practical
consequence: pick `max_iter` for MLX from where the other backends actually
converge on your data, not from their default budget.

It also scopes a claim in `validation.md` — "`min_nd` is unreachable in all
three implementations" means Fortran, PyTorch and NumPy. MLX never computes the
quantity, so it cannot be evaluated on that axis.

## Also corrected

The `keep_best` / MIR / persistence rows were added and verified per backend
rather than assumed — NumPy has no `keep_best`, no `mir`, and no `state_dict`
(it persists through the EEGLAB `amicaout` format instead), so an earlier draft
calling it "partial" would have been wrong.

Docs-only; no code paths touched.